### PR TITLE
Feat/build docker image locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.ONESHELL:
+.PHONY: test
+.PHONY: docker
+.PHONY: build
+.PHONY: prettify
+.PHONY: lint
+
+test:
+	yarn test:unit
+
+lint:
+	yarn run lint
+
+prettify:
+	yarn run prettier
+
+build:
+	yarn build
+
+docker:
+	git clean -xdf && docker build -t hummingbot/gateway${TAG} -f Dockerfile .
+

--- a/README.md
+++ b/README.md
@@ -42,6 +42,26 @@ Dependencies:
 
 See the [`/docker`](./docker) folder for Docker installation scripts and instructions on how to use them.
 
+
+### Build Gateway Docker Image locally
+
+Dependencies:
+* [Docker](https://docker.com)
+
+To build the gateway docker image locally execute the below make command:
+
+```bash
+make docker
+```
+
+Pass the `${TAG}` environmental variable to add a tag to the docker
+image. For example, the below command will create the `hummingbot/gateway:dev`
+image.
+
+```bash
+TAG=dev make docker
+```
+
 ## Documentation
 
 See the [official Gateway docs](https://docs.hummingbot.org/gateway/).


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Adds a Makefile that populates a `docker` make command to build docker image locally.
Furthermore, the Makefile includes various commands for processes described in the README.md, such as `test`, `build` and `prettify`.

The README.md file is also updated to include instructions to build the gateway docker image locally.

**Tests performed by the developer**:

Execute make commands locally

**Tips for QA testing**:

