### PR TITLE
feat/Interact directly with the pool in Uniswap connector

### DIFF
--- a/src/chains/ethereum/ethereum.ts
+++ b/src/chains/ethereum/ethereum.ts
@@ -117,6 +117,11 @@ export class Ethereum extends EthereumBase implements Ethereumish {
     return this._metricsLogInterval;
   }
 
+  // in place for mocking
+  public get provider() {
+    return super.provider;
+  }
+
   /**
    * Automatically update the prevailing gas price on the network.
    *

--- a/src/connectors/uniswap/uniswap.config.ts
+++ b/src/connectors/uniswap/uniswap.config.ts
@@ -11,6 +11,9 @@ export namespace UniswapConfig {
     tradingTypes: (type: string) => Array<string>;
     chainType: string;
     availableNetworks: Array<AvailableNetworks>;
+    useRouter?: boolean;
+    feeTier?: string;
+    quoterContractAddress: (network: string) => string;
   }
 
   export const config: NetworkConfig = {
@@ -56,5 +59,11 @@ export namespace UniswapConfig {
         ),
       },
     ],
+    useRouter: ConfigManagerV2.getInstance().get(`uniswap.useRouter`),
+    feeTier: ConfigManagerV2.getInstance().get(`uniswap.feeTier`),
+    quoterContractAddress: (network: string) =>
+      ConfigManagerV2.getInstance().get(
+        `uniswap.contractAddresses.${network}.uniswapV3QuoterV2ContractAddress`
+      ),
   };
 }

--- a/src/services/common-interfaces.ts
+++ b/src/services/common-interfaces.ts
@@ -148,7 +148,6 @@ export type UniswapishTrade =
   | TradeQuickswap
   | TradeTraderjoe
   | SushiswapTrade<SushiToken, SushiToken, SushiTradeType>
-  | UniswapV3Trade<Currency, UniswapCoreToken, TradeType>
   | TradeUniswap
   | TradeDefikingdoms
   | DefiraTrade<UniswapCoreToken, UniswapCoreToken, TradeType>

--- a/src/services/schema/uniswap-schema.json
+++ b/src/services/schema/uniswap-schema.json
@@ -6,6 +6,10 @@
     "gasLimitEstimate": { "type": "integer" },
     "ttl": { "type": "integer" },
     "maximumHops": { "type": "integer" },
+    "useRouter": { "type": "boolean" },
+    "feeTier": {
+      "enum": ["LOWEST", "LOW", "MEDIUM", "HIGH"]
+    },
     "contractAddresses": {
       "type": "object",
       "patternProperties": {
@@ -13,7 +17,8 @@
           "type": "object",
           "properties": {
             "uniswapV3SmartOrderRouterAddress": { "type": "string" },
-            "uniswapV3NftManagerAddress": { "type": "string" }
+            "uniswapV3NftManagerAddress": { "type": "string" },
+            "uniswapV3QuoterV2ContractAddress": { "type": "string" }
           },
           "required": [
             "uniswapV3SmartOrderRouterAddress",

--- a/src/templates/uniswap.yml
+++ b/src/templates/uniswap.yml
@@ -13,19 +13,34 @@ ttl: 600
 # Note: More hops will increase latency of the algorithm.
 maximumHops: 4
 
+# Use Uniswap Router or Quoter for quoting prices.
+# true - use Uniswap Router.
+# false - use Uniswap Quoter.
+useRouter: true
+
+# Fee tier to use for the Uniswap Quoter.
+# Required if `useRouter` is false.
+# Available options: 'LOWEST', 'LOW', 'MEDIUM', 'HIGH'.
+feeTier: 'MEDIUM'
+
 contractAddresses:
   mainnet:
     uniswapV3SmartOrderRouterAddress: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45'
     uniswapV3NftManagerAddress: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88'
+    uniswapV3QuoterV2ContractAddress: '0x61fFE014bA17989E743c5F6cB21bF9697530B21e'
   goerli:
     uniswapV3SmartOrderRouterAddress: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45'
     uniswapV3NftManagerAddress: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88'
+    uniswapV3QuoterV2ContractAddress: '0x61fFE014bA17989E743c5F6cB21bF9697530B21e'
   arbitrum_one:
     uniswapV3SmartOrderRouterAddress: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45'
     uniswapV3NftManagerAddress: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88'
+    uniswapV3QuoterV2ContractAddress: '0x61fFE014bA17989E743c5F6cB21bF9697530B21e'
   optimism:
     uniswapV3SmartOrderRouterAddress: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45'
     uniswapV3NftManagerAddress: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88'
+    uniswapV3QuoterV2ContractAddress: '0x61fFE014bA17989E743c5F6cB21bF9697530B21e'
   mumbai:
     uniswapV3SmartOrderRouterAddress: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45'
     uniswapV3NftManagerAddress: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88'
+    uniswapV3QuoterV2ContractAddress: '0x61fFE014bA17989E743c5F6cB21bF9697530B21e'

--- a/test/connectors/uniswap/uniswap.test.ts
+++ b/test/connectors/uniswap/uniswap.test.ts
@@ -1,16 +1,26 @@
 jest.useFakeTimers();
+const { MockProvider } = require('mock-ethers-provider');
 import { Uniswap } from '../../../src/connectors/uniswap/uniswap';
 import { patch, unpatch } from '../../services/patch';
 import { UniswapishPriceError } from '../../../src/services/error-handler';
 import { CurrencyAmount, Percent, TradeType, Token } from '@uniswap/sdk-core';
 import { Pair, Route } from '@uniswap/v2-sdk';
 import { Trade } from '@uniswap/router-sdk';
-import { BigNumber, utils } from 'ethers';
+import { BigNumber, constants, utils } from 'ethers';
 import { Ethereum } from '../../../src/chains/ethereum/ethereum';
 import { patchEVMNonceManager } from '../../evm.nonce.mock';
+import { UniswapConfig } from '../../../src/connectors/uniswap/uniswap.config';
+import {
+  FACTORY_ADDRESS,
+  TickMath,
+  encodeSqrtRatioX96,
+  Pool as UniswapV3Pool,
+  FeeAmount,
+} from '@uniswap/v3-sdk';
 
 let ethereum: Ethereum;
 let uniswap: Uniswap;
+let mockProvider: typeof MockProvider;
 
 const WETH = new Token(
   3,
@@ -26,13 +36,23 @@ const DAI = new Token(
   'DAI'
 );
 
+const DAI_WETH_POOL_ADDRESS = '0xBEff876AC507446457C2A6bDA9F7021A97A8547f';
+const POOL_SQRT_RATIO_START = encodeSqrtRatioX96(100e6, 100e18);
+const POOL_TICK_CURRENT = TickMath.getTickAtSqrtRatio(POOL_SQRT_RATIO_START);
+const POOL_LIQUIDITY = 0;
+const DAI_WETH_POOL = new UniswapV3Pool(
+  WETH,
+  DAI,
+  FeeAmount.MEDIUM,
+  POOL_SQRT_RATIO_START,
+  POOL_LIQUIDITY,
+  POOL_TICK_CURRENT
+);
+
 beforeAll(async () => {
   ethereum = Ethereum.getInstance('goerli');
   patchEVMNonceManager(ethereum.nonceManager);
   await ethereum.init();
-
-  uniswap = Uniswap.getInstance('ethereum', 'goerli');
-  await uniswap.init();
 });
 
 beforeEach(() => {
@@ -94,47 +114,196 @@ const patchTrade = (_key: string, error?: Error) => {
   });
 };
 
-describe('verify Uniswap estimateSellTrade', () => {
-  it('Should return an ExpectedTrade when available', async () => {
-    patchTrade('bestTradeExactIn');
+const patchMockProvider = () => {
+  mockProvider.setMockContract(
+    FACTORY_ADDRESS,
+    require('@uniswap/v3-core/artifacts/contracts/UniswapV3Factory.sol/UniswapV3Factory.json')
+      .abi
+  );
+  mockProvider.stub(FACTORY_ADDRESS, 'getPool', DAI_WETH_POOL_ADDRESS);
 
-    const expectedTrade = await uniswap.estimateSellTrade(
-      WETH,
-      DAI,
-      BigNumber.from(1)
-    );
-    expect(expectedTrade).toHaveProperty('trade');
-    expect(expectedTrade).toHaveProperty('expectedAmount');
+  mockProvider.setMockContract(
+    UniswapConfig.config.quoterContractAddress('goerli'),
+    require('@uniswap/swap-router-contracts/artifacts/contracts/lens/QuoterV2.sol/QuoterV2.json')
+      .abi
+  );
+  mockProvider.stub(
+    UniswapConfig.config.quoterContractAddress('goerli'),
+    'quoteExactInputSingle',
+    /* amountOut */ 1,
+    /* sqrtPriceX96After */ 0,
+    /* initializedTicksCrossed */ 0,
+    /* gasEstimate */ 0
+  );
+  mockProvider.stub(
+    UniswapConfig.config.quoterContractAddress('goerli'),
+    'quoteExactOutputSingle',
+    /* amountIn */ 1,
+    /* sqrtPriceX96After */ 0,
+    /* initializedTicksCrossed */ 0,
+    /* gasEstimate */ 0
+  );
+
+  mockProvider.setMockContract(
+    DAI_WETH_POOL_ADDRESS,
+    require('@uniswap/v3-core/artifacts/contracts/UniswapV3Pool.sol/UniswapV3Pool.json')
+      .abi
+  );
+  mockProvider.stub(
+    DAI_WETH_POOL_ADDRESS,
+    'slot0',
+    DAI_WETH_POOL.sqrtRatioX96.toString(),
+    DAI_WETH_POOL.tickCurrent,
+    /* observationIndex */ 0,
+    /* observationCardinality */ 1,
+    /* observationCardinalityNext */ 1,
+    /* feeProtocol */ 0,
+    /* unlocked */ true
+  );
+  mockProvider.stub(DAI_WETH_POOL_ADDRESS, 'liquidity', 0);
+  patch(ethereum, 'provider', () => {
+    return mockProvider;
+  });
+};
+
+const patchGetPool = (address: string | null) => {
+  mockProvider.setMockContract(
+    FACTORY_ADDRESS,
+    require('@uniswap/v3-core/artifacts/contracts/UniswapV3Factory.sol/UniswapV3Factory.json')
+      .abi
+  );
+  mockProvider.stub(FACTORY_ADDRESS, 'getPool', address);
+};
+
+const useRouter = async () => {
+  const config = UniswapConfig.config;
+  config.useRouter = true;
+
+  patch(Uniswap, '_instances', () => ({}));
+  uniswap = Uniswap.getInstance('ethereum', 'goerli');
+  await uniswap.init();
+};
+
+const useQouter = async () => {
+  const config = UniswapConfig.config;
+  config.useRouter = false;
+  config.feeTier = 'MEDIUM';
+
+  patch(Uniswap, '_instances', () => ({}));
+  uniswap = Uniswap.getInstance('ethereum', 'goerli');
+  await uniswap.init();
+
+  mockProvider = new MockProvider();
+  patchMockProvider();
+};
+
+describe('verify Uniswap estimateSellTrade', () => {
+  describe('when using router', () => {
+    beforeAll(async () => {
+      await useRouter();
+    });
+
+    it('Should return an ExpectedTrade when available', async () => {
+      patchTrade('bestTradeExactIn');
+
+      const expectedTrade = await uniswap.estimateSellTrade(
+        WETH,
+        DAI,
+        BigNumber.from(1)
+      );
+      expect(expectedTrade).toHaveProperty('trade');
+      expect(expectedTrade).toHaveProperty('expectedAmount');
+    });
+
+    it('Should throw an error if no pair is available', async () => {
+      patchTrade('bestTradeExactIn', new Error('error getting trade'));
+
+      await expect(async () => {
+        await uniswap.estimateSellTrade(WETH, DAI, BigNumber.from(1));
+      }).rejects.toThrow(UniswapishPriceError);
+    });
   });
 
-  it('Should throw an error if no pair is available', async () => {
-    patchTrade('bestTradeExactIn', new Error('error getting trade'));
+  describe('when using qouter', () => {
+    beforeEach(async () => {
+      await useQouter();
+    });
 
-    await expect(async () => {
-      await uniswap.estimateSellTrade(WETH, DAI, BigNumber.from(1));
-    }).rejects.toThrow(UniswapishPriceError);
+    it('Should return an ExpectedTrade when available', async () => {
+      patchGetPool(DAI_WETH_POOL_ADDRESS);
+
+      const expectedTrade = await uniswap.estimateSellTrade(
+        WETH,
+        DAI,
+        BigNumber.from(1)
+      );
+
+      expect(expectedTrade).toHaveProperty('trade');
+      expect(expectedTrade).toHaveProperty('expectedAmount');
+    });
+
+    it('Should throw an error if no pair is available', async () => {
+      patchGetPool(constants.AddressZero);
+
+      await expect(async () => {
+        await uniswap.estimateSellTrade(WETH, DAI, BigNumber.from(1));
+      }).rejects.toThrow(UniswapishPriceError);
+    });
   });
 });
 
 describe('verify Uniswap estimateBuyTrade', () => {
-  it('Should return an ExpectedTrade when available', async () => {
-    patchTrade('bestTradeExactOut');
+  describe('when using router', () => {
+    beforeAll(async () => {
+      await useRouter();
+    });
 
-    const expectedTrade = await uniswap.estimateBuyTrade(
-      WETH,
-      DAI,
-      BigNumber.from(1)
-    );
-    expect(expectedTrade).toHaveProperty('trade');
-    expect(expectedTrade).toHaveProperty('expectedAmount');
+    it('Should return an ExpectedTrade when available', async () => {
+      patchTrade('bestTradeExactOut');
+
+      const expectedTrade = await uniswap.estimateBuyTrade(
+        WETH,
+        DAI,
+        BigNumber.from(1)
+      );
+      expect(expectedTrade).toHaveProperty('trade');
+      expect(expectedTrade).toHaveProperty('expectedAmount');
+    });
+
+    it('Should return an error if no pair is available', async () => {
+      patchTrade('bestTradeExactOut', new Error('error getting trade'));
+
+      await expect(async () => {
+        await uniswap.estimateBuyTrade(WETH, DAI, BigNumber.from(1));
+      }).rejects.toThrow(UniswapishPriceError);
+    });
   });
 
-  it('Should return an error if no pair is available', async () => {
-    patchTrade('bestTradeExactOut', new Error('error getting trade'));
+  describe('when using qouter', () => {
+    beforeEach(async () => {
+      await useQouter();
+    });
 
-    await expect(async () => {
-      await uniswap.estimateBuyTrade(WETH, DAI, BigNumber.from(1));
-    }).rejects.toThrow(UniswapishPriceError);
+    it('Should return an ExpectedTrade when available', async () => {
+      patchGetPool(DAI_WETH_POOL_ADDRESS);
+
+      const expectedTrade = await uniswap.estimateBuyTrade(
+        WETH,
+        DAI,
+        BigNumber.from(1)
+      );
+
+      expect(expectedTrade).toHaveProperty('trade');
+      expect(expectedTrade).toHaveProperty('expectedAmount');
+    });
+
+    it('Should throw an error if no pair is available', async () => {
+      patchGetPool(constants.AddressZero);
+
+      await expect(async () => {
+        await uniswap.estimateBuyTrade(WETH, DAI, BigNumber.from(1));
+      }).rejects.toThrow(UniswapishPriceError);
+    });
   });
 });
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Adds the ability to use [Quoter](https://docs.uniswap.org/contracts/v3/reference/periphery/lens/QuoterV2) rather than [Smart Order Router](https://github.com/Uniswap/smart-order-router) to the Uniswap connector as an option.
To achieve this `uniswap.yml` config file is extended with the following:
- `useRouter` (bool, default=true) - if True, estimation and execution functions use the Router; if false, use quote and trade functions of SDK.
- `feeTier` (string, default='MEDIUM') - Matches one of the Uniswap fee tier strings. If useRouter is False, then the user has to specify feeTier to find the right pool.
- `uniswapV3QuoterV2ContractAddress` (string) - a variable added to each network in `contractAddresses` section. Stores the address of Uniswap Quoter V2. It can be found here https://docs.uniswap.org/contracts/v3/reference/deployments.

**Tests performed by the developer**:
- Requests to get price and to execute trade sent using examples from `test-helpers/curl/curl.sh`. E.g.:
```bash
curl -s -X POST -k --key $GATEWAY_KEY --cert $GATEWAY_CERT -H "Content-Type: application/json" -d "$(envsubst < ./test-helpers/curl/requests/price_uniswap.json)" https://localhost:15888/amm/price | jq
```
- Checked that prices returned by the Quoter are the same(or very close) as those returned by the Router when using the same fee tier.
- Checked that executing trades(`/amm/trade`) works with the Quoter.


**Tips for QA testing**:
- Sometimes price returned using the Router is different than using the Quoter. This is usually due to a different fee tier. Try a different value for `feeTier` variable in `uniswap.yml` config file to get the same price.
