### PR TITLE
fix/ issue #164: Race condition in init() of connector classes

### DIFF
--- a/src/chains/cosmos/cosmos-base.ts
+++ b/src/chains/cosmos/cosmos-base.ts
@@ -8,6 +8,7 @@ import { BigNumber } from 'ethers';
 import { AccountData, DirectSignResponse } from '@cosmjs/proto-signing';
 
 import { IndexedTx, setupIbcExtension } from '@cosmjs/stargate';
+import { logger } from '../../services/logger';
 
 //Cosmos
 const { DirectSecp256k1Wallet } = require('@cosmjs/proto-signing');
@@ -58,8 +59,7 @@ export class CosmosBase {
   private _tokenMap: Record<string, Token> = {};
 
   private _ready: boolean = false;
-  private _initializing: boolean = false;
-  private _initPromise: Promise<void> = Promise.resolve();
+  private _initialized: Promise<boolean> = Promise.resolve(false);
 
   public chainName;
   public rpcUrl;
@@ -93,17 +93,21 @@ export class CosmosBase {
   }
 
   async init(): Promise<void> {
-    if (!this.ready() && !this._initializing) {
-      this._initializing = true;
-      this._initPromise = this.loadTokens(
-        this.tokenListSource,
-        this.tokenListType
-      ).then(() => {
-        this._ready = true;
-        this._initializing = false;
-      });
+    await this._initialized; // Wait for any previous init() calls to complete
+    if (!this.ready()) {
+      // If we're not ready, this._initialized will be a Promise that resolves after init() completes
+      this._initialized = (async () => {
+        try {
+          await this.loadTokens(this.tokenListSource, this.tokenListType)
+          return true;
+        } catch (e) {
+          logger.error(`Failed to initialize ${this.chainName} chain: ${e}`);
+          return false;
+        }
+      })();
+      this._ready = await this._initialized; // Wait for the initialization to complete
     }
-    return this._initPromise;
+    return;
   }
 
   async loadTokens(

--- a/src/chains/xdc/xdc.base.ts
+++ b/src/chains/xdc/xdc.base.ts
@@ -38,7 +38,7 @@ export class XdcBase {
   private _tokenMap: Record<string, TokenInfo> = {};
   // there are async values set in the constructor
   private _ready: boolean = false;
-  private _initializing: boolean = false;
+  private _initialized: Promise<boolean> = Promise.resolve(false);
   public chainName;
   public chainId;
   public rpcUrl;
@@ -120,16 +120,23 @@ export class XdcBase {
   }
 
   async init(): Promise<void> {
-    if (!this.ready() && !this._initializing) {
-      this._initializing = true;
-      await this._nonceManager.init(
-        async (address) =>
-          (await this.provider.getTransactionCount(address)) - 1
-      );
-
-      await this.loadTokens(this.tokenListSource, this.tokenListType);
-      this._ready = true;
-      this._initializing = false;
+    await this._initialized; // Wait for any previous init() calls to complete
+    if (!this.ready()) {
+      // If we're not ready, this._initialized will be a Promise that resolves after init() completes
+      this._initialized = (async () => {
+        try {
+          await this._nonceManager.init(
+            async (address) =>
+              (await this.provider.getTransactionCount(address)) - 1
+          );
+          await this.loadTokens(this.tokenListSource, this.tokenListType);
+          return true;
+        } catch (e) {
+          logger.error(`Failed to initialize ${this.chainName} chain: ${e}`);
+          return false;
+        }
+      })();
+      this._ready = await this._initialized; // Wait for the initialization to complete
     }
     return;
   }
@@ -242,7 +249,7 @@ export class XdcBase {
     const balance: BigNumber = await contract.balanceOf(wallet.address);
     logger.info(
       `Raw balance of ${contract.address} for ` +
-        `${wallet.address}: ${balance.toString()}`
+      `${wallet.address}: ${balance.toString()}`
     );
     return { value: balance, decimals: decimals };
   }
@@ -256,10 +263,10 @@ export class XdcBase {
   ): Promise<TokenValue> {
     logger.info(
       'Requesting spender ' +
-        spender +
-        ' allowance for owner ' +
-        wallet.address +
-        '.'
+      spender +
+      ' allowance for owner ' +
+      wallet.address +
+      '.'
     );
     const allowance = await contract.allowance(wallet.address, spender);
     logger.info(allowance);
@@ -312,12 +319,12 @@ export class XdcBase {
   ): Promise<Transaction> {
     logger.info(
       'Calling approve method called for spender ' +
-        spender +
-        ' requesting allowance ' +
-        amount.toString() +
-        ' from owner ' +
-        wallet.address +
-        '.'
+      spender +
+      ' requesting allowance ' +
+      amount.toString() +
+      ' from owner ' +
+      wallet.address +
+      '.'
     );
     return this.nonceManager.provideNonce(
       nonce,

--- a/test-bronze/chains/near/near.controllers.test.ts
+++ b/test-bronze/chains/near/near.controllers.test.ts
@@ -20,7 +20,6 @@ const zeroAddress =
 beforeAll(async () => {
   near = Near.getInstance('testnet');
   near.getTokenList = jest.fn().mockReturnValue(getTokenListData);
-  await near.init();
 });
 
 afterEach(() => {
@@ -39,6 +38,18 @@ const patchGetCurrentBlockNumber = () => {
 const patchGetTransaction = () => {
   patch(near, 'getTransaction', () => getTransactionData);
 };
+
+describe('init', () => {
+  it('should wait for the first init() call to finish in future immediate init() calls', async () => {
+    let firstCallFullfilled = false;
+    near.init().then(() => {
+      firstCallFullfilled = true;
+    });
+    await near.init().then(() => {
+      expect(firstCallFullfilled).toEqual(true);
+    });
+  });
+});
 
 describe('poll', () => {
   it('return transaction data for given signature', async () => {

--- a/test-bronze/chains/tezos/tezos.test.ts
+++ b/test-bronze/chains/tezos/tezos.test.ts
@@ -66,8 +66,14 @@ describe('Tezos', () => {
 
     describe('Tezos Base', () => {
 
-        beforeAll(async () => {
-            await tezos.init();
+        it('should wait for the first init() call to finish in future immediate init() calls', async () => {
+            let firstCallFullfilled = false;
+            tezos.init().then(() => {
+                firstCallFullfilled = true;
+            });
+            await tezos.init().then(() => {
+                expect(firstCallFullfilled).toEqual(true);
+            });
         });
 
         it('should be ready', () => {

--- a/test-bronze/chains/xdc/xdc.test.ts
+++ b/test-bronze/chains/xdc/xdc.test.ts
@@ -29,8 +29,6 @@ beforeAll(async () => {
   // Return the mocked token list instead of getting the list from github
   patch(xdc, 'getTokenList', () => TOKENS);
   patchEVMNonceManager(xdc.nonceManager);
-
-  await xdc.init();
 });
 
 beforeEach(() => {
@@ -43,6 +41,18 @@ afterEach(() => {
 
 afterAll(async () => {
   await xdc.close();
+});
+
+describe('init', () => {
+  it('should wait for the first init() call to finish in future immediate init() calls', async () => {
+    let firstCallFullfilled = false;
+    xdc.init().then(() => {
+      firstCallFullfilled = true;
+    });
+    await xdc.init().then(() => {
+      expect(firstCallFullfilled).toEqual(true);
+    });
+  });
 });
 
 describe('verify xdc storedTokenList', () => {

--- a/test/chains/ethereum/ethereum.controllers.test.ts
+++ b/test/chains/ethereum/ethereum.controllers.test.ts
@@ -20,8 +20,6 @@ beforeAll(async () => {
   eth = Ethereum.getInstance('goerli');
 
   patchEVMNonceManager(eth.nonceManager);
-
-  await eth.init();
 });
 
 beforeEach(() => {
@@ -40,6 +38,18 @@ afterAll(async () => {
 //   '0000000000000000000000000000000000000000000000000000000000000000'; // noqa: mock
 
 const mockAddress = '0xFaA12FD102FE8623C9299c72B03E45107F2772B5'; // noqa: mock
+
+describe('init', () => {
+  it('should wait for the first init() call to finish in future immediate init() calls', async () => {
+    let firstCallFullfilled = false;
+    eth.init().then(() => {
+      firstCallFullfilled = true;
+    });
+    await eth.init().then(() => {
+      expect(firstCallFullfilled).toEqual(true);
+    });
+  });
+});
 
 describe('nonce', () => {
   it('return a nonce for a wallet', async () => {


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using the approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
This PR attempts to fix the issue #164. I observed that the cause of the errors in this issue is the following sequence:
1. The first `/amm/price` request is made.
2. This calls the `init()` function for the first time and the promise is returned which is awaited.
3. More subsequent `/amm/price` calls are made.
4. The `ready()` function still returns `false` because the first `init()` call is not finished yet.
5. So, all the subsequent `/amm/price` request again calls the `init()` function.
6. These latter calls skipped the initialization because `this._initializing` was true. Hence, these `init()` calls finished before the first `init()` call.
7. So, the latter price queries proceed as usual and fail at the `getTokenBySymbol()` because the tokens are yet to load from the first `init()` call.

Solution: The latter `init()` calls are made to wait while some other `init()` call is in progress. This is done by having a promise (`this._initialized`), that is unresolved whenever the `init()` is in progress.

**Tests performed by the developer**:
I tested the cases described in the issue thread around ten times. The errors didn't occur in any case.

