### PR TITLE
feat/Osmosis Chain Connector

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:scripts": "jest -i --verbose ./test-scripts/*.test.ts"
   },
   "dependencies": {
+    "@chasevoorhees/osmonauts-math-decimal": "^1.7.1",
     "@cosmjs/proto-signing": "^0.30.1",
     "@cosmjs/stargate": "^0.30.1",
     "@crocswap/sdk": "^2.4.5",
@@ -87,6 +88,8 @@
     "minimist": "^1.2.6",
     "morgan": "^1.10.0",
     "near-api-js": "1.0.0",
+    "osmo-query": "^16.5.2",
+    "osmojs": "^16.5.1",
     "promise-retry": "^2.0.1",
     "quickswap-sdk": "^3.0.8",
     "swagger-ui-express": "^4.1.6",

--- a/src/amm/amm.requests.ts
+++ b/src/amm/amm.requests.ts
@@ -1,3 +1,4 @@
+import { SerializableExtendedPool as CosmosSerializableExtendedPool } from '../chains/osmosis/osmosis.types';
 import { PerpPosition } from '../connectors/perp/perp';
 import {
   NetworkSelectionRequest,
@@ -32,12 +33,34 @@ export interface PriceResponse {
   gasCost: string;
 }
 
+export interface CosmosPriceResponse {
+  base: string;
+  quote: string;
+  amount: string;
+  rawAmount: string;
+  expectedAmount: string;
+  price: string;
+  network: string;
+  timestamp: number;
+  latency: number;
+  gasPrice: string;
+  gasLimit: string;
+  gasUsed: string;
+  gasWanted: string;
+}
+
 export interface PoolPriceRequest extends NetworkSelectionRequest {
   token0: string;
   token1: string;
   fee: string;
   period: number;
   interval: number;
+}
+
+export interface CosmosPoolPriceRequest extends NetworkSelectionRequest {
+  address: string;
+  token0: string;
+  token1: string;
 }
 
 export interface PoolPriceResponse {
@@ -47,6 +70,27 @@ export interface PoolPriceResponse {
   period: number;
   interval: number;
   prices: string[];
+  network: string;
+  timestamp: number;
+  latency: number;
+}
+
+export interface CosmosPoolPriceResponse {
+  token0: string;
+  token1: string;
+  pools: CosmosSerializableExtendedPool[];
+  network: string;
+  timestamp: number;
+  latency: number;
+}
+
+export interface CosmosPoolPositionsRequest extends NetworkSelectionRequest {
+  address: string;
+  poolId?: string;
+}
+
+export interface CosmosPoolPositionsResponse {
+  pools: CosmosSerializableExtendedPool[];
   network: string;
   timestamp: number;
   latency: number;
@@ -84,6 +128,39 @@ export interface TradeResponse {
   txHash: string | any | undefined;
 }
 
+export interface CosmosTradeResponse {
+  network: string;
+  timestamp: number;
+  latency: number;
+  base: string;
+  quote: string;
+  amount: string;
+  rawAmount: string;
+  expectedAmountReceived: string;
+  finalAmountReceived: string;
+  finalAmountReceived_basetoken: string;
+  expectedPrice: string;
+  finalPrice: string;
+  gasPrice: string;
+  gasLimit: string;
+  gasUsed: string;
+  gasWanted: string;
+  txHash: string;
+}
+
+export interface CosmosTransferResponse {
+  network: string;
+  timestamp: number;
+  latency: number;
+  amount: string;
+  gasPrice: string;
+  gasLimit: string;
+  gasUsed: string;
+  gasWanted: string;
+  txHash: string;
+}
+
+
 export interface AddLiquidityRequest extends NetworkSelectionRequest {
   address: string;
   token0: string;
@@ -97,6 +174,16 @@ export interface AddLiquidityRequest extends NetworkSelectionRequest {
   nonce?: number;
   maxFeePerGas?: string;
   maxPriorityFeePerGas?: string;
+}
+
+export interface CosmosAddLiquidityRequest extends NetworkSelectionRequest {
+  address: string;
+  token0: string;
+  token1: string;
+  amount0: string;
+  amount1: string;
+  poolId?: string; // will select one for you if not provided
+  allowedSlippage?: string;
 }
 
 export interface AddLiquidityResponse {
@@ -115,6 +202,24 @@ export interface AddLiquidityResponse {
   txHash: string | undefined;
 }
 
+export interface CosmosAddLiquidityResponse {
+  poolId: string;
+  poolAddress: string;
+  poolShares: string;
+  token0: string;
+  token0FinalAmount: string;
+  token1: string;
+  token1FinalAmount: string;
+  network: string;
+  timestamp: number;
+  latency: number;
+  gasPrice: string;
+  gasLimit: string;
+  gasUsed: string;
+  gasWanted: string;
+  txHash: string;
+}
+
 export interface CollectEarnedFeesRequest extends NetworkSelectionRequest {
   address: string;
   tokenId: number;
@@ -125,6 +230,13 @@ export interface CollectEarnedFeesRequest extends NetworkSelectionRequest {
 
 export interface RemoveLiquidityRequest extends CollectEarnedFeesRequest {
   decreasePercent?: number;
+}
+
+export interface CosmosRemoveLiquidityRequest extends NetworkSelectionRequest {
+  address: string;
+  decreasePercent: number;
+  poolId: string; // required
+  allowedSlippage?: string;
 }
 
 export interface RemoveLiquidityResponse {
@@ -138,6 +250,22 @@ export interface RemoveLiquidityResponse {
   gasCost: string;
   nonce: number;
   txHash: string | undefined;
+}
+
+export interface CosmosRemoveLiquidityResponse {
+  network: string;
+  timestamp: number;
+  latency: number;
+  poolId: string; 
+  gasPrice: string;
+  gasLimit: string;
+  gasUsed: string;
+  gasWanted: string;
+  txHash: string;
+  token0: string;
+  token1: string;
+  amount0: string;
+  amount1: string;
 }
 
 export interface PositionRequest extends NetworkSelectionRequest {

--- a/src/amm/amm.routes.ts
+++ b/src/amm/amm.routes.ts
@@ -18,6 +18,11 @@ import {
   poolPrice,
   estimateGas,
   perpBalance,
+  // cosmosPoolPrice,
+  // cosmosPoolPositions,
+  // cosmosAddLiquidity,
+  // cosmosReduceLiquidity,
+  // cosmosPrice
 } from './amm.controllers';
 import {
   EstimateGasResponse,
@@ -44,6 +49,16 @@ import {
   PoolPriceResponse,
   PerpBalanceRequest,
   PerpBalanceResponse,
+  CosmosAddLiquidityRequest,
+  CosmosRemoveLiquidityRequest,
+  CosmosAddLiquidityResponse,
+  CosmosRemoveLiquidityResponse,
+  CosmosPoolPriceRequest,
+  CosmosPoolPriceResponse,
+  CosmosPoolPositionsRequest,
+  CosmosPoolPositionsResponse,
+  CosmosPriceResponse,
+  CosmosTradeResponse
 } from './amm.requests';
 import {
   validateEstimateGasRequest,
@@ -60,31 +75,53 @@ import {
   validatePositionRequest,
   validatePoolPriceRequest,
   validatePerpBalanceRequest,
+  validateCosmosPriceRequest,
+  validateCosmosAddLiquidityRequest,
+  validateCosmosRemoveLiquidityRequest,
+  validateCosmosPoolPositionsRequest,
+  validateCosmosPoolPriceRequest,
 } from './amm.validators';
 import { NetworkSelectionRequest } from '../services/common-interfaces';
 
 export namespace AmmRoutes {
   export const router = Router();
-
+  
   router.post(
     '/price',
     asyncHandler(
       async (
         req: Request<{}, {}, PriceRequest>,
-        res: Response<PriceResponse | string, {}>
+        res: Response<PriceResponse | CosmosPriceResponse | string, {}>
       ) => {
-        validatePriceRequest(req.body);
+        if (req.body.chain == 'osmosis'){
+          validateCosmosPriceRequest(req.body)
+        }else{
+          validatePriceRequest(req.body);
+        }
         res.status(200).json(await price(req.body));
       }
     )
   );
+
+  // router.post(
+  //   '/price_cosmos',
+  //   asyncHandler(
+  //     async (
+  //       req: Request<{}, {}, PriceRequest>,
+  //       res: Response<CosmosPriceResponse | string, {}>
+  //     ) => {
+  //       validateCosmosPriceRequest(req.body);
+  //       res.status(200).json(await cosmosPrice(req.body));
+  //     }
+  //   )
+  // );
 
   router.post(
     '/trade',
     asyncHandler(
       async (
         req: Request<{}, {}, TradeRequest>,
-        res: Response<TradeResponse | string, {}>
+        res: Response<TradeResponse | CosmosTradeResponse | string, {}>
       ) => {
         validateTradeRequest(req.body);
         res.status(200).json(await trade(req.body));
@@ -113,10 +150,14 @@ export namespace AmmLiquidityRoutes {
     '/position',
     asyncHandler(
       async (
-        req: Request<{}, {}, PositionRequest>,
-        res: Response<PositionResponse | string, {}>
+        req: Request<{}, {}, PositionRequest | CosmosPoolPositionsRequest>,
+        res: Response<PositionResponse | CosmosPoolPositionsResponse | string, {}>
       ) => {
-        validatePositionRequest(req.body);
+        if (req.body.chain == 'osmosis'){
+          validateCosmosPoolPositionsRequest(req.body)
+        }else{
+          validatePositionRequest(req.body);
+        }
         res.status(200).json(await positionInfo(req.body));
       }
     )
@@ -126,10 +167,14 @@ export namespace AmmLiquidityRoutes {
     '/add',
     asyncHandler(
       async (
-        req: Request<{}, {}, AddLiquidityRequest>,
-        res: Response<AddLiquidityResponse | string, {}>
+        req: Request<{}, {}, AddLiquidityRequest | CosmosAddLiquidityRequest>,
+        res: Response<AddLiquidityResponse | CosmosAddLiquidityResponse | string, {}>
       ) => {
-        validateAddLiquidityRequest(req.body);
+        if (req.body.chain == 'osmosis'){
+          validateCosmosAddLiquidityRequest(req.body)
+        }else{
+          validateAddLiquidityRequest(req.body);
+        }
         res.status(200).json(await addLiquidity(req.body));
       }
     )
@@ -139,14 +184,44 @@ export namespace AmmLiquidityRoutes {
     '/remove',
     asyncHandler(
       async (
-        req: Request<{}, {}, RemoveLiquidityRequest>,
-        res: Response<RemoveLiquidityResponse | string, {}>
+        req: Request<{}, {}, RemoveLiquidityRequest | CosmosRemoveLiquidityRequest>,
+        res: Response<RemoveLiquidityResponse | CosmosRemoveLiquidityResponse | string, {}>
       ) => {
-        validateRemoveLiquidityRequest(req.body);
+        if (req.body.chain == 'osmosis'){
+          validateCosmosRemoveLiquidityRequest(req.body)
+        }else{
+          validateRemoveLiquidityRequest(req.body);
+        }
         res.status(200).json(await reduceLiquidity(req.body));
       }
     )
   );
+
+  // router.post(
+  //   '/add_cosmos',
+  //   asyncHandler(
+  //     async (
+  //       req: Request<{}, {}, CosmosAddLiquidityRequest>,
+  //       res: Response<CosmosAddLiquidityResponse | string, {}>
+  //     ) => {
+  //       validateCosmosAddLiquidityRequest(req.body);
+  //       res.status(200).json(await cosmosAddLiquidity(req.body));
+  //     }
+  //   )
+  // );
+
+  // router.post(
+  //   '/remove_cosmos',
+  //   asyncHandler(
+  //     async (
+  //       req: Request<{}, {}, CosmosRemoveLiquidityRequest>,
+  //       res: Response<CosmosRemoveLiquidityResponse | string, {}>
+  //     ) => {
+  //       validateCosmosRemoveLiquidityRequest(req.body);
+  //       res.status(200).json(await cosmosReduceLiquidity(req.body));
+  //     }
+  //   )
+  // );
 
   router.post(
     '/collect_fees',
@@ -165,14 +240,44 @@ export namespace AmmLiquidityRoutes {
     '/price',
     asyncHandler(
       async (
-        req: Request<{}, {}, PoolPriceRequest>,
-        res: Response<PoolPriceResponse | string, {}>
+        req: Request<{}, {}, PoolPriceRequest | CosmosPoolPriceRequest>,
+        res: Response<PoolPriceResponse | CosmosPoolPriceResponse | string, {}>
       ) => {
-        validatePoolPriceRequest(req.body);
+        if (req.body.chain == 'osmosis'){
+          validateCosmosPoolPriceRequest(req.body)
+        }else{
+          validatePoolPriceRequest(req.body);
+        }
         res.status(200).json(await poolPrice(req.body));
       }
     )
   );
+
+  // router.post(
+  //   '/price_cosmos',
+  //   asyncHandler(
+  //     async (
+  //       req: Request<{}, {}, CosmosPoolPriceRequest>,
+  //       res: Response<CosmosPoolPriceResponse | string, {}>
+  //     ) => {
+  //       validateCosmosPoolPriceRequest(req.body);
+  //       res.status(200).json(await cosmosPoolPrice(req.body));
+  //     }
+  //   )
+  // );
+
+  // router.post(
+  //   '/positions_cosmos',
+  //   asyncHandler(
+  //     async (
+  //       req: Request<{}, {}, CosmosPoolPositionsRequest>,
+  //       res: Response<CosmosPoolPositionsResponse | string, {}>
+  //     ) => {
+  //       validateCosmosPoolPositionsRequest(req.body);
+  //       res.status(200).json(await cosmosPoolPositions(req.body));
+  //     }
+  //   )
+  // );
 }
 
 export namespace PerpAmmRoutes {
@@ -282,3 +387,4 @@ export namespace PerpAmmRoutes {
     )
   );
 }
+

--- a/src/amm/amm.validators.ts
+++ b/src/amm/amm.validators.ts
@@ -16,6 +16,11 @@ import {
   validateMaxPriorityFeePerGas,
 } from '../chains/ethereum/ethereum.validators';
 
+import {
+  validatePublicKey as validatePublicKeyCosmos,
+  validatePrivateKey as validatePrivateKeyCosmos
+} from '../chains/cosmos/cosmos.validators';
+
 import { FeeAmount } from '@uniswap/v3-sdk';
 
 export const invalidConnectorError: string =
@@ -155,6 +160,23 @@ export const validateTokenId: Validator = mkValidator(
   true
 );
 
+export const validatePoolIdRequired: Validator = mkValidator(
+  'poolId',
+  invalidTokenIdError,
+  (val) =>
+    (typeof val === 'string' && BigInt(val) >= 0),
+  true
+);
+
+export const validatePoolIdOptional: Validator = mkValidator(
+  'poolId',
+  invalidTokenIdError,
+  (val) =>
+    typeof val === 'undefined' ||
+    (typeof val === 'string' && BigInt(val) >= 0),
+  true
+);
+
 export const validatePeriod: Validator = mkValidator(
   'period',
   invalidTimeError,
@@ -182,6 +204,13 @@ export const validateAllowedSlippage: Validator = mkValidator(
   'allowedSlippage',
   invalidAllowedSlippageError,
   (val) => typeof val === 'string' && isFractionString(val),
+  true
+);
+
+export const validateAllowedSlippageCosmos: Validator = mkValidator(
+  'allowedSlippage',
+  invalidAllowedSlippageError,
+  (val) => typeof val === 'string' && val.includes('%'),
   true
 );
 
@@ -308,6 +337,66 @@ export const validateRemoveLiquidityRequest: RequestValidator =
     validateMaxFeePerGas,
     validateMaxPriorityFeePerGas,
   ]);
+
+export const validateCosmosPriceRequest: RequestValidator = mkRequestValidator([
+  validateConnector,
+  validateChain,
+  validateNetwork,
+  validateQuote,
+  validateBase,
+  validateAmount,
+  validateSide,
+  validateAllowedSlippageCosmos,
+]);
+
+export const validateCosmosAddLiquidityRequest: RequestValidator = mkRequestValidator(
+  [
+    validateConnector,
+    validateChain,
+    validateNetwork,
+    validatePublicKeyCosmos,
+    validatePrivateKeyCosmos,
+    validateToken0,
+    validateToken1,
+    validateAmount0,
+    validateAmount1,
+    // validateUpperPrice,
+    // validateLowerPrice,
+    validatePoolIdOptional,
+  ]
+);
+
+export const validateCosmosRemoveLiquidityRequest: RequestValidator =
+  mkRequestValidator([
+    validateConnector,
+    validateChain,
+    validateNetwork,
+    validatePublicKeyCosmos,
+    validatePrivateKeyCosmos,
+    validateDecreasePercent,
+    validatePoolIdRequired,
+]);
+  
+export const validateCosmosPoolPriceRequest: RequestValidator =
+  mkRequestValidator([
+    validateConnector,
+    validateChain,
+    validateNetwork,
+    validatePublicKeyCosmos,
+    validatePrivateKeyCosmos,
+    validateToken0,
+    validateToken1,
+]);
+
+export const validateCosmosPoolPositionsRequest: RequestValidator =
+  mkRequestValidator([
+    validateConnector,
+    validateChain,
+    validateNetwork,
+    validatePublicKeyCosmos,
+    validatePrivateKeyCosmos,
+    validatePoolIdOptional,
+]);
 
 export const validateCollectFeeRequest: RequestValidator = mkRequestValidator([
   validateConnector,

--- a/src/chains/chain.requests.ts
+++ b/src/chains/chain.requests.ts
@@ -12,7 +12,7 @@ export interface NonceResponse {
 
 export interface AllowancesRequest extends NetworkSelectionRequest {
   address: string; // the users public Ethereum key
-  spender: string; // the spender address for whom approvals are checked
+  spender: string; // the spender address for whom approvals are checked - spender string eg. openocean returns routerAddress
   tokenSymbols: string[]; // a list of token symbol
 }
 

--- a/src/chains/chain.routes.ts
+++ b/src/chains/chain.routes.ts
@@ -124,7 +124,7 @@ export namespace ChainRoutes {
         req: Request<{}, {}, {}, TokensRequest>,
         res: Response<TokensResponse, {}>
       ) => {
-        const chain = await getInitializedChain(
+        const chain = await getInitializedChain<Chain>(
           req.query.chain as string,
           req.query.network as string
         );

--- a/src/chains/cosmos/cosmos.validators.ts
+++ b/src/chains/cosmos/cosmos.validators.ts
@@ -7,13 +7,25 @@ import {
   validateTxHash,
 } from '../../services/validators';
 import { normalizeBech32 } from '@cosmjs/encoding';
+const { fromHex } = require('@cosmjs/encoding');
 
 export const invalidCosmosAddressError: string =
   'The spender param is not a valid Cosmos address. (Bech32 format)';
+export const invalidCosmosPrivateKeyError: string =
+  'The privateKey param is not a valid Cosmos private key.';
 
 export const isValidCosmosAddress = (str: string): boolean => {
   try {
     normalizeBech32(str);
+
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+export const isValidCosmosPrivateKey = (str: string): boolean => {
+  try {
+    fromHex(str);
 
     return true;
   } catch (e) {
@@ -34,3 +46,9 @@ export const validateCosmosBalanceRequest: RequestValidator =
 export const validateCosmosPollRequest: RequestValidator = mkRequestValidator([
   validateTxHash,
 ]);
+
+export const validatePrivateKey: Validator = mkValidator(
+  'privateKey',
+  invalidCosmosPrivateKeyError,
+  (val) => typeof val === 'string' && isValidCosmosPrivateKey(val)
+);

--- a/src/chains/osmosis/osmosis.apr.ts
+++ b/src/chains/osmosis/osmosis.apr.ts
@@ -1,0 +1,38 @@
+// import { Asset } from '@chain-registry/types';
+// import { asset_list, assets } from '@chain-registry/osmosis';
+import { calcPoolAprs as _calcPoolAprs } from '@chasevoorhees/osmonauts-math-decimal';
+
+import { CalcPoolAprsParams } from './osmosis.types';
+
+// const osmosisAssets: Asset[] = [
+//   ...assets.assets,
+//   ...asset_list.assets,
+// ];
+
+// need to pass this tokenList from osmosis.ts...
+export const calcPoolAprs = ({
+  activeGauges,
+  pool,
+  prices,
+  superfluidPools,
+  aprSuperfluid,
+  lockupDurations,
+  volume7d,
+  swapFee,
+  lockup = '14',
+  includeNonPerpetual = true,
+}: CalcPoolAprsParams) => {
+  return _calcPoolAprs({
+    activeGauges,
+    pool,
+    assets: [],
+    prices,
+    superfluidPools,
+    aprSuperfluid,
+    lockupDurations,
+    volume7d,
+    swapFee,
+    lockup,
+    includeNonPerpetual,
+  });
+};

--- a/src/chains/osmosis/osmosis.config.ts
+++ b/src/chains/osmosis/osmosis.config.ts
@@ -1,0 +1,53 @@
+import { AvailableNetworks } from '../../services/config-manager-types';
+import { ConfigManagerV2 } from '../../services/config-manager-v2';
+import { TokenListType } from '../../services/base';
+
+export namespace OsmosisConfig {
+  export interface NetworkConfig {
+    chainType: string;
+    chainId: (network: string) => string;
+    rpcURL: (network: string) => string;
+    tokenListType: (network: string) => TokenListType;
+    tokenListSource: (network: string) => string;
+    availableNetworks: Array<AvailableNetworks>;
+    tradingTypes: (type: string) => Array<string>;
+    nativeCurrencySymbol: string;
+
+    feeTier: string;
+    gasAdjustment: number;
+    gasLimitTransaction: string;
+    manualGasPrice: string;
+    allowedSlippage: string;
+  }
+
+  export const config: NetworkConfig = {
+    chainType: 'osmosis',
+    chainId: (network: string) =>
+      ConfigManagerV2.getInstance().get(`osmosis.networks.${network}.chainId`),
+    rpcURL: (network: string) =>
+      ConfigManagerV2.getInstance().get(`osmosis.networks.${network}.rpcURL`),
+    tokenListType: (network: string) =>
+      ConfigManagerV2.getInstance().get(
+        `osmosis.networks.${network}.tokenListType`
+      ),
+    tokenListSource: (network: string) =>
+      ConfigManagerV2.getInstance().get(
+        `osmosis.networks.${network}.tokenListSource`
+      ),
+    availableNetworks: [
+      {
+        chain: 'osmosis',
+        networks: ['mainnet', 'testnet'],
+      },
+    ],
+    tradingTypes: (type: string) => {
+      return type === 'swap' ? ['AMM_LP'] : ['AMM_LP'];
+    },
+    manualGasPrice: ConfigManagerV2.getInstance().get(`osmosis.manualGasPrice`),
+    nativeCurrencySymbol: ConfigManagerV2.getInstance().get(`osmosis.nativeCurrencySymbol`),
+    gasLimitTransaction: ConfigManagerV2.getInstance().get(`osmosis.gasLimitTransaction`),
+    gasAdjustment: ConfigManagerV2.getInstance().get(`osmosis.gasAdjustment`),
+    allowedSlippage: ConfigManagerV2.getInstance().get(`osmosis.allowedSlippage`),
+    feeTier: ConfigManagerV2.getInstance().get(`osmosis.feeTier`),
+  };
+}

--- a/src/chains/osmosis/osmosis.controllers.ts
+++ b/src/chains/osmosis/osmosis.controllers.ts
@@ -1,0 +1,675 @@
+
+import {
+  HttpException,
+  LOAD_WALLET_ERROR_CODE,
+  LOAD_WALLET_ERROR_MESSAGE,
+  PRICE_FAILED_ERROR_CODE,
+  PRICE_FAILED_ERROR_MESSAGE,
+  TRADE_FAILED_ERROR_CODE,
+  TRADE_FAILED_ERROR_MESSAGE,
+  SWAP_PRICE_EXCEEDS_LIMIT_PRICE_ERROR_CODE,
+  SWAP_PRICE_EXCEEDS_LIMIT_PRICE_ERROR_MESSAGE,
+  SWAP_PRICE_LOWER_THAN_LIMIT_PRICE_ERROR_CODE,
+  SWAP_PRICE_LOWER_THAN_LIMIT_PRICE_ERROR_MESSAGE,
+  UNKNOWN_ERROR_ERROR_CODE,
+  UNKNOWN_ERROR_MESSAGE,
+} from '../../services/error-handler';
+import { CosmosAsset, CosmosWallet } from '../../chains/cosmos/cosmos-base'; 
+import { OsmosisExpectedTrade, TransactionEvent, TransactionEventAttribute, } from './osmosis.types' 
+import { latency } from '../../services/base';
+import {
+  CustomTransaction,
+  Tokenish,
+} from '../../services/common-interfaces';
+import { logger } from '../../services/logger';
+import {
+  EstimateGasResponse,
+  PriceRequest,
+  TradeRequest,
+  CosmosAddLiquidityRequest,
+  CosmosAddLiquidityResponse,
+  CosmosPoolPriceRequest,
+  CosmosPoolPriceResponse,
+  CosmosRemoveLiquidityRequest,
+  CosmosRemoveLiquidityResponse,
+  CosmosPoolPositionsRequest,
+  CosmosPoolPositionsResponse,
+  CosmosPriceResponse,
+  CosmosTradeResponse,
+} from '../../amm/amm.requests';
+import { Osmosis } from './osmosis';
+
+import BigNumber from 'bignumber.js';
+import { Decimal } from 'decimal.js-light';
+import { CosmosAsset as TokenishCosmosAsset} from '../../chains/cosmos/cosmos-base';
+import { TokensRequest, TokensResponse } from '../../network/network.requests';
+import { TransferRequest, TransferResponse } from '../../chains/injective/injective.requests';
+import { validateCosmosBalanceRequest, validateCosmosPollRequest } from '../cosmos/cosmos.validators';
+import { CosmosBalanceRequest, CosmosPollRequest } from '../cosmos/cosmos.requests';
+import { toCosmosBalances } from '../cosmos/cosmos.controllers';
+import { AllowancesRequest, ApproveRequest, CancelRequest, NonceRequest, NonceResponse } from '../chain.requests';
+const { decodeTxRaw } = require('@cosmjs/proto-signing');
+
+const successfulTransaction = 0;
+
+export interface TradeInfo {
+  baseToken: TokenishCosmosAsset;
+  quoteToken: TokenishCosmosAsset;
+  requestAmount: BigNumber;
+  expectedTrade: OsmosisExpectedTrade;
+}
+
+export async function getOsmoWallet(
+  osmosis: Osmosis,
+  address: string,
+): Promise<{
+  wallet: CosmosWallet;
+}> {
+  let wallet: CosmosWallet;
+  try {
+    wallet = await osmosis.getWallet(address, 'osmosis');
+  } catch (err) {
+    logger.error(`Wallet ${address} not available.`);
+    throw new HttpException(
+      500,
+      LOAD_WALLET_ERROR_MESSAGE + err,
+      LOAD_WALLET_ERROR_CODE
+    );
+  }
+  return { wallet };
+}
+
+export class OsmosisController {
+
+  static async getTradeInfo(
+      osmosis: Osmosis,
+      baseAsset: string,
+      quoteAsset: string,
+      baseAmount: Decimal,
+      tradeSide: string,
+    ): Promise<TradeInfo> {
+      const gasAdjustment = osmosis.gasAdjustment; // 
+      const feeTier = osmosis.feeTier; // 
+      const allowedSlippage = osmosis.allowedSlippage; // 
+
+      const baseToken: Tokenish = osmosis.getTokenBySymbol(baseAsset);
+      const quoteToken: Tokenish = osmosis.getTokenBySymbol(quoteAsset);
+
+      const requestAmount: BigNumber = BigNumber(
+        baseAmount.toFixed(baseToken.decimals)
+      );
+
+      let expectedTrade: OsmosisExpectedTrade;
+      expectedTrade = await osmosis.estimateTrade(
+        quoteToken,
+        baseToken,
+        requestAmount,
+        tradeSide,
+        allowedSlippage,
+        feeTier,
+        gasAdjustment,
+      );
+
+      return {
+        baseToken,
+        quoteToken,
+        requestAmount,
+        expectedTrade,
+      };
+    }
+
+    static async price(
+      osmosis: Osmosis,
+      req: PriceRequest
+    ): Promise<CosmosPriceResponse> {
+      const startTimestamp: number = Date.now();
+
+      const gasPrice = osmosis.manualGasPrice;  // GAS PRICE PER UNIT OF WORK  
+      const gasLimitTransaction = osmosis.gasLimitEstimate; // MAX uOSMO COST PER TRANSACTION 
+
+      let tradeInfo: TradeInfo;
+      try {
+        tradeInfo = await this.getTradeInfo(
+          osmosis,
+          req.base,
+          req.quote,
+          new Decimal(req.amount),
+          req.side,
+        );
+      } catch (e) {
+        if (e instanceof Error) {
+          throw new HttpException(
+            500,
+            PRICE_FAILED_ERROR_MESSAGE + e.message,
+            PRICE_FAILED_ERROR_CODE
+          );
+        } else {
+          throw new HttpException(
+            500,
+            UNKNOWN_ERROR_MESSAGE,
+            UNKNOWN_ERROR_ERROR_CODE
+          );
+        }
+      }
+
+      const trade = tradeInfo.expectedTrade; 
+      const expectedAmount = tradeInfo.expectedTrade.expectedAmount;
+      const tradePrice = trade.executionPrice;
+
+
+      return {
+        network: osmosis.chainName,
+        timestamp: startTimestamp,
+        latency: latency(startTimestamp, Date.now()),
+        base: tradeInfo.baseToken.symbol,
+        quote: tradeInfo.quoteToken.symbol,
+        amount: new Decimal(req.amount).toFixed(tradeInfo.baseToken.decimals),
+        rawAmount: tradeInfo.requestAmount.toString(),
+        expectedAmount: expectedAmount.toString(),
+        price: tradePrice.toString(),
+        gasPrice: gasPrice,
+        gasLimit: gasLimitTransaction,
+        gasUsed: tradeInfo.expectedTrade.gasUsed,
+        gasWanted: tradeInfo.expectedTrade.gasWanted,
+      };
+    }
+
+    static async trade(
+      osmosis: Osmosis,
+      req: TradeRequest
+    ): Promise<CosmosTradeResponse> {
+      const startTimestamp: number = Date.now();
+
+      const limitPrice = req.limitPrice;
+      const { wallet } =
+        await getOsmoWallet(
+          osmosis,
+          req.address,
+        );
+
+      let tradeInfo: TradeInfo;
+      try {
+        tradeInfo = await this.getTradeInfo(
+          osmosis,
+          req.base,
+          req.quote,
+          new Decimal(req.amount),
+          req.side
+        );
+      } catch (e) {
+        if (e instanceof Error) {
+          logger.error(`Could not get trade info. ${e.message}`);
+          throw new HttpException(
+            500,
+            TRADE_FAILED_ERROR_MESSAGE + e.message,
+            TRADE_FAILED_ERROR_CODE
+          );
+        } else {
+          logger.error('Unknown error trying to get trade info.');
+          throw new HttpException(
+            500,
+            UNKNOWN_ERROR_MESSAGE,
+            UNKNOWN_ERROR_ERROR_CODE
+          );
+        }
+      }
+
+      const price = tradeInfo.expectedTrade.executionPrice;
+
+      const gasPrice = osmosis.manualGasPrice;  // GAS PRICE PER UNIT OF WORK  
+      const gasLimitTransaction = osmosis.gasLimitEstimate; // MAX uOSMO COST PER TRANSACTION 
+      const gasAdjustment = osmosis.gasAdjustment; // 
+      const feeTier = osmosis.feeTier; // 
+
+      if (req.side === 'BUY') {
+
+        if (
+          limitPrice &&
+          new Decimal(price.toFixed(8)).gt(new Decimal(limitPrice))
+        ) {
+          logger.error('Swap price exceeded limit price.');
+          throw new HttpException(
+            500,
+            SWAP_PRICE_EXCEEDS_LIMIT_PRICE_ERROR_MESSAGE(
+              price.toFixed(8),
+              limitPrice
+            ),
+            SWAP_PRICE_EXCEEDS_LIMIT_PRICE_ERROR_CODE
+          );
+        }
+
+      } 
+      else {
+        logger.info(
+          `Expected execution price is ${price.toFixed(6)}, ` +
+            `limit price is ${limitPrice}.`
+        );
+        if (
+          limitPrice &&
+          new Decimal(price.toFixed(8)).lt(new Decimal(limitPrice))
+        ) {
+          logger.error('Swap price lower than limit price.');
+          throw new HttpException(
+            500,
+            SWAP_PRICE_LOWER_THAN_LIMIT_PRICE_ERROR_MESSAGE(
+              price.toFixed(8),
+              limitPrice
+            ),
+            SWAP_PRICE_LOWER_THAN_LIMIT_PRICE_ERROR_CODE
+          );
+        }
+      }
+
+      const tx = await osmosis.executeTrade(
+        wallet,
+        tradeInfo,
+        req.address,
+        req.allowedSlippage,
+        feeTier,
+        gasAdjustment,
+      );
+      if (tx.code == successfulTransaction){
+        logger.info(
+          `Trade has been executed, txHash is ${tx.transactionHash}, gasUsed is ${tx.gasUsed}.`
+        );
+      
+
+        var finalAmountReceived_string = '';
+        for (var txEvent_idx=0; txEvent_idx<tx.events.length; txEvent_idx++){
+          var txEvent: TransactionEvent = tx.events[txEvent_idx];
+          if (txEvent.type == 'coin_received'){
+            for (var txEventAttribute_idx=0; txEventAttribute_idx<txEvent.attributes.length; txEventAttribute_idx++){
+              var txEventAttribute: TransactionEventAttribute = txEvent.attributes[txEventAttribute_idx];
+              if (txEventAttribute.key == 'receiver'){
+                if (txEventAttribute.value == req.address){
+                    var next_txEventAttribute: TransactionEventAttribute = txEvent.attributes[txEventAttribute_idx+1];
+                    if (next_txEventAttribute.key == 'amount' && next_txEventAttribute.value){
+                      finalAmountReceived_string = next_txEventAttribute.value;
+                    }
+                } 
+              }
+            }
+          }
+        }
+
+        var finalAmountReceived = new BigNumber(0)
+        if (finalAmountReceived_string != ''){
+          finalAmountReceived = (new BigNumber(finalAmountReceived_string.replace(tradeInfo.quoteToken.base, ''))).shiftedBy(tradeInfo.quoteToken.decimals * -1).decimalPlaces(tradeInfo.quoteToken.decimals);
+        }
+        const finalExecutionPrice = finalAmountReceived.dividedBy(req.amount);
+
+        return {
+          network: osmosis.chainName,
+          timestamp: startTimestamp,
+          latency: latency(startTimestamp, Date.now()),
+          base: tradeInfo.baseToken.base, // this is base denom. might want symbol tho? no address from what i see
+          quote: tradeInfo.quoteToken.base,
+          amount: new Decimal(req.amount).toFixed(tradeInfo.baseToken.decimals),
+          rawAmount: tradeInfo.requestAmount.toString(),
+          expectedAmountReceived: new BigNumber(tradeInfo.expectedTrade.expectedAmount).decimalPlaces(8).toString(),
+          finalAmountReceived: finalAmountReceived.toString(),
+          finalAmountReceived_basetoken: finalAmountReceived_string,
+          expectedPrice: new BigNumber(price).decimalPlaces(8).toString(),
+          finalPrice: finalExecutionPrice.toString(),
+          gasPrice: gasPrice,
+          gasLimit: gasLimitTransaction,
+          gasUsed: tx.gasUsed,
+          gasWanted: tx.gasWanted,
+          txHash: tx.transactionHash,
+        };
+      } else{
+        logger.error(
+          `Failed to execute trade. txHash is ${tx.transactionHash}, gasUsed is ${tx.gasUsed}. Log: ${tx.rawLog}`
+        )
+
+        throw new HttpException(
+          500,
+          TRADE_FAILED_ERROR_MESSAGE,
+          TRADE_FAILED_ERROR_CODE
+        );
+
+      }
+
+    }
+
+    static async addLiquidity(
+      osmosis: Osmosis,
+      req: CosmosAddLiquidityRequest 
+    ): Promise<CosmosAddLiquidityResponse> {
+      const startTimestamp: number = Date.now();
+
+      const { wallet } =
+        await getOsmoWallet(
+          osmosis,
+          req.address,
+        );
+
+      const token0: TokenishCosmosAsset = osmosis.getTokenBySymbol(req.token0);
+      const token1: TokenishCosmosAsset = osmosis.getTokenBySymbol(req.token1);
+
+      const gasPrice = osmosis.manualGasPrice;  // GAS PRICE PER UNIT OF WORK  
+      const gasLimitTransaction = osmosis.gasLimitEstimate; // MAX uOSMO COST PER TRANSACTION 
+      const gasAdjustment = osmosis.gasAdjustment; // 
+      const feeTier = osmosis.feeTier; // 
+
+      const tx = await osmosis.addPosition(
+        wallet,
+        req.address,
+        token0,
+        token1,
+        req.amount0,
+        req.amount1,
+        req.poolId,
+        req.allowedSlippage,
+        feeTier,
+        gasAdjustment,
+      );
+
+      logger.info(
+          `Liquidity added, txHash is ${tx.transactionHash}, gasUsed is ${tx.gasUsed}.`
+      );
+
+      if (tx.code == successfulTransaction){
+        logger.info(
+          `Trade has been executed, txHash is ${tx.transactionHash}, gasUsed is ${tx.gasUsed}.`
+        );
+      
+        return {
+          network: osmosis.chainName,
+          timestamp: startTimestamp,
+          latency: latency(startTimestamp, Date.now()),
+          token0: req.token0,
+          token1: req.token1,
+          poolId: tx.poolId,
+          gasPrice: gasPrice,
+          gasLimit: gasLimitTransaction,
+          gasUsed: tx.gasUsed,
+          gasWanted: tx.gasWanted,
+          txHash: tx.transactionHash,
+          poolAddress: tx.poolAddress,
+          poolShares: tx.poolshares,
+          token0FinalAmount: tx.token0_finalamount,
+          token1FinalAmount: tx.token1_finalamount,
+        };
+      }
+      else{
+        logger.error(
+          `Failed to execute trade. txHash is ${tx.transactionHash}, gasUsed is ${tx.gasUsed}. Log: ${tx.rawLog}`
+        )
+
+        throw new HttpException(
+          500,
+          TRADE_FAILED_ERROR_MESSAGE,
+          TRADE_FAILED_ERROR_CODE
+        );
+      }
+    }
+
+    static async removeLiquidity(
+      osmosis: Osmosis,
+      req: CosmosRemoveLiquidityRequest
+    ): Promise<CosmosRemoveLiquidityResponse> {
+      const startTimestamp: number = Date.now();
+
+      const { wallet } =
+        await getOsmoWallet(
+          osmosis,
+          req.address,
+        );
+
+      const gasPrice = osmosis.manualGasPrice;  // GAS PRICE PER UNIT OF WORK  
+      const gasLimitTransaction = osmosis.gasLimitEstimate; // MAX uOSMO COST PER TRANSACTION 
+      const gasAdjustment = osmosis.gasAdjustment; // 
+      const feeTier = osmosis.feeTier; // 
+
+      const tx = await osmosis.reducePosition(
+        wallet,
+        req.decreasePercent,
+        req.address,
+        req.poolId,
+        req.allowedSlippage,
+        feeTier,
+        gasAdjustment,
+      );
+
+      logger.info(
+        `Liquidity removed, txHash is ${tx.transactionHash}, gasUsed is ${tx.gasUsed}.`
+      );
+
+      return {
+        network: osmosis.chainName,
+        timestamp: startTimestamp,
+        latency: latency(startTimestamp, Date.now()),
+        poolId: req.poolId,
+        token0: tx.token0,
+        token1: tx.token1,
+        amount0: tx.amount0,
+        amount1: tx.amount1,
+        gasPrice: gasPrice,
+        gasLimit: gasLimitTransaction,
+        gasUsed: tx.gasUsed,
+        gasWanted: tx.gasWanted,
+        txHash: tx.transactionHash,
+      };
+    } 
+
+    // find pools containing both token0, token1
+    static async poolPrice(
+      osmosis: Osmosis,
+      req: CosmosPoolPriceRequest
+    ): Promise<CosmosPoolPriceResponse> {
+      const startTimestamp: number = Date.now();
+
+      const token0: TokenishCosmosAsset = osmosis.getTokenBySymbol(req.token0);
+      const token1: TokenishCosmosAsset = osmosis.getTokenBySymbol(req.token1);
+
+      const pools = await osmosis.findPoolsPrices(
+        token0,
+        token1,
+        req.address
+      );
+
+      logger.info(
+        `Found pools and prices for ${req.token0}, ${req.token1}.`
+      );
+
+      return {
+        network: osmosis.chainName,
+        timestamp: startTimestamp,
+        latency: latency(startTimestamp, Date.now()),
+        token0: req.token0,
+        token1: req.token1,
+        pools: pools, //CosmosExtendedPool[];
+      };
+    }
+
+    // find all pool positions for address or singular poolId if supplied
+    static async poolPositions(
+      osmosis: Osmosis,
+      req: CosmosPoolPositionsRequest
+    ): Promise<CosmosPoolPositionsResponse> {
+      const startTimestamp: number = Date.now();
+
+      const pools = await osmosis.findPoolsPositions(
+        req.address,
+        req.poolId
+      );
+      
+      if (req.poolId){
+        logger.info(
+          `Found pool positions for ${req.address}, ${req.poolId}`
+        );
+      }else{
+        logger.info(
+          `Found pools positions for ${req.address}.`
+        );
+      }
+
+
+      return {
+        network: osmosis.chainName,
+        timestamp: startTimestamp,
+        latency: latency(startTimestamp, Date.now()),
+        pools: pools, //CosmosExtendedPool[];
+      };
+    }
+
+
+    static async estimateGas(
+      osmosis: Osmosis,
+    ): Promise<EstimateGasResponse> {
+      
+      const gasPrice = Number(osmosis.manualGasPrice.replace('uosmo',''));  // GAS PRICE PER UNIT OF WORK  
+      const gasLimitTransaction = osmosis.gasLimitEstimate; // MAX uOSMO COST PER TRANSACTION 
+
+      return {
+        network: osmosis.chainName,
+        timestamp: Date.now(),
+        gasPrice,
+        gasPriceToken: 'uosmo',
+        gasLimit: Number(gasLimitTransaction),
+        gasCost: '0',
+      };
+      
+    }
+
+    static async getTokens(
+      osmosis: Osmosis,
+      req: TokensRequest
+    ): Promise<TokensResponse> {
+      return await osmosis.getTokens(req);
+    }
+
+    static async transfer(
+      osmosis: Osmosis,
+      req: TransferRequest
+    ): Promise<TransferResponse> {
+
+      const { wallet } =
+        await getOsmoWallet(
+          osmosis,
+          req.from,
+        );
+
+      const token: TokenishCosmosAsset = osmosis.getTokenBySymbol(req.token);
+    
+      const tx = await osmosis.transfer(wallet, token, req);
+
+      if (tx.code == successfulTransaction){
+        return 'Transfer success. To: ' + req.to + ' From: ' + req.from + ' Hash: ' + tx.transactionHash + ' gasUsed: ' + tx.gasUsed + ' gasWanted: ' + tx.gasWanted
+        // return {
+        //   amount: new Decimal(req.amount).toFixed(tradeInfo.baseToken.decimals),
+        //   gasPrice: gasPrice,
+        //   gasLimit: gasLimitTransaction,
+        //   gasUsed: tx.gasUsed,
+        //   gasWanted: tx.gasWanted,
+        //   txHash: tx.transactionHash,
+        // };
+      }
+      else{
+        throw new HttpException(
+          500,
+          UNKNOWN_ERROR_MESSAGE,
+          UNKNOWN_ERROR_ERROR_CODE
+        );
+      }
+    }
+
+    static async balances(osmosis: Osmosis, req: CosmosBalanceRequest) {
+      validateCosmosBalanceRequest(req);
+
+      const wallet = await osmosis.getWallet(req.address, 'osmo');
+
+      var tokenSymbols: string[] = [];
+      // FILTER IF req.tokenSymbols != []
+      if (req && req.tokenSymbols && req.tokenSymbols.length > 0){
+        tokenSymbols = req.tokenSymbols;
+      } else{
+        const tokenAssets = osmosis.storedTokenList;
+        tokenAssets.forEach((token: CosmosAsset) => {
+          tokenSymbols.push(token.symbol);
+        });
+      }
+
+      const balances = await osmosis.getBalances(wallet);
+      const filteredBalances = toCosmosBalances(balances, tokenSymbols);
+
+      return {
+        balances: filteredBalances,
+      };
+    }
+
+    static async poll(osmosis: Osmosis, req: CosmosPollRequest) {
+      validateCosmosPollRequest(req);
+
+      const transaction = await osmosis.getTransaction(req.txHash);
+      const currentBlock = await osmosis.getCurrentBlockNumber();
+
+      return {
+        txHash: req.txHash,
+        currentBlock,
+        txBlock: transaction.height,
+        gasUsed: transaction.gasUsed,
+        gasWanted: transaction.gasWanted,
+        txData: decodeTxRaw(transaction.tx),
+      };
+    }
+
+    static async allowances(
+      osmosis: Osmosis,
+      req: AllowancesRequest
+    ){
+      if (osmosis || req){}
+      // Not applicable.
+      return {
+        spender: undefined as unknown as string,
+        approvals: {} as Record<string, string>,
+      };
+    }
+
+    static async approve(
+      osmosis: Osmosis,
+      req: ApproveRequest
+    ){
+      if (osmosis || req){}
+      // Not applicable.
+      return {
+        tokenAddress: undefined as unknown as string,
+        spender: undefined as unknown as string,
+        amount: undefined as unknown as string,
+        nonce: undefined as unknown as number,
+        approval: undefined as unknown as CustomTransaction,
+      };
+    }
+
+    static async cancel(
+      osmosis: Osmosis,
+      req: CancelRequest
+    ){
+      if (osmosis || req){}
+      // Not applicable.
+      return {
+        txHash: undefined as unknown as string,
+      };
+    }
+
+    static async nonce(
+      osmosis: Osmosis,
+      req: NonceRequest
+    ): Promise<NonceResponse> {
+      if (osmosis || req){}
+      // Not applicable.
+      const nonce = 0;
+      return { nonce };
+    }
+  
+    static async nextNonce(
+      osmosis: Osmosis,
+      req: NonceRequest
+    ): Promise<NonceResponse> {
+      if (osmosis || req){}
+      // Not applicable.
+      const nonce = 0;
+      return { nonce };
+    }
+}

--- a/src/chains/osmosis/osmosis.lp.utils.ts
+++ b/src/chains/osmosis/osmosis.lp.utils.ts
@@ -1,0 +1,105 @@
+// adapted from utils/pools.ts from createcosmoapp liquidity example
+
+import BigNumber from 'bignumber.js';
+import { Asset } from '@chain-registry/types';
+import { Pool } from 'osmo-query/dist/codegen/osmosis/gamm/pool-models/balancer/balancerPool';
+import { Coin } from 'osmo-query/dist/codegen/cosmos/base/v1beta1/coin';
+import {
+  calcPoolLiquidity,
+  getPoolByGammName as _getPoolByGammName,
+  convertGammTokenToDollarValue,
+} from '@chasevoorhees/osmonauts-math-decimal';
+
+import {
+  PriceHash,
+} from './osmosis.types';
+import { Fee } from './osmosis.utils';
+
+export const getPoolByGammName = (pools: Pool[], gammId: string): Pool => {
+  return _getPoolByGammName(pools, gammId);
+};
+
+export const filterPools = (assets: Asset[], pools: Pool[], prices: PriceHash) => {
+  return pools
+    .filter(({ $typeUrl }) => !$typeUrl?.includes('stableswap'))
+    .filter(({ poolAssets }) =>
+      poolAssets != undefined &&
+      poolAssets.every(
+        ({ token }) =>
+          prices[token.denom] &&
+          !token.denom.startsWith('gamm/pool') &&
+          assets.find(({ base }) => base === token.denom)
+      )
+    );
+};
+
+interface ExtendPoolProps {
+  pool: Pool;
+  fees: Fee[];
+  balances: Coin[];
+  lockedCoins: Coin[];
+  prices: PriceHash;
+}
+
+export const extendPool = (assets: Asset[], {
+  pool,
+  fees,
+  balances,
+  lockedCoins,
+  prices,
+}: ExtendPoolProps) => {
+  const liquidity = new BigNumber(calcPoolLiquidity(assets, pool, prices))
+    .decimalPlaces(0)
+    .toNumber();
+
+  const feeData = fees.find((fee) => fee.pool_id === pool.id.toString());
+  const volume24H = Math.round(Number(feeData?.volume_24h || 0));
+  const volume7d = Math.round(Number(feeData?.volume_7d || 0));
+  const fees7D = Math.round(Number(feeData?.fees_spent_7d || 0));
+
+  const poolDenom = pool.totalShares?.denom;
+
+  const balanceCoin = balances.find(({ denom }) => denom === poolDenom);
+  const myLiquidity = balanceCoin
+    ? convertGammTokenToDollarValue(assets, balanceCoin, pool, prices)
+    : '0';
+
+  const lockedCoin = lockedCoins.find(({ denom }) => denom === poolDenom);
+  const bonded = lockedCoin
+    ? convertGammTokenToDollarValue(assets, lockedCoin, pool, prices)
+    : '0';
+
+  return {
+    ...pool,
+    liquidity,
+    volume24H,
+    fees7D,
+    volume7d,
+    myLiquidity,
+    bonded,
+    denom: poolDenom,
+  };
+};
+
+export type ExtendedPool = ReturnType<typeof extendPool>;
+
+export const descByLiquidity = (pool1: ExtendedPool, pool2: ExtendedPool) => {
+  return new BigNumber(pool1.liquidity).lt(pool2.liquidity) ? 1 : -1;
+};
+
+export const descByMyLiquidity = (pool1: ExtendedPool, pool2: ExtendedPool) => {
+  return new BigNumber(pool1.myLiquidity).lt(pool2.myLiquidity) ? 1 : -1;
+};
+
+type Item = {
+  denom: string;
+  [key: string]: any;
+};
+
+export const getPoolsByDenom = (allPools: ExtendedPool[], items: Item[]) => {
+  return items
+    .filter(({ denom }) => allPools.find(({ denom: d }) => d === denom))
+    .map(({ denom }) => {
+      return allPools.find(({ denom: d }) => d === denom) as ExtendedPool;
+    });
+};

--- a/src/chains/osmosis/osmosis.prices.ts
+++ b/src/chains/osmosis/osmosis.prices.ts
@@ -1,0 +1,99 @@
+import { Asset } from '@chain-registry/types';
+
+import {
+  PriceHash,
+} from '@chasevoorhees/osmonauts-math-decimal/dist/types';
+import { CosmosAsset } from '../cosmos/cosmos-base';
+
+type CoinGeckoId = string;
+type CoinGeckoUSD = { usd: number };
+type CoinGeckoUSDResponse = Record<CoinGeckoId, CoinGeckoUSD>;
+
+const getAssetsWithGeckoIds = (assets: Asset[]) => {
+  return assets.filter((asset) => !!asset?.coingecko_id);
+};
+
+const getGeckoIds = (assets: Asset[]) => {
+  return assets.map((asset) => asset.coingecko_id) as string[];
+};
+
+const formatPrices = (
+  prices: CoinGeckoUSDResponse,
+  assets: Asset[]
+): Record<string, number> => {
+  return Object.entries(prices).reduce((priceHash, cur) => {
+    const key = assets.find((asset) => asset.coingecko_id === cur[0])!.base;
+    // const key = assets.find((asset) => asset.coingecko_id === cur[0])!.symbol;  // hash by symbol
+    return { ...priceHash, [key]: cur[1].usd };
+  }, {});
+};
+
+export const getCoinGeckoPrices = async (assets: Asset[]): Promise<Record<string, number>> => {
+  const assetsWithGeckoIds = getAssetsWithGeckoIds(assets);
+  const geckoIds = getGeckoIds(assetsWithGeckoIds);
+
+  const priceData: CoinGeckoUSDResponse | undefined = await getData(geckoIds);
+  if (priceData){
+    return formatPrices(priceData, assetsWithGeckoIds)
+  }
+  throw new Error('Osmosis failed to get prices from coingecko.com')
+};
+
+
+const getData = async (
+  geckoIds: string[]
+): Promise<CoinGeckoUSDResponse | undefined> => {
+  let prices: CoinGeckoUSDResponse;
+
+  const url = `https://api.coingecko.com/api/v3/simple/price?ids=${geckoIds.join()}&vs_currencies=usd`;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) throw Error('Get price error');
+    prices = (await response.json()) as CoinGeckoUSDResponse;
+    return prices;
+  } catch (err) {
+    console.error(err);
+  }
+  return undefined;
+};
+
+export const getImperatorPriceHash = async (tokenList?: CosmosAsset[]) => {
+  let prices = [];
+
+  try {
+    const response = await fetch(
+      'https://api-osmosis.imperator.co/tokens/v2/all'
+    );
+    if (!response.ok) throw Error('Get price error');
+    prices = (await response.json()) as any[];
+  } catch (err) {
+    console.error(err);
+  }
+
+  var priceHash: PriceHash = {};
+  // need to sort from symbol->denom input to make testnet denoms work (prices always come with mainnet denoms)
+  if (tokenList && tokenList.length>0){
+    prices.forEach((element) => {
+      if (element.symbol){
+        var testnet_element = tokenList.find(({symbol}) => symbol==element.symbol);
+        if (testnet_element){
+          priceHash[testnet_element.base] = element.price;
+        }else{
+          priceHash[element.denom] = element.price;
+        }
+      }else{
+        priceHash[element.denom] = element.price;
+      }
+    });
+  }else{
+    priceHash = prices.reduce(
+      (prev: any, cur: { denom: any; price: any }) => ({
+        ...prev,
+        [cur.denom]: cur.price,
+      }),
+      {}
+    );
+  }
+
+  return priceHash;
+};

--- a/src/chains/osmosis/osmosis.ts
+++ b/src/chains/osmosis/osmosis.ts
@@ -1,0 +1,1665 @@
+// @ts-nocheck
+// OSMO message composer classes don't quite match up with what the RPC/Go backend actually accepts.
+
+import axios from 'axios';
+import fse from 'fs-extra';
+import { promises as fs } from 'fs';
+import { AccountData } from '@cosmjs/proto-signing';
+import { CosmosWallet, CosmosAsset, EncryptedPrivateKey } from '../../chains/cosmos/cosmos-base'; 
+import { OsmosisController } from './osmosis.controllers';
+import BigNumber from 'bignumber.js';
+import { logger } from '../../services/logger';
+import { coins, coin, Coin } from '@cosmjs/amino';
+import { FEES, } from 'osmojs/dist/utils/gas/values'
+import { TokenInfo, TokenListType, TokenValue, walletPath } from '../../services/base'; 
+
+import { osmosis, cosmos, getSigningOsmosisClient } from 'osmojs';
+import {
+  CoinGeckoToken,
+  CoinDenom,
+  Exponent,
+  CoinSymbol,
+  PriceHash,
+  TransactionEvent,
+  TransactionEventAttribute,
+  OsmosisExpectedTrade, 
+  ToLog_OsmosisExpectedTrade, 
+  TransactionResponse, 
+  OsmosisExpectedTradeRoute, 
+  AddPositionTransactionResponse, 
+  ReduceLiquidityTransactionResponse, 
+  SerializableExtendedPool
+} from './osmosis.types';
+
+import { OsmosisConfig } from './osmosis.config'; 
+import {
+  convertDollarValueToCoins,
+  convertDollarValueToShares,
+  calcShareOutAmount,
+  makePoolPairs,
+  getRoutesForTrade,
+  calcAmountWithSlippage,
+  calcPriceImpactGivenIn,
+  calcPriceImpactGivenOut
+} from '@chasevoorhees/osmonauts-math-decimal';
+import type {
+  PrettyPair,
+} from "@chasevoorhees/osmonauts-math-decimal/dist/types";
+import NodeCache from 'node-cache';
+import { TradeInfo } from './osmosis.controllers';
+import { PoolAsset } from 'osmojs/dist/codegen/osmosis/gamm/pool-models/balancer/balancerPool';
+import { HttpException, TRADE_FAILED_ERROR_CODE, TRADE_FAILED_ERROR_MESSAGE, INSUFFICIENT_FUNDS_ERROR_CODE, INSUFFICIENT_FUNDS_ERROR_MESSAGE } from '../../services/error-handler';
+import { ExtendedPool, extendPool, filterPools as filterPoolsLP } from './osmosis.lp.utils';
+import { fetchFees } from './osmosis.utils';
+import { getCoinGeckoPrices, getImperatorPriceHash } from './osmosis.prices';
+import { GasPrice, IndexedTx, calculateFee, setupIbcExtension } from '@cosmjs/stargate';
+import { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
+import { TokensRequest, TokensResponse } from '../../network/network.requests';
+import { TransferRequest } from '../../chains/injective/injective.requests';
+import { ConfigManagerCertPassphrase } from '../../services/config-manager-cert-passphrase';
+
+const crypto = require('crypto').webcrypto;
+const { DirectSecp256k1Wallet } = require('@cosmjs/proto-signing');
+const { toBase64, fromBase64, fromHex } = require('@cosmjs/encoding');
+const {
+  joinPool,
+  exitPool,
+  joinSwapExternAmountIn,
+  swapExactAmountIn,
+} = osmosis.gamm.v1beta1.MessageComposer.withTypeUrl;
+const {
+send
+} = cosmos.bank.v1beta1.MessageComposer.fromPartial;
+
+const { createRPCQueryClient } = osmosis.ClientFactory;
+
+export class Osmosis { 
+
+  public controller;
+  private static _instances: { [name: string]: Osmosis };
+  private _gasPrice: number;
+  private _nativeTokenSymbol: string;
+  private _chain: string;
+  private _requestCount: number;
+  private _metricsLogInterval: number;
+  private _metricTimer;
+
+  private _osmosReady: boolean = false;
+  private _osmosInitializing: boolean = false;
+  private _osmosInitPromise: Promise<void> = Promise.resolve();
+  private rpcClient?: any;
+  private signingClient?: any;
+  public chainId: string;
+  protected tokenList: CosmosAsset[] = [];
+  protected tokenMap: Record<string, CosmosAsset> = {}; // all the other connectors are using this instead of/as tokenMap - so changing in cosmos-base too
+  public chainName: string;
+  public rpcURL: string;
+
+  public gasAdjustment: number;
+  public gasLimitEstimate: string;
+  public readonly feeTier: string; // FEE_VALUES.osmosis[_feeTier] low medium high osmojs/src/utils/gas/values.ts
+  public manualGasPrice: string;
+  public allowedSlippage: string;
+  
+  public tokenListSource: string;
+  public tokenListType: TokenListType; //TokenListType = FILE | URL
+  public cache: import("node-cache");
+
+  private constructor(network: string) {
+    const config = OsmosisConfig.config;
+    this._chain = network;
+    this._nativeTokenSymbol = config.nativeCurrencySymbol;
+    this.manualGasPrice = config.manualGasPrice;
+    this._gasPrice = Number(this.manualGasPrice.replace('uosmo',''))
+    this.tokenMap = {}
+    this.feeTier = config.feeTier;
+    this.gasAdjustment = config.gasAdjustment
+    this.gasLimitEstimate = config.gasLimitTransaction
+    this.allowedSlippage = config.allowedSlippage
+
+    this.tokenListType = config.tokenListType(network)
+    this.tokenListSource = config.tokenListSource(network)
+    this.cache = new NodeCache();
+    this.rpcURL = config.rpcURL(network).toString()
+    this.chainName = config.availableNetworks[0].chain;
+    this.chainId = config.chainId(network);
+    this.rpcClient = undefined;
+    this.signingClient = undefined;
+    this.controller = OsmosisController;
+
+    this._requestCount = 0;
+    this._metricsLogInterval = 300000; // 5 minutes
+
+    this._metricTimer = setInterval(
+      this.metricLogger.bind(this),
+      this.metricsLogInterval
+    );
+  }
+
+  public static getInstance(network: string): Osmosis {
+    if (Osmosis._instances === undefined) {
+      Osmosis._instances = {};
+    }
+    if (!(network in Osmosis._instances)) {
+      Osmosis._instances[network] = new Osmosis(network);
+    }
+
+    return Osmosis._instances[network];
+  }
+
+  public static getConnectedInstances(): { [name: string]: Osmosis } {
+    return Osmosis._instances;
+  }
+
+  public requestCounter(msg: any): void {
+    if (msg.action === 'request') this._requestCount += 1;
+  }
+
+  public metricLogger(): void {
+    logger.info(
+      this.requestCount +
+        ' request(s) sent in last ' +
+        this.metricsLogInterval / 1000 +
+        ' seconds.'
+    );
+    this._requestCount = 0; // reset
+  }
+
+  public get gasPrice(): number {
+    return this._gasPrice;
+  }
+
+  public get chain(): string {
+    return this._chain;
+  }
+
+  public get nativeTokenSymbol(): string {
+    return this._nativeTokenSymbol;
+  }
+
+  public get requestCount(): number {
+    return this._requestCount;
+  }
+
+  public get metricsLogInterval(): number {
+    return this._metricsLogInterval;
+  }
+
+  async close() {
+    clearInterval(this._metricTimer);
+    if (this._chain in Osmosis._instances) {
+      delete Osmosis._instances[this._chain];
+    }
+  }
+
+  public ready(): boolean {
+    return this._osmosReady
+  }
+
+  public async init(): Promise<void> {
+
+    if (!this.ready() && !this._osmosInitializing) {
+      this._osmosInitializing = true;
+
+      this.rpcClient = await createRPCQueryClient({rpcEndpoint: this.rpcURL});
+      this._osmosInitPromise = this.loadTokens(
+        this.tokenListSource,
+        this.tokenListType
+      ).then(() => {
+        this._osmosReady = true;
+        this._osmosInitializing = false;
+      });
+
+
+      for (const token of this.storedTokenList) {
+        if (token.address !== undefined){
+          this.tokenMap[token.address] = token;
+        }
+      }
+    }
+
+    return this._osmosInitPromise;
+  }
+
+  // returns a cosmos tx for a txHash
+  async getTransaction(id: string): Promise<IndexedTx> {
+    const transaction = await this.rpcClient.getTx(id);
+
+    if (!transaction) {
+      throw new Error('Transaction not found');
+    }
+
+    return transaction;
+  }
+  
+  async getWalletFromPrivateKey(
+    privateKey: string,
+    prefix: string
+  ): Promise<CosmosWallet> {
+    const wallet = await DirectSecp256k1Wallet.fromKey(
+      fromHex(privateKey),
+      prefix
+    );
+
+    return wallet;
+  }
+
+  async getAccountsfromPrivateKey(
+    privateKey: string,
+    prefix: string
+  ): Promise<AccountData> {
+    const wallet = await this.getWalletFromPrivateKey(privateKey, prefix);
+
+    const accounts = await wallet.getAccounts();
+
+    return accounts[0];
+  }
+
+  // returns Wallet for an address
+  // TODO: Abstract-away into base.ts
+  async getWallet(address: string, prefix: string): Promise<CosmosWallet> {
+    const path = `${walletPath}/${this.chainName}`;
+
+    const encryptedPrivateKey: EncryptedPrivateKey = JSON.parse(
+      await fse.readFile(`${path}/${address}.json`, 'utf8'),
+      (key, value) => {
+        switch (key) {
+          case 'ciphertext':
+          case 'salt':
+          case 'iv':
+            return fromBase64(value);
+          default:
+            return value;
+        }
+      }
+    );
+
+    const passphrase = ConfigManagerCertPassphrase.readPassphrase();
+    if (!passphrase) {
+      throw new Error('missing passphrase');
+    }
+
+    return await this.decrypt(encryptedPrivateKey, passphrase, prefix);
+  }
+
+  private static async getKeyMaterial(password: string) {
+    const enc = new TextEncoder();
+    return await crypto.subtle.importKey(
+      'raw',
+      enc.encode(password),
+      'PBKDF2',
+      false,
+      ['deriveBits', 'deriveKey']
+    );
+  }
+
+  private static async getKey(
+    keyAlgorithm: {
+      salt: Uint8Array;
+      name: string;
+      iterations: number;
+      hash: string;
+    },
+    keyMaterial: CryptoKey
+  ) {
+    return await crypto.subtle.deriveKey(
+      keyAlgorithm,
+      keyMaterial,
+      { name: 'AES-GCM', length: 256 },
+      true,
+      ['encrypt', 'decrypt']
+    );
+  }
+
+  // from Solana.ts
+  async encrypt(privateKey: string, password: string): Promise<string> {
+    const iv = crypto.getRandomValues(new Uint8Array(16));
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const keyMaterial = await Osmosis.getKeyMaterial(password);
+    const keyAlgorithm = {
+      name: 'PBKDF2',
+      salt: salt,
+      iterations: 500000,
+      hash: 'SHA-256',
+    };
+    const key = await Osmosis.getKey(keyAlgorithm, keyMaterial);
+    const cipherAlgorithm = {
+      name: 'AES-GCM',
+      iv: iv,
+    };
+    const enc = new TextEncoder();
+    const ciphertext: Uint8Array = (await crypto.subtle.encrypt(
+      cipherAlgorithm,
+      key,
+      enc.encode(privateKey)
+    )) as Uint8Array;
+    return JSON.stringify(
+      {
+        keyAlgorithm,
+        cipherAlgorithm,
+        ciphertext: new Uint8Array(ciphertext),
+      },
+      (key, value) => {
+        switch (key) {
+          case 'ciphertext':
+          case 'salt':
+          case 'iv':
+            return toBase64(Uint8Array.from(Object.values(value)));
+          default:
+            return value;
+        }
+      }
+    );
+  }
+
+  async decrypt(
+    encryptedPrivateKey: EncryptedPrivateKey,
+    password: string,
+    prefix: string
+  ): Promise<CosmosWallet> {
+    const keyMaterial = await Osmosis.getKeyMaterial(password);
+    const key = await Osmosis.getKey(
+      encryptedPrivateKey.keyAlgorithm,
+      keyMaterial
+    );
+    const decrypted = await crypto.subtle.decrypt(
+      encryptedPrivateKey.cipherAlgorithm,
+      key,
+      encryptedPrivateKey.ciphertext
+    );
+    const dec = new TextDecoder();
+    dec.decode(decrypted);
+
+    return await this.getWalletFromPrivateKey(dec.decode(decrypted), prefix);
+  }
+
+  getTokenDecimals(token: any): number {
+    return token ? token.denom_units[token.denom_units.length - 1].exponent : 6; // Last denom unit has the decimal amount we need from our list
+  }
+
+  // returns a Tokens for a given list source and list type
+  //  chase: kind of unsure about this - just parsing cosmo JSON into native hbot Token[] 
+  async getTokenList(
+    tokenListSource: string,
+    tokenListType: TokenListType
+  ): Promise<CosmosAsset[]> {
+    let tokens: CosmosAsset[] = [];
+    let tokensJson = [];
+
+    if (tokenListType === 'URL') {
+      ({ data: tokensJson } = await axios.get(tokenListSource));
+    } else {
+      ({ tokensJson } = JSON.parse(await fs.readFile(tokenListSource, 'utf8')));
+    }
+    for (var tokenAssetIdx=0; tokenAssetIdx<tokensJson.assets.length; tokenAssetIdx++){
+      var tokenAsset = tokensJson.assets[tokenAssetIdx];
+      tokens.push(new CosmosAsset(tokenAsset))
+    }
+    return tokens;
+  }
+  async loadTokens(
+    tokenListSource: string,
+    tokenListType: TokenListType
+  ): Promise<void> {
+    this.tokenList = await this.getTokenList(tokenListSource, tokenListType);
+  }
+
+  public get storedTokenList(): CosmosAsset[] {
+    return this.tokenList;
+  }
+
+  public getTokenForSymbol(tokenSymbol: string): CosmosAsset {
+    return this.getTokenBySymbol(tokenSymbol);
+  }
+  public getTokenBySymbol(tokenSymbol: string): CosmosAsset {
+    const token = this.tokenList.find(
+      (token: CosmosAsset) => token.symbol.toUpperCase() === tokenSymbol.toUpperCase()
+    );
+    if (!token){
+      throw new Error('Osmosis token not found for symbol: ' + tokenSymbol);
+    }
+    return token; 
+  }
+  public getTokenByBase(base: string): CosmosAsset | undefined {
+    const token = this.tokenList.find((token: CosmosAsset) => token.base === base);
+    if (!token){
+      return undefined
+      // throw new Error('Osmosis token not found for base: ' + base);
+    }
+    return token; 
+  }
+  public getTokenByAddress(address: string): CosmosAsset {
+    const token = this.tokenList.find((token: CosmosAsset) => token.address === address);
+    if (!token){
+      throw new Error('Osmosis token not found for address: ' + address);
+    }
+    return token; 
+  }
+  public getDenomForCoinGeckoId = (
+    coinGeckoId: CoinGeckoToken
+  ): CoinDenom => {
+    var asset_found = this.tokenList.find((asset) => asset.coingecko_id === coinGeckoId);
+    if (asset_found) {
+      return asset_found.base
+    } else {
+      return '';
+    }
+  };
+  public osmoDenomToSymbol = (denom: CoinDenom): CoinSymbol => {
+    const asset = this.getTokenByBase(denom);
+    const symbol = asset?.symbol;
+    if (!symbol) {
+      return denom;
+    }
+    return symbol;
+  };
+  public symbolToOsmoDenom = (token: CoinSymbol): CoinDenom => {
+    const asset = this.tokenList.find(({ symbol }) => symbol === token);
+    const base = asset?.base;
+    if (!base) {
+      console.log(`cannot find base for token ${token}`);
+      return '';
+    }
+    return base;
+  };
+
+  // technically by base
+  public getExponentByBase = (denom: CoinDenom): Exponent => {
+    const asset = this.getTokenByBase(denom);
+    if (asset && asset.denom_units){
+      const unit = asset.denom_units.find(({ denom }) => denom === asset.display);
+      if (unit){
+        return unit.exponent;
+      } 
+    }
+    return 0
+  };
+  public noDecimals = (num: number | string) => {
+    return new BigNumber(num).decimalPlaces(0, BigNumber.ROUND_DOWN).toString();
+  };
+  public baseUnitsToDollarValue = (
+    prices: PriceHash,
+    symbol: string,
+    amount: string | number
+  ) => {
+    const denom = this.symbolToOsmoDenom(symbol);
+    return new BigNumber(amount)
+      .shiftedBy(-this.getExponentByBase(denom))
+      .multipliedBy(prices[denom])
+      .toString();
+  };
+  public dollarValueToDenomUnits = (
+    prices: PriceHash,
+    symbol: string,
+    value: string | number
+  ) => {
+    const denom = this.symbolToOsmoDenom(symbol);
+    return new BigNumber(value)
+      .dividedBy(prices[denom])
+      .shiftedBy(this.getExponentByBase(denom))
+      .toString();
+  };
+  public baseUnitsToDisplayUnits = (
+    symbol: string,
+    amount: string | number
+  ) => {
+    const denom = this.symbolToOsmoDenom(symbol);
+    return new BigNumber(amount).shiftedBy(-this.getExponentByBase(denom)).toString();
+  };
+
+  public isEmptyArray = (arr: any[]) => arr.length === 0;
+ 
+  async getBalances(wallet: CosmosWallet): Promise<Record<string, TokenValue>> {
+    const balances: Record<string, TokenValue> = {};
+
+    const accounts = await wallet.getAccounts();
+
+    var { address } = accounts[0];
+
+    var balancesContainer;
+    balancesContainer = await this.rpcClient.cosmos.bank.v1beta1.allBalances({
+      address: address,
+      pagination: {
+        key: new Uint8Array(),
+        offset: BigInt(0),
+        limit: BigInt(10000),
+        countTotal: false,
+        reverse: false,
+      },
+    })
+
+    const allTokens = balancesContainer.balances
+
+    await Promise.all(
+      allTokens.map(async (t: { denom: string; amount: string }) => {
+        let token = this.getTokenByBase(t.denom);
+
+        try{
+          if (!token && t.denom.startsWith('ibc/')) {
+            const ibcHash: string = t.denom.replace('ibc/', '');
+
+            // Get base denom by IBC hash
+            if (ibcHash) {
+              const { denomTrace } = await setupIbcExtension(this.rpcClient).ibc.transfer.denomTrace(ibcHash);
+              if (denomTrace) {
+                const { baseDenom } = denomTrace;
+                token = this.getTokenByBase(baseDenom);
+              }
+            }
+          }
+        } catch (err) {
+          //console.debug(err);
+        }
+
+        // Not all tokens are added in the registry so we use the denom if the token doesn't exist
+        balances[token ? token.symbol : t.denom] = {
+          value: new BigNumber(t.amount),
+          decimals: this.getTokenDecimals(token),
+        };
+      })
+    );
+
+    return balances;
+  }
+  /**
+   * Given the amount of `baseToken` to put into a transaction, calculate the
+   * amount of `quoteToken` that can be expected from the transaction.
+   *
+   * This is typically used for calculating token buy/sell prices.
+   *
+   * @param baseToken Token input for the transaction
+   * @param quoteToken Output from the transaction
+   * @param amount Amount of `baseToken` to put into the transaction
+   * @param tradeType "BUY" or "SELL"
+   * @param allowedSlippage? Allowed slippage eg "1%"
+   * @param feeTier_input? low/medium/high, overwrites feeTier specified in .yml
+   * @param gasAdjustment_input? Gas offered multiplier, overwrites gasAdjustment specified in .yml
+   */
+  async estimateTrade(
+    baseToken: CosmosAsset,
+    quoteToken: CosmosAsset,
+    amount: BigNumber,
+    tradeType: string,
+    allowedSlippage?: string,
+    feeTier_input?: string,
+    gasAdjustment_input?: number,
+  ): Promise<OsmosisExpectedTrade>{
+
+    var slippage = 0;
+    if (allowedSlippage){
+      slippage = Number(allowedSlippage.split('%')[0]);
+    }else{
+      slippage = Number(this.allowedSlippage.split('%')[0]);
+    }
+    var feeTier = this.feeTier;
+    if (feeTier_input){
+      feeTier = feeTier_input;
+    }
+    var gasAdjustment = this.gasAdjustment;
+    if (gasAdjustment_input){
+      gasAdjustment = gasAdjustment_input;
+    }
+
+    if (tradeType == "BUY"){
+      //swap base and quotetokens
+      const realBaseToken = quoteToken;
+      quoteToken = baseToken;
+      baseToken = realBaseToken;
+    }
+
+    logger.info(
+      `Fetching pair data for ${quoteToken.symbol}-${baseToken.symbol}.`
+    );
+    //console.debug(`Fetching pair data for ${quoteToken.symbol}-${baseToken.symbol}.`);
+
+    var callImperatorWithTokens = undefined
+    if (this.chain == 'testnet'){
+      callImperatorWithTokens = this.tokenList;
+    }
+    const [prices, { pools: poolsData }] = await Promise.all([
+      // getCoinGeckoPrices(this.tokenList),
+      getImperatorPriceHash(callImperatorWithTokens),
+      this.rpcClient.osmosis.gamm.v1beta1.pools({
+        pagination: {
+          key: new Uint8Array(),
+          offset: BigInt(0),
+          limit: BigInt(2000),
+          countTotal: false,
+          reverse: false,
+        },
+      }) as Promise<{ pools: ExtendedPool[] }>, // ExtendedBalancerPool
+    ]);
+
+    // filterPoolsSWAP
+    var pools: ExtendedPool[] = poolsData  // ExtendedBalancerPool
+    .filter(({ $typeUrl }) => !$typeUrl?.includes('stableswap'))
+    .filter(({ poolAssets }) =>
+      poolAssets.every(
+        ({ token }) =>
+          prices[token!.denom] &&
+          this.getTokenByBase(token!.denom)
+          // osmosisAssets.find((asset) => asset.base === token!.denom)
+      )
+    );
+    
+
+    var pairs: PrettyPair[] = [];
+    if (!this.isEmptyArray(pools) && !this.isEmptyArray(Object.keys(prices))){
+      pairs = makePoolPairs(this.tokenList, pools, prices);
+    }
+    
+    // eg. token=OSMO, token.base=uOSMO, so swap calcs are done in uosmo is 
+    const tokenInAmount = new BigNumber(amount)
+      .shiftedBy(baseToken.decimals)
+      .toString();
+
+    const tokenInDollarValue = new BigNumber(amount || '0').multipliedBy(
+      prices[baseToken.base]
+    );
+  
+    const toTokenAmount = tokenInDollarValue.div(prices[quoteToken.base]);
+
+    const tokenOutAmount = new BigNumber(toTokenAmount)
+      .shiftedBy(quoteToken.decimals)
+      // tokenOut defined by .base (eg. uION)
+      .toString();
+
+    var tokenOutAmountAfterSlippage;
+    if (slippage == 100){
+      tokenOutAmountAfterSlippage = '1';
+    }else{
+      tokenOutAmountAfterSlippage = calcAmountWithSlippage(
+      tokenOutAmount,
+      slippage
+      );
+    }
+
+
+    const tokenIn = {
+      denom: baseToken.base,
+      amount: tokenInAmount,
+    };
+    const tokenOut = {
+      denom: quoteToken.base,
+      amount: tokenOutAmountAfterSlippage,
+    };
+
+    const routes = getRoutesForTrade(this.tokenList, { // SwapAmountInRoute[] = (poolId, tokenOutDenom)[]
+      trade: {
+        sell: {
+          denom: tokenIn.denom,
+          amount: tokenIn.amount,
+        },
+        buy: {
+          denom: tokenOut.denom,
+          amount: tokenOut.amount,
+        },
+      },
+      pairs,
+    });
+
+    // so far we have pools, routes, and token info...
+    let route_length_1_pool_swapFee = '';
+    let priceImpact = '';
+
+    if (new BigNumber(tokenIn.amount).isEqualTo(0)) {
+      priceImpact = '0';
+    } 
+    else if (routes.length === 1) 
+    {
+      const route_length_1_pool = pools.find((pool) => pool.id === routes[0].poolId)!;
+      priceImpact = calcPriceImpactGivenIn(tokenIn, tokenOut.denom, route_length_1_pool);
+      route_length_1_pool_swapFee = route_length_1_pool.poolParams?.swapFee || '0';
+    } 
+    else {
+      const tokenInRoute = routes.find(
+        (route) => route.tokenOutDenom !== tokenOut.denom
+      )!;
+      const tokenOutRoute = routes.find(
+        (route) => route.tokenOutDenom === tokenOut.denom
+      )!;
+
+      const tokenInPool = pools.find(
+        (pool) => pool.id === tokenInRoute.poolId
+      )!;
+      const tokenOutPool = pools.find(
+        (pool) => pool.id === tokenOutRoute.poolId
+      )!;
+
+      const priceImpactIn = calcPriceImpactGivenIn(
+        tokenIn,
+        tokenInRoute.tokenOutDenom,
+        tokenInPool
+      );
+      const priceImpactOut = calcPriceImpactGivenOut(
+        tokenOut,
+        tokenOutRoute.tokenOutDenom,
+        tokenOutPool
+      );
+      priceImpact = new BigNumber(priceImpactIn)
+        .plus(priceImpactOut)
+        .toString();
+    }
+
+// routes.length=1 mean there's just 1 hop - we're always just given one potentially route[] for a trade route request
+    let swapRoutes: OsmosisExpectedTradeRoute[] = []
+    if (routes.length === 0) {
+      logger.info(
+        `No trade routes found for ${quoteToken.symbol}-${
+          baseToken.symbol} ${quoteToken.symbol}-${
+            baseToken.symbol}`
+      );  
+      throw new Error(`No trade routes found for ${quoteToken.symbol}-${
+        baseToken.symbol} ${quoteToken.symbol}-${
+          baseToken.symbol}`); 
+    }
+    else if (routes.length === 1) {
+      swapRoutes = routes.map((route) => {
+        return {
+          poolId: route.poolId.toString(),
+          swapFee: route_length_1_pool_swapFee,
+          baseLogo: baseToken.logo_URIs,
+          baseSymbol: baseToken.symbol,
+          quoteLogo: quoteToken.logo_URIs,
+          quoteSymbol: quoteToken.symbol,
+          tokenOutDenom: tokenOut.denom,
+        };
+      });
+    } else {
+      let swapFees: BigNumber[] = [];
+      swapRoutes = routes
+        .map((route) => {
+          const pool = pools.find((pool) => pool.id === route.poolId);
+          let baseAsset: CosmosAsset;
+          let quoteAsset: CosmosAsset;
+          if (route.tokenOutDenom !== tokenOut.denom) {
+            baseAsset = baseToken;
+            quoteAsset = this.getTokenByBase(route.tokenOutDenom)!;
+          } else {
+            const tokenInDenom = pool?.poolAssets.find(
+              ({ token }) => token!.denom !== tokenOut.denom
+            )?.token?.denom!;
+            baseAsset = this.getTokenByBase(tokenInDenom)!;
+            quoteAsset = quoteToken;
+          }
+          const fee = new BigNumber(pool?.poolParams?.swapFee || 0).shiftedBy(
+            -16
+          );
+          swapFees.push(fee);
+          return {
+            poolId: route.poolId.toString(),
+            swapFee: fee,
+            baseLogo: baseAsset.logo_URIs,
+            baseSymbol: baseAsset.symbol,
+            quoteLogo: quoteAsset.logo_URIs,
+            quoteSymbol: quoteAsset.symbol,
+            tokenOutDenom: route.tokenOutDenom,
+          };
+        })
+        .map((route) => {
+          const totalFee = swapFees.reduce(
+            (total, cur) => total.plus(cur),
+            new BigNumber(0)
+          );
+          const highestFee = swapFees.sort((a, b) => (a.lt(b) ? 1 : -1))[0];
+          const feeRatio = highestFee.div(totalFee);
+          return {
+            ...route,
+            swapFee: route.swapFee.multipliedBy(feeRatio).toString() + '%',
+          };
+        });
+    }
+
+    let expectedOutput = tokenOutAmountAfterSlippage;
+    let feeObject = FEES.osmosis.swapExactAmountIn(feeTier)
+
+    const gasLimitEstimate = new BigNumber(feeObject.gas).multipliedBy(gasAdjustment)
+
+    const expectedAmountNum = new BigNumber(expectedOutput)
+    const tokenInAmountNum = new BigNumber(amount).shiftedBy(baseToken.decimals)
+    const executionPrice = expectedAmountNum.div(tokenInAmountNum)
+
+    logger.info(
+      `Best trade for ${quoteToken.address}-${
+        baseToken.address
+      }: ${ToLog_OsmosisExpectedTrade({ gasUsed: '', gasWanted: '', routes: swapRoutes, expectedAmount: expectedOutput, executionPrice: executionPrice, gasLimitEstimate: gasLimitEstimate, tokenInDenom:tokenIn.denom, tokenInAmount: tokenInAmount, tokenOutDenom:tokenOut.denom,  })}`
+    );  
+    return { gasUsed: '', gasWanted: '', routes: swapRoutes, expectedAmount: expectedOutput, executionPrice: executionPrice, gasLimitEstimate: gasLimitEstimate, tokenInDenom:tokenIn.denom, tokenInAmount: tokenInAmount, tokenOutDenom:tokenOut.denom }; // == OsmosisExpectedTrade
+  }
+
+
+
+  /**
+   * Given a wallet and a Cosmosish trade, try to execute it on blockchain.
+   *
+   * @param wallet CosmosWallet
+   * @param trade Expected trade
+   * @param allowedSlippage? Allowed slippage eg "1%"
+   * @param feeTier_input? low/medium/high, overwrites feeTier specified in .yml
+   * @param gasAdjustment_input? Gas offered multiplier, overwrites gasAdjustment specified in .yml
+  */
+  async executeTrade(
+    wallet: CosmosWallet,
+    trade: TradeInfo,   
+    address: string,
+    allowedSlippage?: string,
+    feeTier_input?: string,
+    gasAdjustment_input?: number,
+  ): Promise<TransactionResponse> { 
+    var slippage = 0;
+    if (allowedSlippage){
+      slippage = Number(allowedSlippage.split('%')[0]);
+    }else{
+      slippage = Number(this.allowedSlippage.split('%')[0]);
+    }
+    var feeTier = this.feeTier;
+    if (feeTier_input){
+      feeTier = feeTier_input;
+    }
+    var gasAdjustment = this.gasAdjustment;
+    if (gasAdjustment_input){
+      gasAdjustment = gasAdjustment_input;
+    }
+
+    const keyWallet = await DirectSecp256k1Wallet.fromKey(wallet.privkey, 'osmo')
+    this.signingClient = await getSigningOsmosisClient({
+      rpcEndpoint: this.rpcURL,
+      signer: keyWallet
+    });
+    const routes = trade.expectedTrade.routes;
+
+    var tokenOutMinAmount;
+    if (slippage == 100){
+      tokenOutMinAmount = 1;
+    }else{
+      tokenOutMinAmount = this.noDecimals((Number(trade.expectedTrade.expectedAmount) * (100-slippage))/100)
+    }
+    const msg = swapExactAmountIn({
+      'sender': address,
+      'routes': routes,
+      'tokenIn': coin(trade.expectedTrade.tokenInAmount, trade.expectedTrade.tokenInDenom),
+      'tokenOutMinAmount': tokenOutMinAmount.toString(),
+    });
+
+    const fee = FEES.osmosis.swapExactAmountIn(this.feeTier);
+
+    try {
+      const res = await this.signingClient.signAndBroadcast(address, [msg], fee);
+      return res;
+    } catch (error) {
+      console.debug(error);
+    } finally {
+      this.signingClient.disconnect();
+    }
+
+    throw new HttpException(
+      500,
+      TRADE_FAILED_ERROR_MESSAGE,
+      TRADE_FAILED_ERROR_CODE
+    );
+  }
+
+  /**
+   * Given a 2 token symbols and 1-2 amounts, exchange amounts for pool liquidity shares
+   *
+   * @param wallet CosmosWallet
+   * @param address Wallet address
+   * @param token0 
+   * @param token1 
+   * @param amount0 
+   * @param amount1 
+   * @param poolId? Optional string specify poolId instead of search by tokens
+   * @param allowedSlippage? Allowed slippage eg "1%"
+   * @param feeTier_input? low/medium/high, overwrites feeTier specified in .yml
+   * @param gasAdjustment_input? Gas offered multiplier, overwrites gasAdjustment specified in .yml
+  */
+  async addPosition(
+    wallet: CosmosWallet,
+    address: string,
+    token0: CosmosAsset,
+    token1: CosmosAsset,
+    amount0: string,
+    amount1: string,
+    poolId?: string, 
+    allowedSlippage?: string,
+    feeTier_input?: string,
+    gasAdjustment_input?: number,
+  ): Promise<AddPositionTransactionResponse> {
+
+    var slippage = 0;
+    if (allowedSlippage){
+      slippage = Number(allowedSlippage.split('%')[0]);
+    }else{
+      slippage = Number(this.allowedSlippage.split('%')[0]);
+    }
+    var feeTier = this.feeTier;
+    if (feeTier_input){
+      feeTier = feeTier_input;
+    }
+    var gasAdjustment = this.gasAdjustment;
+    if (gasAdjustment_input){
+      gasAdjustment = gasAdjustment_input;
+    }
+
+    try {
+      const keyWallet = await DirectSecp256k1Wallet.fromKey(wallet.privkey, 'osmo')
+      this.signingClient = await getSigningOsmosisClient({
+        rpcEndpoint: this.rpcURL,
+        signer: keyWallet
+      });
+      
+      if (!this.signingClient || !address) {
+        console.error('stargateClient undefined or address undefined.');
+        throw new HttpException(
+          500,
+          "addPosition failed: Can't instantiate signing client.",
+          TRADE_FAILED_ERROR_CODE
+        );
+      }
+
+      const poolsContainer = await this.rpcClient.osmosis.poolmanager.v1beta1.allPools({});
+      const pools: ExtendedPool[] = poolsContainer.pools;
+      const prices = await getCoinGeckoPrices(this.tokenList);
+
+      if (!amount0 && !amount1){
+        throw new HttpException(
+          500,
+          "addPosition failed: Both token amounts equal to 0.",
+          TRADE_FAILED_ERROR_CODE
+        );
+      }
+
+      var amount0_bignumber = new BigNumber(0);
+      var amount1_bignumber = new BigNumber(0);
+      if (amount0){
+        amount0_bignumber = new BigNumber(amount0);
+      }
+      if (amount1){
+        amount1_bignumber = new BigNumber(amount1);
+      }
+      if (amount0_bignumber.isEqualTo(0) && amount1_bignumber.isEqualTo(0)){
+        throw new HttpException(
+          500,
+          "addPosition failed: Both token amounts equal to 0.",
+          TRADE_FAILED_ERROR_CODE
+        );
+      }
+      
+      var singleToken_UseWhich: string | null = null;
+      if (!amount0_bignumber.isEqualTo(0) && amount1_bignumber.isEqualTo(0)){ // only token0
+        singleToken_UseWhich = '0';
+      }        
+      if (amount0_bignumber.isEqualTo(0) && !amount1_bignumber.isEqualTo(0)){ // only token1
+        singleToken_UseWhich = '1';
+      }
+      // NOT CHECKING (local wallet) BALANCES HERE it will bounce back either way
+
+      // now find the poolid for this pair
+      var foundPools: ExtendedPool[] = [];
+      pools.forEach(function (cPool: ExtendedPool) {
+        var foundToken0 = false;
+        var foundToken1 = false;
+        if (cPool.poolAssets){
+          for (var poolAsset_idx=0; poolAsset_idx<cPool.poolAssets.length; poolAsset_idx++){
+            var poolAsset: PoolAsset = cPool.poolAssets[poolAsset_idx];
+            if (poolAsset!.token! && poolAsset!.token!.denom){
+              if (poolAsset!.token!.denom == token0.base){
+                foundToken0 = true;
+              }
+              if (poolAsset!.token!.denom == token1.base){
+                foundToken1 = true;
+              }
+            }
+          }
+        }
+        if (foundToken0 && foundToken1){
+          foundPools.push(cPool);
+        }
+      });
+
+      var pool;
+      if (poolId){
+        pool = pools.find(({id}) => id.toString() == poolId);
+      }else if (foundPools){
+        pool = foundPools.pop(); // this is not selective without poolid input (can be multiple pools per token pair).. though order should cause pool with greatest liquidity to be used
+      }
+
+      if (pool){
+        var fee = {
+          amount: coins(0, 'uosmo'),
+          gas: '240000',
+        }; // default, going to overwrite below
+
+        let msg = [];
+        if (singleToken_UseWhich) { // in case 1 of the amounts == 0 
+          var singleToken_amount = new BigNumber(0);
+          var singleToken: CosmosAsset | undefined = undefined;
+          if (singleToken_UseWhich == '0'){
+            singleToken_amount = amount0_bignumber;
+            singleToken = token0;
+          }else{
+            singleToken_amount = amount1_bignumber;
+            singleToken = token1;
+          }
+          const inputCoin = {'denom':singleToken.base, 'amount':singleToken_amount.shiftedBy(this.getExponentByBase(singleToken.base)).toString()};
+
+          const coinSymbol = singleToken.symbol;
+          const inputValue = this.baseUnitsToDollarValue(
+            prices,
+            coinSymbol,
+            singleToken_amount.toNumber()
+          );
+
+          const coinsNeeded = convertDollarValueToCoins(this.tokenList, inputValue, pool, prices);
+          const shareOutAmount = calcShareOutAmount(pool, coinsNeeded);
+
+          var finalShareOutAmount;
+          if (slippage == 100){
+            finalShareOutAmount = (new BigNumber(1).integerValue(BigNumber.ROUND_CEIL));
+          }else{
+            finalShareOutAmount = (new BigNumber(calcAmountWithSlippage(shareOutAmount, slippage)).integerValue(BigNumber.ROUND_CEIL))
+          }
+
+          const joinSwapExternAmountInMsg = joinSwapExternAmountIn({
+            poolId: pool.id.toString(),
+            sender: address,
+            tokenIn: inputCoin,
+            shareOutMinAmount: finalShareOutAmount.toString(),
+          });
+          msg.push(joinSwapExternAmountInMsg);
+          fee = FEES.osmosis.joinSwapExternAmountIn(feeTier);
+        } 
+        else {
+          var allCoins = [];
+          allCoins.push({'denom':token0.base, 'amount':new BigNumber(amount0)
+          .shiftedBy(this.getExponentByBase(token0.base))
+          .toString()});
+          allCoins.push({'denom':token1.base, 'amount':new BigNumber(amount1)
+          .shiftedBy(this.getExponentByBase(token1.base))
+          .toString()});
+
+          const shareOutAmount = calcShareOutAmount(pool, allCoins);
+          const tokenInMaxs = allCoins.map((c: Coin) => {
+            return coin(c.amount, c.denom);
+          });
+          
+          var finalShareOutAmount;
+          if (slippage == 100){
+            finalShareOutAmount = (new BigNumber(1).integerValue(BigNumber.ROUND_CEIL));
+          }else{
+            finalShareOutAmount = (new BigNumber(calcAmountWithSlippage(shareOutAmount, slippage)).integerValue(BigNumber.ROUND_CEIL))
+          }
+
+          const joinPoolMsg = joinPool({
+            poolId: pool.id.toString(),
+            sender: address,
+            shareOutAmount: finalShareOutAmount.toString(),
+            tokenInMaxs,
+          });
+          msg.push(joinPoolMsg);
+          fee = FEES.osmosis.joinPool(feeTier);
+        }
+
+        const successfulTransaction = 0;
+        const insufficientFunds = 5;
+        const res: AddPositionTransactionResponse = await this.signingClient.signAndBroadcast(address, msg, fee);
+        if (res?.code == insufficientFunds) throw new HttpException(
+          500,
+          INSUFFICIENT_FUNDS_ERROR_MESSAGE + " : " + res.rawLog,
+          INSUFFICIENT_FUNDS_ERROR_CODE
+        );
+
+        if (res?.code !== successfulTransaction) throw res;
+        //console.debug(res?.rawLog);
+
+        // RETURNED VALUE DISSECTION
+        //  osmo doesnt send back a clear value, we need to discern it from the event logs >.>
+        var outbound_coins_string = '' // 990uion,98159uosmo
+        var outbound_shares_string = '' // 57568515255656500gamm/pool/62
+        var token0_finalamount = '0'
+        var token1_finalamount = '0'
+        var poolshares = '0'
+        try {
+          for (var event_idx=0; event_idx<res.events.length; event_idx++){
+            var event = res.events[event_idx];
+            if (event.type == 'coin_received'){
+              
+              for (var attribute_idx=0; attribute_idx<event.attributes.length; attribute_idx++){
+                var attribute = event.attributes[attribute_idx];
+                if (attribute.key == 'receiver' && attribute.value && attribute.value == pool.address){
+                  if (event.attributes.length > attribute_idx){
+                    outbound_coins_string = event.attributes[attribute_idx+1].value
+                  }
+                }
+                else if (attribute.key == 'amount'){
+                  if (pool.totalShares && pool.totalShares.denom && attribute.value.includes(pool.totalShares.denom)){
+                    outbound_shares_string = attribute.value;
+                  }
+                }
+              }
+            }
+          }
+          if (outbound_coins_string != ''){
+            if (outbound_coins_string.includes(',')){
+              var coins_string_list = outbound_coins_string.split(',');
+              for (var coin_string_idx=0; coin_string_idx<coins_string_list.length; coin_string_idx++){
+                var coin_string = coins_string_list[coin_string_idx];
+                if (coin_string.includes(token0.base)){
+                  token0_finalamount = coin_string.replace(token0.base,'');
+                } else if (coin_string.includes(token1.base)){
+                  token1_finalamount = coin_string.replace(token1.base,'');
+                }
+              }
+            }else{
+              if (outbound_coins_string.includes(token0.base)){
+                token0_finalamount = outbound_coins_string.replace(token0.base,'');
+              } else if (outbound_coins_string.includes(token1.base)){
+                token1_finalamount = outbound_coins_string.replace(token1.base,'');
+              }
+            }
+          }
+          
+          if (outbound_shares_string != ''){
+            poolshares = outbound_shares_string.replace(pool.totalShares.denom,'');
+          }
+        } catch (error) {
+          console.debug(error);
+        }
+
+        res.token0_finalamount = token0_finalamount
+        res.token1_finalamount = token1_finalamount
+        res.poolshares = poolshares
+        res.poolId = pool.id.toString()
+        res.poolAddress = pool.address
+        this.signingClient.disconnect();
+        return res; 
+      }
+
+    } catch (error) {
+      console.debug(error);
+    } finally {
+      this.signingClient.disconnect();
+    }
+    throw new HttpException(
+      500,
+      TRADE_FAILED_ERROR_MESSAGE,
+      TRADE_FAILED_ERROR_CODE
+    );
+  }
+
+
+  /**
+   * Given a 2 token symbols and 1-2 amounts, exchange amounts for pool liquidity shares
+   *
+   * @param wallet CosmosWallet
+   * @param decreasePercent 
+   * @param address Wallet address
+   * @param poolId? Optional string specify poolId instead of search by tokens
+   * @param allowedSlippage? Allowed slippage eg "1%"
+   * @param feeTier_input? low/medium/high, overwrites feeTier specified in .yml
+   * @param gasAdjustment_input? Gas offered multiplier, overwrites gasAdjustment specified in .yml
+  */
+  async reducePosition(
+    wallet: CosmosWallet,
+    decreasePercent: number = 100,
+    address: string,
+    poolId: string, 
+    allowedSlippage?: string,
+    feeTier_input?: string,
+    gasAdjustment_input?: number,
+    ): Promise<ReduceLiquidityTransactionResponse> {
+
+    var slippage = Number(this.allowedSlippage.split('%')[0]);
+    if (allowedSlippage){
+      slippage = Number(allowedSlippage.split('%')[0]);
+    }
+    var feeTier = this.feeTier;
+    if (feeTier_input){
+      feeTier = feeTier_input;
+    }
+    var gasAdjustment = this.gasAdjustment;
+    if (gasAdjustment_input){
+      gasAdjustment = gasAdjustment_input;
+    }
+
+    try {
+      const keyWallet = await DirectSecp256k1Wallet.fromKey(wallet.privkey, 'osmo')
+      this.signingClient = await getSigningOsmosisClient({
+        rpcEndpoint: this.rpcURL,
+        signer: keyWallet
+      });
+      
+      const balancesContainer = await this.rpcClient.cosmos.bank.v1beta1.allBalances({
+        address: address,
+        pagination: {
+          key: new Uint8Array(),
+          offset: BigInt(0),
+          limit: BigInt(10000),
+          countTotal: false,
+          reverse: false,
+        },
+      })
+      const balances = balancesContainer.balances
+      const lockedCoinsContainer = await this.rpcClient.osmosis.lockup.accountLockedCoins({
+        owner: address,
+      });
+      const lockedCoins: Coin[] = lockedCoinsContainer.lockedCoins ? lockedCoinsContainer.lockedCoins : []
+
+      // RETURN TYPES:
+      // concentrated-liquidity/pool || cosmwasmpool/v1beta1/model/pool || gamm/pool-models/balancer/balancerPool || gamm/pool-models/stableswap/stableswap_pool
+      const poolsContainer = await this.rpcClient.osmosis.poolmanager.v1beta1.allPools({});
+      const pools: ExtendedPool[] = poolsContainer.pools;
+
+      const fees = await fetchFees();
+      var callImperatorWithTokens = undefined
+      if (this.chain == 'testnet'){
+        callImperatorWithTokens = this.tokenList;
+      }
+      const prices = await getImperatorPriceHash(callImperatorWithTokens); // need to compare these two.. i think formatting is the same?
+
+      // filter for CL
+      const filteredPools = filterPoolsLP(this.tokenList, pools, prices); // removes stableswap, !token.denom.startsWith('gamm/pool'), has price, has osmosisAsset
+
+      const extendedPools = filteredPools.map((pool) =>
+        extendPool(this.tokenList, { pool, fees, balances, lockedCoins, prices:prices })
+      );
+
+      const currentPool = extendedPools.filter((pl) => pl.id.toString() == poolId)[0];
+      const percent = decreasePercent; // total percent of pool shares
+
+      const myLiquidity = new BigNumber(currentPool.myLiquidity || 0)
+      .multipliedBy(percent)
+      .div(100)
+      .toString();
+
+      const unbondedShares = convertDollarValueToShares(
+        this.tokenList, 
+        myLiquidity || 0,
+        currentPool,
+        prices
+      );
+    
+      const myCoins = convertDollarValueToCoins(
+        this.tokenList, 
+        myLiquidity || 0,
+        currentPool,
+        prices
+      );
+
+      const coinsNeeded = myCoins.map(({ denom, amount }) => {
+      
+        var amountWithSlippage;
+        if (slippage == 100){
+          amountWithSlippage = new BigNumber(1).toString();
+        }else{
+          amountWithSlippage = new BigNumber(amount)
+          .multipliedBy(new BigNumber(100).minus(slippage))
+          .div(100)
+          .toString();
+        }
+  
+        return {
+          denom,
+          amount: this.noDecimals(amountWithSlippage),
+        };
+      });
+  
+      const shareInAmount = new BigNumber(unbondedShares)
+        .shiftedBy(18)
+        .decimalPlaces(0)
+        .toString();
+  
+      const tokenOutMins = coinsNeeded.map((c: Coin) => {
+        return coin(c.amount, c.denom);
+      });
+  
+      var msgs = []
+      const msg = exitPool({
+        poolId: currentPool.id.toString(),
+        sender: address,
+        shareInAmount,
+        tokenOutMins,
+      });
+      msgs.push(msg)
+  
+      const fee = FEES.osmosis.exitPool(feeTier);
+
+      const gasEstimation = await this.signingClient.simulate(
+        address,
+        msgs,
+      );
+      if (!gasEstimation) {
+        throw new Error('estimate gas error');
+      }
+  
+      const calcedFee = calculateFee(
+        Math.round(gasEstimation * (gasAdjustment || 1.5)),
+        GasPrice.fromString(this.manualGasPrice)
+      );
+      if (calcedFee){}
+
+
+
+      const successfulTransaction = 0;
+      const res: ReduceLiquidityTransactionResponse = await this.signingClient.signAndBroadcast(address, msgs, fee);
+
+      if (res?.code !== successfulTransaction) throw res;
+      //console.debug(res?.rawLog);
+      this.signingClient.disconnect();
+
+
+      
+      var finalAmountReceived_string = '';
+      var token0_denom = currentPool.poolAssets[0].token.denom
+      var token1_denom = currentPool.poolAssets[1].token.denom
+      var token0 = this.getTokenByBase(token0_denom)
+      var token1 = this.getTokenByBase(token1_denom)
+      var amount0_base = ''
+      var amount1_base = ''
+      var amount0 = ''
+      var amount1 = ''
+
+      try {
+        for (var txEvent_idx=0; txEvent_idx<res.events.length; txEvent_idx++){
+          var txEvent: TransactionEvent = res.events[txEvent_idx];
+          if (txEvent.type == 'coin_received'){
+            for (var txEventAttribute_idx=0; txEventAttribute_idx<txEvent.attributes.length; txEventAttribute_idx++){
+              var txEventAttribute: TransactionEventAttribute = txEvent.attributes[txEventAttribute_idx];
+              if (txEventAttribute.key == 'receiver'){
+                if (txEventAttribute.value == address){
+                    var next_txEventAttribute: TransactionEventAttribute = txEvent.attributes[txEventAttribute_idx+1];
+                    if (next_txEventAttribute.key == 'amount' && next_txEventAttribute.value){
+                      finalAmountReceived_string = next_txEventAttribute.value;
+                    }
+                } 
+              }
+            }
+          }
+        }
+
+        if (finalAmountReceived_string != ''){
+          if (finalAmountReceived_string.includes(',')){
+            var coins_string_list = finalAmountReceived_string.split(',');
+            for (var coin_string_idx=0; coin_string_idx<coins_string_list.length; coin_string_idx++){
+              var coin_string = coins_string_list[coin_string_idx];
+              if (coin_string.includes(token0!.base)){
+                amount0_base = coin_string.replace(token0!.base,'');
+              } else if (coin_string.includes(token1!.base)){
+                amount1_base = coin_string.replace(token1!.base,'');
+              }
+            }
+          }else{
+            if (finalAmountReceived_string.includes(token0!.base)){
+              amount0_base = finalAmountReceived_string.replace(token0!.base,'');
+            } else if (finalAmountReceived_string.includes(token1!.base)){
+              amount1_base = finalAmountReceived_string.replace(token1!.base,'');
+            }
+          }
+        }
+
+        if (amount0_base != ''){
+          amount0 = (new BigNumber(amount0_base)).shiftedBy(token0!.decimals * -1).decimalPlaces(token0!.decimals).toString();
+        }
+        if (amount1_base != ''){
+          amount1 = (new BigNumber(amount1_base)).shiftedBy(token1!.decimals * -1).decimalPlaces(token1!.decimals).toString();
+        }
+      } catch (error) {
+        console.debug(error);
+      } 
+
+      res.amount0 = amount0
+      res.amount1 = amount1
+      res.token0 = token0!.symbol
+      res.token1 = token1!.symbol
+      return res;
+
+    } catch (error) {
+      console.debug(error);
+    } finally {
+      this.signingClient.disconnect();
+    }
+    throw new HttpException(
+      500,
+      TRADE_FAILED_ERROR_MESSAGE,
+      TRADE_FAILED_ERROR_CODE
+    );
+  }
+
+  /**
+   * Returns all pools and their prices for 2 tokens. Address used for balance query.
+   *
+   * @param token0 
+   * @param token1 
+   * @param address Wallet address
+  */
+  async findPoolsPrices(
+    token0: CosmosAsset,
+    token1: CosmosAsset,
+    address: string,
+  ): Promise<SerializableExtendedPool[]> {
+
+    try {
+      const balancesContainer = await this.rpcClient.cosmos.bank.v1beta1.allBalances({
+        address: address,
+        pagination: {
+          key: new Uint8Array(),
+          offset: BigInt(0),
+          limit: BigInt(10000),
+          countTotal: false,
+          reverse: false,
+        },
+      })
+      const balances = balancesContainer.balances
+      const lockedCoinsContainer = await this.rpcClient.osmosis.lockup.accountLockedCoins({
+        owner: address,
+      });
+      const lockedCoins: Coin[] = lockedCoinsContainer.lockedCoins ? lockedCoinsContainer.lockedCoins : []
+
+      // RETURN TYPES:
+      // concentrated-liquidity/pool || cosmwasmpool/v1beta1/model/pool || gamm/pool-models/balancer/balancerPool || gamm/pool-models/stableswap/stableswap_pool
+      const poolsContainer = await this.rpcClient.osmosis.poolmanager.v1beta1.allPools({});
+      const pools: ExtendedPool[] = poolsContainer.pools;
+      const fees = await fetchFees();
+      var callImperatorWithTokens = undefined
+      if (this.chain == 'testnet'){
+        callImperatorWithTokens = this.tokenList;
+      }
+      const prices = await getImperatorPriceHash(callImperatorWithTokens);
+
+      // filter for CL
+      const filteredPools = filterPoolsLP(this.tokenList, pools, prices); // removes stableswap, !token.denom.startsWith('gamm/pool'), has price, has osmosisAsset
+
+      const extendedPools = filteredPools.map((pool) =>
+        extendPool(this.tokenList, { pool, fees, balances, lockedCoins, prices:prices })
+      );
+
+      var returnPools: SerializableExtendedPool[] = [];
+      extendedPools.forEach(function (cPool) {
+        var foundToken0 = false;
+        var foundToken1 = false;
+
+        if (cPool.poolAssets){
+          for (var poolAsset_idx=0; poolAsset_idx<cPool.poolAssets.length; poolAsset_idx++){
+            var poolAsset: PoolAsset = cPool.poolAssets[poolAsset_idx];
+            if (poolAsset!.token! && poolAsset!.token!.denom){
+              if (poolAsset!.token!.denom == token0.base){
+                foundToken0 = true;
+              }
+              if (poolAsset!.token!.denom == token1.base){
+                foundToken1 = true;
+              }
+            }
+          }
+        }
+
+        if (foundToken0 && foundToken1){
+          returnPools.push(new SerializableExtendedPool(cPool));
+        }
+      });
+
+      return returnPools;
+
+    } catch (error) {
+      console.debug(error);
+    } finally {
+
+    }
+    throw new HttpException(
+      500,
+      TRADE_FAILED_ERROR_MESSAGE,
+      TRADE_FAILED_ERROR_CODE
+    );
+  }
+
+  /**
+   * Returns all pool positions data including number of user's shares, or for single specified poolId
+   *
+   * @param token0 
+   * @param token1 
+   * @param address Wallet address
+  */
+  async findPoolsPositions(
+    address: string,
+    poolId?: string,
+  ): Promise<SerializableExtendedPool[]> {
+
+    try {
+      const balancesContainer = await this.rpcClient.cosmos.bank.v1beta1.allBalances({
+        address: address,
+        pagination: {
+          key: new Uint8Array(),
+          offset: BigInt(0),
+          limit: BigInt(10000),
+          countTotal: false,
+          reverse: false,
+        },
+      })
+      const balances = balancesContainer.balances
+      const lockedCoinsContainer = await this.rpcClient.osmosis.lockup.accountLockedCoins({
+        owner: address,
+      });
+      const lockedCoins: Coin[] = lockedCoinsContainer.lockedCoins ? lockedCoinsContainer.lockedCoins : []
+
+      // RETURN TYPES:
+      // concentrated-liquidity/pool || cosmwasmpool/v1beta1/model/pool || gamm/pool-models/balancer/balancerPool || gamm/pool-models/stableswap/stableswap_pool
+      const poolsContainer = await this.rpcClient.osmosis.poolmanager.v1beta1.allPools({});
+      const pools: ExtendedPool[] = poolsContainer.pools;
+
+      const fees = await fetchFees();
+      var callImperatorWithTokens = undefined
+      if (this.chain == 'testnet'){
+        callImperatorWithTokens = this.tokenList;
+      }
+      const prices = await getImperatorPriceHash(callImperatorWithTokens); 
+
+      // filter for CL
+      const filteredPools = filterPoolsLP(this.tokenList, pools, prices); // removes stableswap, !token.denom.startsWith('gamm/pool'), has price, has osmosisAsset
+
+      const extendedPools = filteredPools.map((pool) =>
+        extendPool(this.tokenList, { pool, fees, balances, lockedCoins, prices:prices })
+      );
+
+      var returnPools: SerializableExtendedPool[] = [];
+      extendedPools.forEach(function (cPool) {
+        if (poolId){
+          if (cPool.id.toString() == poolId){
+            returnPools.push(new SerializableExtendedPool(cPool));
+          }
+        }else{
+
+          if ((cPool.myLiquidity && cPool.myLiquidity != '0') || (cPool.bonded && cPool.bonded != '0'))
+          {
+            returnPools.push(new SerializableExtendedPool(cPool));
+          }
+        }
+
+      });
+
+      return returnPools;
+
+    } catch (error) {
+      console.debug(error);
+    } finally {
+
+    }
+    throw new HttpException(
+      500,
+      TRADE_FAILED_ERROR_MESSAGE,
+      TRADE_FAILED_ERROR_CODE
+    );
+  }
+
+  
+  async getCurrentBlockNumber(): Promise<number>{
+    const client = await CosmWasmClient
+    .connect(this.rpcURL);
+    const getHeight = await client.getHeight()
+    return getHeight;
+  }
+
+  /**
+   * Transfer tokens
+   *
+   * @param wallet 
+   * @param token 
+   * @param req TransferRequest
+  */
+  async transfer(
+    wallet: CosmosWallet,
+    token: CosmosAsset,
+    req: TransferRequest
+  ): Promise<TransactionResponse> {
+
+    const keyWallet = await DirectSecp256k1Wallet.fromKey(wallet.privkey, 'osmo')
+    this.signingClient = await getSigningOsmosisClient({
+      rpcEndpoint: this.rpcURL,
+      signer: keyWallet
+    });
+
+    const tokenInAmount = new BigNumber(req.amount)
+    .shiftedBy(token.decimals)
+    .toString();
+
+    const coinIn = {
+      denom: token.base,
+      amount: tokenInAmount,
+    };
+
+    var coinsList = []
+    coinsList.push(coinIn)
+    const msg = send({
+      fromAddress: req.from,
+      toAddress: req.to,
+      amount: coinsList
+    });
+
+    const fee = FEES.osmosis.swapExactAmountIn(this.feeTier);
+
+    const res = await this.signingClient.signAndBroadcast(req.from, [msg], fee);
+    //console.debug(res);
+    this.signingClient.disconnect();
+    return res;
+  }
+
+  async getTokens(req?: TokensRequest): Promise<TokensResponse> {
+    var responseTokens: TokenInfo[] = [];
+    this.tokenList.forEach(element => {
+      // FILTER IF req.tokenSymbols != []
+      var addToken = true;
+      if (req && req.tokenSymbols && req.tokenSymbols.length > 0){
+        addToken = false;
+        for (var idx=0; idx<req.tokenSymbols.length; idx++){
+          if (req.tokenSymbols[idx] == element.symbol){
+            addToken = true;
+            break;
+          }
+        }
+      }
+      if (addToken){
+        responseTokens.push({chainId:0, address:element.address, name:element.name, symbol:element.symbol, decimals:element.decimals})
+      }
+    });
+
+    return {tokens:responseTokens};
+  }
+}

--- a/src/chains/osmosis/osmosis.types.ts
+++ b/src/chains/osmosis/osmosis.types.ts
@@ -1,0 +1,388 @@
+// import { AssetDenomUnit } from '@chain-registry/types';
+// import { Duration } from 'osmo-query/dist/codegen/google/protobuf/duration';
+// import { Gauge } from 'osmo-query/dist/codegen/osmosis/incentives/gauge';
+// import { SuperfluidAsset } from 'osmo-query/dist/codegen/osmosis/superfluid/superfluid';
+import { Coin } from 'osmo-query/dist/codegen/cosmos/base/v1beta1/coin';
+// import { Trade as OsmonautsTrade} from '@chasevoorhees/osmonauts-math-decimal/dist/types' // sell, buy = Coin(denom, amount)
+// import { Trade as OsmojsTrade } from 'osmojs/dist/codegen/osmosis/protorev/v1beta1/protorev'; // pool, tokenIn, tokenOut
+import BigNumber from 'bignumber.js';
+import { ExtendedPool } from './osmosis.lp.utils'
+import { Pool as OsmosisPool, PoolAsset } from 'osmojs/dist/codegen/osmosis/gamm/pool-models/balancer/balancerPool';
+export type Pool = OsmosisPool & ExtraPoolProperties;
+
+
+import type {
+  CoinDenom,
+  Exponent,
+  CoinSymbol,
+  PriceHash,
+  CoinGeckoToken,
+  CoinGeckoUSD,
+  CoinGeckoUSDResponse,
+  CoinValue,
+  CoinBalance,
+  PoolAssetPretty,
+  PoolTokenImage,
+  PoolPretty,
+  CalcPoolAprsParams,
+  Trade,
+  PrettyPair,
+} from "@chasevoorhees/osmonauts-math-decimal/dist/types";
+
+// will this work for type?
+type calcPoolAprs = (...args: any) => any
+// import {calcPoolAprs} from './osmosis.apr'
+
+export interface Scenario {
+  token: CoinBalance;
+  ratio: string;
+  symbol: string;
+  amount: string;
+  enoughCoinsExist: boolean;
+  totalDollarValue?: string;
+}
+
+export interface Scenarios {
+  [key: string]: Scenario[];
+}
+
+export {
+  CoinDenom,
+  Exponent,
+  CoinSymbol,
+  PriceHash,
+  CoinGeckoToken,
+  CoinGeckoUSD,
+  CoinGeckoUSDResponse,
+  CoinValue,
+  CoinBalance,
+  PoolAssetPretty,
+  PoolTokenImage,
+  PoolPretty,
+  CalcPoolAprsParams,
+  Trade,
+  PrettyPair,
+};
+
+export type Peroid = '1' | '7' | '14';
+
+export type PoolApr = {
+  [K in Peroid]: ReturnType<calcPoolAprs>; // typeof calcPoolAprs
+};
+
+
+export type ExtraPoolProperties = {
+  fees7D: number;
+  volume24H: number;
+  volume7d: number;
+  liquidity: string | number;
+  myLiquidity?: string | number;
+  bonded?: string | number;
+  apr: PoolApr;
+};
+
+// export interface Trade {
+//   sell: Coin;
+//   buy: Coin;
+// }
+
+export interface FetchedData {
+  pools: Pool[];
+  prices: PriceHash;
+  balances: Coin[];
+}
+
+// export interface PrettyPair {
+//   poolId: string;
+//   poolAddress: string;
+//   baseName: string;
+//   baseSymbol: string;
+//   baseAddress: string;
+//   quoteName: string;
+//   quoteSymbol: string;
+//   quoteAddress: string;
+// }
+
+export interface SwapOptionType {
+  /**
+   * Required. Unique identifier for option.
+   */
+  value: string;
+  /**
+   * Display symbol name.
+   */
+  symbol: string;
+  /**
+   * Icon display for option.
+   */
+  icon?: {
+    png?: string;
+    jpeg?: string;
+    svg?: string;
+  };
+  /**
+   * Unit of the chain.
+   */
+  denom: string;
+  amount: string;
+  displayAmount: string;
+  dollarValue: string;
+  chainName: string;
+}
+
+export interface OsmosisExpectedTrade {
+  routes: OsmosisExpectedTradeRoute[];
+  expectedAmount: string;
+  executionPrice: BigNumber;
+  gasLimitEstimate: BigNumber;
+  tokenInAmount: string;
+  tokenInDenom: string;
+  tokenOutDenom: string;
+  gasUsed: string,
+  gasWanted: string,
+}
+export interface OsmosisExpectedTradeRoute {
+    poolId: string;
+    swapFee: string;
+    baseLogo?: {
+      png?: string;
+      svg?: string;
+      jpeg?: string;
+    };
+    baseSymbol: string;
+    quoteLogo?: {
+      png?: string;
+      svg?: string;
+      jpeg?: string;
+    };
+    quoteSymbol: string;
+    tokenOutDenom: string;
+}
+
+export interface SwapAmountInRoute {
+  poolId: bigint ;
+  tokenOutDenom: string;
+}
+
+export interface OsmosisExpectedTradeSwapOut {
+  routes: {
+    poolId: string;
+    swapFee: string;
+    baseLogo?: {
+      png?: string;
+      svg?: string;
+      jpeg?: string;
+    };
+    baseSymbol: string;
+    quoteLogo?: {
+      png?: string;
+      svg?: string;
+      jpeg?: string;
+    };
+    quoteSymbol: string;
+    tokenInDenom: string;
+  }[];
+  expectedAmount: string;
+  executionPrice: BigNumber;
+  gasLimitEstimate: BigNumber;
+  tokenInDenom: string;
+  tokenOutDenom: string;
+}
+
+export function ToLog_OsmosisExpectedTrade(trade: OsmosisExpectedTrade){
+  var output = ''
+  trade.routes.forEach((element)=>{
+    output += 'poolId: '
+    output += element.poolId;
+    output += ', '
+    output += 'swapFee: '
+    output += element.swapFee;
+    output += ', '
+    output += 'baseSymbol: '
+    output += element.baseSymbol;
+    output += ', '
+    output += 'quoteSymbol: '
+    output += element.quoteSymbol;
+    output += ', '
+  })
+  output += 'expectedAmount: '
+  output += trade.expectedAmount;
+  output += ', '
+  output += 'executionPrice: '
+  output += trade.executionPrice.toString();
+  output += ', '
+  output += 'gasLimitEstimate: '
+  output += trade.gasLimitEstimate.toString();
+  output += ', '
+  return output
+}
+
+export interface ReduceLiquidityTransactionResponse extends TransactionResponse {
+  token0: string;
+  token1: string;
+  amount0: string;
+  amount1: string;
+}
+
+export interface TransactionResponse {
+  transactionHash: string;
+  code: number;
+  events: TransactionEvent[];
+  gasUsed: string;
+  gasWanted: string;
+  height: number;
+  rawLog: string;
+}
+
+export interface AddPositionTransactionResponse extends TransactionResponse {
+  rawLog: string;
+  poolId: string;
+  poolAddress: string;
+  token0_finalamount: string;
+  token1_finalamount: string;
+  poolshares: string;
+}
+
+export interface TransactionEvent {
+  attributes: TransactionEventAttribute[];
+  type: string;
+}
+export interface TransactionEventAttribute {
+  key: string;
+  value: string;
+}
+
+export class SerializableExtendedPool {
+  constructor(input: ExtendedPool) {
+    this.$typeUrl = input.$typeUrl;
+    this.address = input.address;
+    this.id = input.id.toString();
+    this.futurePoolGovernor = input.futurePoolGovernor;
+    this.totalShares = input.totalShares;
+    this.poolAssets = input.poolAssets;
+    this.totalWeight = input.totalWeight;
+    this.fees_volume24H = input.volume24H;
+    this.fees_spent_7d = input.fees7D;
+    this.fees_volume7d = input.volume7d;
+    this.myLiquidityShares = input.liquidity;
+    this.myLiquidityDollarValue = input.myLiquidity;
+    this.my_bonded_shares = input.bonded;
+    this.denom = input.denom;
+  }
+  $typeUrl?: string;
+  address: string;
+  id: string;
+  // poolParams: PoolParams;
+  futurePoolGovernor: string;
+  totalShares: Coin;
+  poolAssets: PoolAsset[];
+  totalWeight: string;
+
+  fees_volume24H: number;
+  fees_spent_7d: number;
+  fees_volume7d: number;
+  myLiquidityShares: number;
+  myLiquidityDollarValue: string;
+  my_bonded_shares: string;
+  denom: string;
+}
+
+// code:
+// 1
+// events:
+// (7) [{…}, {…}, {…}, {…}, {…}, {…}, {…}]
+// gasUsed:
+// 67966
+// gasWanted:
+// 250000
+// height:
+// 3492765
+// rawLog:
+// 'failed to execute message; message index: 0: failed to find route for pool id (0)'
+// transactionHash:
+// '4433060F89AAD08E84716B98D20B73E84E12C7DFEA6C5F72B6585B6100B13FB6'
+
+
+// TRADE
+
+// code:
+// 0
+// events:
+
+// gasUsed:
+// 160167
+// gasWanted:
+// 250000
+// height:
+// 3507003
+// rawLog:
+// '[{"events":
+    // [{"type":"coin_received",
+    // "attributes":
+    //     [{"key":"receiver","value":"osmo1g7ajkk295vactngp74shkfrprvjrdwn662dg26"},
+    //     {"key":"amount"},
+    //     {"key":"receiver","value":"osmo1mw0ac6rwlp5r8wapwk3zs6g29h8fcscxqakdzw9emkne6c8wjp9q0t3v8t"},
+    //     {"key":"amount","value":"1000000uosmo"},
+    //     {"key":"receiver","value":"osmo1gxfandcf6x6y0lv3afv0p4w4akv809ycrly4cs"},
+    //     {"key":"amount","value":"3966uion"}]},
+    // {"type":"coin_spent",
+    // "attributes":
+    //     [{"key":"spender","value":"osmo1gxfandcf6x6y0lv3afv0p4w4akv809ycrly4cs"},
+    //     {"key":"…
+    //     {"key":"sender","value":"osmo1gxfandcf6x6y0lv3afv0p4w4akv809ycrly4cs"},
+    //     {"key":"amount"},
+    //     {"key":"recipient","value":"osmo1mw0ac6rwlp5r8wapwk3zs6g29h8fcscxqakdzw9emkne6c8wjp9q0t3v8t"},
+    //     {"key":"sender","value":"osmo1gxfandcf6x6y0lv3afv0p4w4akv809ycrly4cs"},
+    //     {"key":"amount","value":"1000000uosmo"},
+    //     {"key":"recipient","value":"osmo1gxfandcf6x6y0lv3afv0p4w4akv809ycrly4cs"},
+    //     {"key":"sender","value":"osmo1mw0ac6rwlp5r8wapwk3zs6g29h8fcscxqakdzw9emkne6c8wjp9q0t3v8t"},
+    //     {"key":"amount","value":"3966uion"}]}]}]'
+// transactionHash:
+// 'B48CCE7A474B7237DA60DF8BE6BA4BB64914E94445086D7D2D22218B8B045B26'
+
+
+// ADD LIQUIDITY
+  // code:
+  // 0
+  // events:
+  // gasUsed:
+  // 134375
+  // gasWanted:
+  // 250000
+  // height:
+  // 3523121
+  // rawLog:
+  // '[{"events":[{"type":"coin_received",
+  // "attributes":[
+  // {"key":"receiver","value":"osmo17svzplxq3dmkz0atv6vtepftvtfl5daxuajtzxjwchnyjumupg5q649708"},
+  // {"key":"amount","value":"990uion,98159uosmo"},
+  // {"key":"receiver","value":"osmo1c9y7crgg6y9pfkq0y8mqzknqz84c3etr0kpcvj"},
+  // {"key":"amount","value":"57568515255656500gamm/pool/62"},
+  // {"key":"receiver","value":"osmo1gxfandcf6x6y0lv3afv0p4w4akv809ycrly4cs"},
+  // {"key":"amount","value":"57568515255656500gamm/pool/62"}]},
+  // {"type":"coin_spent",
+  // "attributes":[{"key":"spend…ey":"tokens_in","value":"990uion,98159uosmo"}]},
+  // {"type":"transfer",
+  // "attributes":[
+  // {"key":"recipient","value":"osmo17svzplxq3dmkz0atv6vtepftvtfl5daxuajtzxjwchnyjumupg5q649708"},
+  // {"key":"sender","value":"osmo1gxfandcf6x6y0lv3afv0p4w4akv809ycrly4cs"},
+  // {"key":"amount","value":"990uion,98159uosmo"},
+  // {"key":"recipient","value":"osmo1gxfandcf6x6y0lv3afv0p4w4akv809ycrly4cs"},
+  // {"key":"sender","value":"osmo1c9y7crgg6y9pfkq0y8mqzknqz84c3etr0kpcvj"},
+  // {"key":"amount","value":"57568515255656500gamm/pool/62"}]}]}]'
+  // transactionHash:
+  // 'F86D3C78DE05C3B4B96DCA44F29D7E7B1881C06B654F70B92406EA6E2766389F'
+
+
+  // code:
+  // 5
+  // gasUsed:
+  // 76935
+  // gasWanted:
+  // 250000
+  // height:
+  // 3558566
+  // rawLog:
+  // 'failed to execute message; message index: 0: 798uion is smaller than 990uion: insufficient funds'
+  // transactionHash:
+  // '331E8709F466ED00DD2DFA6BA2FD3BFF170725FE3BE3274951C4E92F8B7015B2'

--- a/src/chains/osmosis/osmosis.utils.ts
+++ b/src/chains/osmosis/osmosis.utils.ts
@@ -1,0 +1,40 @@
+
+export interface Fee {
+  pool_id: string;
+  volume_24h: number;
+  volume_7d: number;
+  fees_spent_24h: number;
+  fees_spent_7d: number;
+  fees_percentage: string;
+}
+
+export const fetchFees = async (): Promise<Fee[]> => {
+  const url = 'https://api-osmosis.imperator.co/fees/v1/pools';
+  return fetch(url)
+    // .then(handleError)
+    .then((res) => res.json())
+    .then((res) => res.data);
+};
+
+type PoolReward = {
+  day_usd: number;
+  month_usd: number;
+  year_usd: number;
+};
+
+type Rewards = {
+  pools: {
+    [key: number]: PoolReward;
+  };
+  total_day_usd: number;
+  total_month_usd: number;
+  total_year_usd: number;
+};
+
+export const fetchRewards = async (address: string): Promise<Rewards> => {
+  const url = `https://api-osmosis-chain.imperator.co/lp/v1/rewards/estimation/${address}`;
+  return fetch(url)
+    // .then(handleError)
+    .then((res) => res.json());
+};
+

--- a/src/connectors/connectors.routes.ts
+++ b/src/connectors/connectors.routes.ts
@@ -18,6 +18,7 @@ import { XsswapConfig } from './xsswap/xsswap.config';
 import { ConnectorsResponse } from './connectors.request';
 import { DexalotCLOBConfig } from './dexalot/dexalot.clob.config';
 import { TinymanConfig } from './tinyman/tinyman.config';
+import { OsmosisConfig } from '../chains/osmosis/osmosis.config';
 import { PlentyConfig } from './plenty/plenty.config';
 import { KujiraConfig } from './kujira/kujira.config';
 
@@ -145,6 +146,12 @@ export namespace ConnectorsRoutes {
             trading_type: TinymanConfig.config.tradingTypes,
             chain_type: TinymanConfig.config.chainType,
             available_networks: TinymanConfig.config.availableNetworks,
+          },
+          {
+            name: 'osmosis',
+            trading_type: OsmosisConfig.config.tradingTypes('swap'),
+            chain_type: OsmosisConfig.config.chainType,
+            available_networks: OsmosisConfig.config.availableNetworks,
           },
           {
             name: 'plenty',

--- a/src/network/network.controllers.ts
+++ b/src/network/network.controllers.ts
@@ -1,6 +1,7 @@
 import { StatusRequest, StatusResponse } from './network.requests';
 import { Avalanche } from '../chains/avalanche/avalanche';
 import { BinanceSmartChain } from '../chains/binance-smart-chain/binance-smart-chain';
+import { Cosmos } from '../chains/cosmos/cosmos';
 import { Ethereum } from '../chains/ethereum/ethereum';
 import { Harmony } from '../chains/harmony/harmony';
 import { Polygon } from '../chains/polygon/polygon';
@@ -20,6 +21,7 @@ import {
   getInitializedChain,
   UnsupportedChainException,
 } from '../services/connection-manager';
+import { Osmosis } from '../chains/osmosis/osmosis';
 
 export async function getStatus(
   req: StatusRequest
@@ -98,6 +100,16 @@ export async function getStatus(
     connections = connections.concat(
       injectiveConnections ? Object.values(injectiveConnections) : []
     );
+
+    const cosmosConnections = Cosmos.getConnectedInstances();
+    connections = connections.concat(
+      cosmosConnections ? Object.values(cosmosConnections) : []
+    );
+
+    const osmosisConnections = Osmosis.getConnectedInstances();
+    connections = connections.concat(
+      osmosisConnections ? Object.values(osmosisConnections) : []
+      );
 
     const tezosConnections = Tezos.getConnectedInstances();
     connections = connections.concat(

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -16,7 +16,7 @@ export interface TokenInfo {
 }
 
 // insert a string into another string at an index
-const stringInsert = (str: string, val: string, index: number) => {
+export const stringInsert = (str: string, val: string, index: number) => {
   if (index > 0) {
     return str.substring(0, index) + val + str.substr(index);
   }

--- a/src/services/common-interfaces.ts
+++ b/src/services/common-interfaces.ts
@@ -7,6 +7,7 @@ import {
   BigNumber,
   ethers,
 } from 'ethers';
+
 import {
   Contract as XdcContract,
   Transaction as XdcTransaction,
@@ -14,7 +15,7 @@ import {
   providers as XdcProviders,
 } from 'ethers-xdc';
 import { EthereumBase } from '../chains/ethereum/ethereum-base';
-import { CosmosBase } from '../chains/cosmos/cosmos-base';
+import { CosmosAsset, CosmosBase } from '../chains/cosmos/cosmos-base';
 import { Provider } from '@ethersproject/abstract-provider';
 import { CurrencyAmount, Token, Trade as TradeUniswap } from '@uniswap/sdk';
 import { Trade } from '@uniswap/router-sdk';
@@ -108,7 +109,6 @@ import {
 } from '../clob/clob.requests';
 import { BalanceRequest } from '../network/network.requests';
 import { TradeV2 } from '@traderjoe-xyz/sdk-v2';
-
 // TODO Check the possibility to have clob/solana/serum equivalents here
 //  Check this link https://hummingbot.org/developers/gateway/building-gateway-connectors/#5-add-sdk-classes-to-uniswapish-interface
 export type Tokenish =
@@ -122,7 +122,8 @@ export type Tokenish =
   | PancakeSwapToken
   | MMFToken
   | VVSToken
-  | TokenXsswap;
+  | TokenXsswap
+  | CosmosAsset;
 
 export type TokenAmountish = MMFTokenAmount | VVSTokenAmount;
 

--- a/src/services/connection-manager.ts
+++ b/src/services/connection-manager.ts
@@ -38,6 +38,7 @@ import { DexalotCLOB } from '../connectors/dexalot/dexalot';
 import { Algorand } from '../chains/algorand/algorand';
 import { Cosmos } from '../chains/cosmos/cosmos';
 import { Tinyman } from '../connectors/tinyman/tinyman';
+import { Osmosis } from '../chains/osmosis/osmosis';
 import { Plenty } from '../connectors/plenty/plenty';
 import { Kujira } from '../chains/kujira/kujira';
 import { KujiraCLOB } from '../connectors/kujira/kujira';
@@ -47,6 +48,7 @@ export type ChainUnion =
   | Cosmos
   | Ethereumish
   | Nearish
+  | Osmosis
   | Injective
   | Xdcish
   | Tezosish
@@ -64,6 +66,8 @@ export type Chain<T> = T extends Algorand
   ? Xdcish
   : T extends Injective
   ? Injective
+  : T extends Osmosis
+  ? Osmosis
   : T extends Tezosish
   ? Tezosish
   : T extends KujiraCLOB
@@ -119,6 +123,8 @@ export async function getChainInstance(
     connection = Cronos.getInstance(network);
   } else if (chain === 'cosmos') {
     connection = Cosmos.getInstance(network);
+  } else if (chain === 'osmosis') {
+    connection = Osmosis.getInstance(network);
   } else if (chain === 'near') {
     connection = Near.getInstance(network);
   } else if (chain === 'binance-smart-chain') {

--- a/src/services/error-handler.ts
+++ b/src/services/error-handler.ts
@@ -104,6 +104,8 @@ export const ACCOUNT_NOT_SPECIFIED_CODE = 1016;
 export const TRADE_NOT_FOUND_ERROR_CODE = 1017;
 export const UNKNOWN_ERROR_ERROR_CODE = 1099;
 export const AMOUNT_NOT_SUPPORTED_ERROR_CODE = 1016;
+export const INSUFFICIENT_FUNDS_ERROR_CODE = 1018;
+export const COLLECTFEES_ENDPOINT_NOT_SUPPORTED_ERROR_CODE = 1019;
 
 export const NETWORK_ERROR_MESSAGE =
   'Network error. Please check your node URL, API key, and Internet connection.';
@@ -117,6 +119,8 @@ export const INCOMPLETE_REQUEST_PARAM = 'Incomplete request parameters.';
 export const INVALID_NONCE_ERROR_MESSAGE = 'Invalid Nonce provided: ';
 export const AMOUNT_NOT_SUPPORTED_ERROR_MESSAGE =
   'Amount provided in an unexpected format';
+export const INSUFFICIENT_FUNDS_ERROR_MESSAGE = 'Insufficient funds for transaction.'
+export const COLLECTFEES_ENDPOINT_NOT_SUPPORTED_ERROR_MESSAGE = 'Endpoint not supported for current chain. Use reduceLiquidity() instead.';
 
 export const SWAP_PRICE_EXCEEDS_LIMIT_PRICE_ERROR_MESSAGE = (
   price: any,

--- a/src/services/schema/osmosis-schema.json
+++ b/src/services/schema/osmosis-schema.json
@@ -9,11 +9,12 @@
           "type": "object",
           "properties": {
             "rpcURL": { "type": "string" },
+            "nodeURL": { "type": "string" },
             "tokenListType": { "type": "string" },
             "tokenListSource": { "type": "string" },
-            "nodeURL": { "type": "string" }
+            "chainId": { "type": "string" }
           },
-          "required": ["rpcURL", "tokenListType", "tokenListSource", "nodeURL"],
+          "required": ["rpcURL", "nodeURL", "tokenListType", "tokenListSource", "chainId"],
           "additionalProperties": false
         }
       },
@@ -21,7 +22,13 @@
     },
     "network": { "type": "string" },
     "nativeCurrencySymbol": { "type": "string" },
-    "manualGasPrice": { "type": "integer" }
+    "feeTier": {
+      "enum": ["low", "medium", "high"]
+    },
+    "gasAdjustment": { "type": "number" },
+    "gasLimitTransaction": { "type": "integer" },
+    "manualGasPrice": { "type": "string" },
+    "allowedSlippage": { "type": "string" }
   },
   "additionalProperties": false
 }

--- a/src/services/wallet/wallet.controllers.ts
+++ b/src/services/wallet/wallet.controllers.ts
@@ -1,6 +1,5 @@
 import fse from 'fs-extra';
 import { Xdc } from '../../chains/xdc/xdc';
-import { Cosmos } from '../../chains/cosmos/cosmos';
 import { Injective } from '../../chains/injective/injective';
 import { Tezos } from '../../chains/tezos/tezos';
 import { Kujira } from '../../chains/kujira/kujira';
@@ -34,6 +33,8 @@ import {
 } from '../connection-manager';
 import { Ethereumish, Tezosish } from '../common-interfaces';
 import { Algorand } from '../../chains/algorand/algorand';
+import { Osmosis } from '../../chains/osmosis/osmosis';
+import { Cosmos } from '../../chains/cosmos/cosmos';
 
 export function convertXdcAddressToEthAddress(publicKey: string): string {
   return publicKey.length === 43 && publicKey.slice(0, 3) === 'xdc'
@@ -105,10 +106,20 @@ export async function addWallet(
     } else if (connection instanceof Cosmos) {
       const wallet = await (connection as Cosmos).getAccountsfromPrivateKey(
         req.privateKey,
-        'cosmos'
+        'cosmos' // changed from cosmos - the only dex we connect to currently is osmosis anyway
       );
       address = wallet.address;
       encryptedPrivateKey = await (connection as Cosmos).encrypt(
+        req.privateKey,
+        passphrase
+      );
+    } else if (connection instanceof Osmosis) {
+      const wallet = await (connection as Osmosis).getAccountsfromPrivateKey(
+        req.privateKey,
+        'osmo' // changed from cosmos - the only dex we connect to currently is osmosis anyway
+      );
+      address = wallet.address;
+      encryptedPrivateKey = await (connection as Osmosis).encrypt(
         req.privateKey,
         passphrase
       );

--- a/src/services/wallet/wallet.routes.ts
+++ b/src/services/wallet/wallet.routes.ts
@@ -23,6 +23,7 @@ import {
   validateAddWalletRequest,
   validateRemoveWalletRequest,
   validateWalletSignRequest,
+  validateAddWalletRequestCosmos,
 } from './wallet.validators';
 
 export namespace WalletRoutes {
@@ -43,7 +44,11 @@ export namespace WalletRoutes {
         req: Request<{}, {}, AddWalletRequest>,
         res: Response<AddWalletResponse, {}>
       ) => {
-        validateAddWalletRequest(req.body);
+        if (req.body.chain == 'osmosis'){
+          validateAddWalletRequestCosmos(req.body);
+        } else{
+          validateAddWalletRequest(req.body);
+        }
         res.status(200).json(await addWallet(req.body));
       }
     )

--- a/src/services/wallet/wallet.validators.ts
+++ b/src/services/wallet/wallet.validators.ts
@@ -7,6 +7,10 @@ import {
   mkSelectingValidator,
 } from '../validators';
 
+import {
+  validatePrivateKey as validatePrivateKeyCosmos
+} from '../../chains/cosmos/cosmos.validators'
+
 const { fromBase64 } = require('@cosmjs/encoding');
 
 export const invalidAlgorandPrivateKeyOrMnemonicError: string =
@@ -138,7 +142,7 @@ export const validatePrivateKey: Validator = mkSelectingValidator(
 );
 
 export const invalidChainError: string =
-  'chain must be "ethereum", "avalanche", "near", "harmony", "cosmos", "binance-smart-chain", "injective", or "kujira"';
+  'chain must be "ethereum", "avalanche", "near", "harmony", "cosmos", "osmosis", "binance-smart-chain", "injective", or "kujira"';
 
 export const invalidNetworkError: string =
   'expected a string for the network key';
@@ -164,6 +168,7 @@ export const validateChain: Validator = mkValidator(
       val === 'harmony' ||
       val === 'cronos' ||
       val === 'cosmos' ||
+      val === 'osmosis' ||
       val === 'binance-smart-chain' ||
       val === 'injective' ||
       val === 'tezos' ||
@@ -198,6 +203,13 @@ export const validateMessage: Validator = mkValidator(
 
 export const validateAddWalletRequest: RequestValidator = mkRequestValidator([
   validatePrivateKey,
+  validateChain,
+  validateNetwork,
+  validateAccountID,
+]);
+
+export const validateAddWalletRequestCosmos: RequestValidator = mkRequestValidator([
+  validatePrivateKeyCosmos,
   validateChain,
   validateNetwork,
   validateAccountID,

--- a/src/templates/cosmos.yml
+++ b/src/templates/cosmos.yml
@@ -1,13 +1,14 @@
 networks:
   mainnet:
-    rpcURL: https://cosmos-mainnet-rpc.allthatnode.com:26657
+    rpcURL: https://rpc.osmosis.zone/   # https://cosmos-rpc.publicnode.com:443
     tokenListType: URL
-    tokenListSource: >-
-      https://cosmos-chain-registry-list.vercel.app/list.json
+    tokenListSource: https://raw.githubusercontent.com/osmosis-labs/assetlists/main/osmosis-1/osmosis-1.assetlist.json #https://cosmos-chain-registry-list.vercel.app/list.json
+    nodeURL: https://rpc.osmosis.zone/   # AKA nodeurl sometimes - see xdc ## ALSO CAN USE https://rpc.cosmos.directory/osmosis
   testnet:
-    rpcURL: https://cosmos-testnet-rpc.allthatnode.com:26657
+    rpcURL: https://rpc.testnet.osmosis.zone/ # https://cosmos-testnet-rpc.polkachu.com
     tokenListType: URL
-    tokenListSource: https://cosmos-chain-registry-list.vercel.app/list.json
-network: mainnet
-nativeCurrencySymbol: ATOM
+    tokenListSource: https://raw.githubusercontent.com/osmosis-labs/osmosis/c387e00c6338fa113ccb3abcb129f633670445f6/cmd/osmosisd/cmd/osmo-test-5-assetlist.json
+    nodeURL: https://rpc.testnet.osmosis.zone/
+network: testnet
+nativeCurrencySymbol: OSMO
 manualGasPrice: 110

--- a/src/templates/lists/osmosis_assets.json
+++ b/src/templates/lists/osmosis_assets.json
@@ -1,0 +1,11146 @@
+{
+  "chain_name": "osmosis",
+  "assets": [
+    {
+      "description": "The native token of Osmosis",
+      "denom_units": [
+        {
+          "denom": "uosmo",
+          "exponent": 0
+        },
+        {
+          "denom": "osmo",
+          "exponent": 6
+        }
+      ],
+      "base": "uosmo",
+      "name": "Osmosis",
+      "display": "osmo",
+      "symbol": "OSMO",
+      "traces": [],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
+      },
+      "coingecko_id": "osmosis",
+      "keywords": [
+        "dex",
+        "staking",
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858:678"
+      ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "uion",
+          "exponent": 0
+        },
+        {
+          "denom": "ion",
+          "exponent": 6
+        }
+      ],
+      "base": "uion",
+      "name": "Ion",
+      "display": "ion",
+      "symbol": "ION",
+      "traces": [],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg"
+      },
+      "coingecko_id": "ion",
+      "keywords": [
+        "memecoin",
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:2"
+      ]
+    },
+    {
+      "description": "Circle's stablecoin on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+          "exponent": 0,
+          "aliases": [
+            "uusdc"
+          ]
+        },
+        {
+          "denom": "usdc",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+      "name": "USD Coin",
+      "display": "usdc",
+      "symbol": "USDC",
+      "traces": [
+        {
+          "type": "synthetic",
+          "counterparty": {
+            "chain_name": "forex",
+            "base_denom": "USD"
+          },
+          "provider": "Circle"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "uusdc",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/uusdc"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.svg"
+      },
+      "coingecko_id": "axlusdc",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info"
+      ]
+    },
+    {
+      "description": "Wrapped Ether on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
+          "exponent": 0,
+          "aliases": [
+            "weth-wei"
+          ]
+        },
+        {
+          "denom": "weth",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
+      "name": "Wrapped Ether",
+      "display": "weth",
+      "symbol": "ETH",
+      "traces": [
+        {
+          "type": "wrapped",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "wei"
+          },
+          "provider": "Ethereum"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "weth-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/weth-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.png"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:704"
+      ]
+    },
+    {
+      "description": "Wrapped Bitcoin on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
+          "exponent": 0,
+          "aliases": [
+            "wbtc-satoshi"
+          ]
+        },
+        {
+          "denom": "wbtc",
+          "exponent": 8
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
+      "name": "Wrapped Bitcoin",
+      "display": "wbtc",
+      "symbol": "WBTC",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "bitcoin",
+            "base_denom": "sat"
+          },
+          "provider": "BitGo, Kyber, and Ren"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "wbtc-satoshi",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/wbtc-satoshi"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wbtc.png"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:712"
+      ]
+    },
+    {
+      "description": "Tether's USD stablecoin on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
+          "exponent": 0,
+          "aliases": [
+            "uusdt"
+          ]
+        },
+        {
+          "denom": "usdt",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
+      "name": "Tether USD",
+      "display": "usdt",
+      "symbol": "USDT.axl",
+      "traces": [
+        {
+          "type": "synthetic",
+          "counterparty": {
+            "chain_name": "forex",
+            "base_denom": "USD"
+          },
+          "provider": "Tether"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "uusdt",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/uusdt"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdt.axl.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:831"
+      ]
+    },
+    {
+      "description": "Dai stablecoin on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+          "exponent": 0,
+          "aliases": [
+            "dai-wei"
+          ]
+        },
+        {
+          "denom": "dai",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      "name": "Dai Stablecoin",
+      "display": "dai",
+      "symbol": "DAI",
+      "traces": [
+        {
+          "type": "synthetic",
+          "counterparty": {
+            "chain_name": "forex",
+            "base_denom": "USD"
+          },
+          "provider": "MakerDAO"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x6b175474e89094c44da98b954eedeac495271d0f"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "dai-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/dai-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dai.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dai.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:674"
+      ]
+    },
+    {
+      "description": "Binance USD on Axelar.",
+      "denom_units": [
+        {
+          "denom": "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
+          "exponent": 0,
+          "aliases": [
+            "busd-wei"
+          ]
+        },
+        {
+          "denom": "busd",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
+      "name": "Binance USD",
+      "display": "busd",
+      "symbol": "BUSD",
+      "traces": [
+        {
+          "type": "synthetic",
+          "counterparty": {
+            "chain_name": "forex",
+            "base_denom": "USD"
+          },
+          "provider": "Binance"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x4fabb145d64652a948d72533023f6e7a623c7c53"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "busd-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/busd-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858:877"
+      ]
+    },
+    {
+      "description": "The native staking and governance token of the Cosmos Hub.",
+      "denom_units": [
+        {
+          "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+          "exponent": 0,
+          "aliases": [
+            "uatom"
+          ]
+        },
+        {
+          "denom": "atom",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "name": "Cosmos Hub Atom",
+      "display": "atom",
+      "symbol": "ATOM",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "cosmoshub",
+            "base_denom": "uatom",
+            "channel_id": "channel-141"
+          },
+          "chain": {
+            "channel_id": "channel-0",
+            "path": "transfer/channel-0/uatom"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
+      },
+      "coingecko_id": "cosmos",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:1"
+      ]
+    },
+    {
+      "description": "CRO is the native token of the Crypto.org Chain, referred to as Native CRO.",
+      "denom_units": [
+        {
+          "denom": "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+          "exponent": 0,
+          "aliases": [
+            "basecro"
+          ]
+        },
+        {
+          "denom": "cro",
+          "exponent": 8
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "name": "Cronos",
+      "display": "cro",
+      "symbol": "CRO",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "cryptoorgchain",
+            "base_denom": "basecro",
+            "channel_id": "channel-10"
+          },
+          "chain": {
+            "channel_id": "channel-5",
+            "path": "transfer/channel-5/basecro"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/images/cronos.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/images/cro.svg"
+      },
+      "coingecko_id": "crypto-com-chain",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:9"
+      ]
+    },
+    {
+      "description": "Wrapped BNB on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
+          "exponent": 0,
+          "aliases": [
+            "wbnb-wei"
+          ]
+        },
+        {
+          "denom": "wbnb",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
+      "name": "Wrapped BNB",
+      "display": "wbnb",
+      "symbol": "BNB",
+      "traces": [
+        {
+          "type": "wrapped",
+          "counterparty": {
+            "chain_name": "binancesmartchain",
+            "base_denom": "wei"
+          },
+          "chain": {
+            "contract": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c"
+          },
+          "provider": "Binance"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "binancesmartchain",
+            "base_denom": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "wbnb-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/wbnb-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:840"
+      ]
+    },
+    {
+      "description": "Wrapped Matic on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
+          "exponent": 0,
+          "aliases": [
+            "wmatic-wei"
+          ]
+        },
+        {
+          "denom": "wmatic",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
+      "name": "Wrapped Matic",
+      "display": "wmatic",
+      "symbol": "MATIC",
+      "traces": [
+        {
+          "type": "wrapped",
+          "counterparty": {
+            "chain_name": "polygon",
+            "base_denom": "wei"
+          },
+          "provider": "Polygon"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "polygon",
+            "base_denom": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "wmatic-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/wmatic-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/matic-purple.png"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:789"
+      ]
+    },
+    {
+      "description": "Wrapped AVAX on Axelar.",
+      "denom_units": [
+        {
+          "denom": "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
+          "exponent": 0,
+          "aliases": [
+            "wavax-wei"
+          ]
+        },
+        {
+          "denom": "avax",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
+      "name": "Wrapped AVAX",
+      "display": "avax",
+      "symbol": "AVAX",
+      "traces": [
+        {
+          "type": "wrapped",
+          "counterparty": {
+            "chain_name": "avalanche",
+            "base_denom": "wei"
+          },
+          "provider": "Avalanche"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "avalanche",
+            "base_denom": "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "wavax-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/wavax-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/avalanche/images/avax.png"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:899"
+      ]
+    },
+    {
+      "description": "The native staking token of Terra Classic.",
+      "denom_units": [
+        {
+          "denom": "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+          "exponent": 0,
+          "aliases": [
+            "microluna",
+            "uluna"
+          ]
+        },
+        {
+          "denom": "mluna",
+          "exponent": 3,
+          "aliases": [
+            "milliluna"
+          ]
+        },
+        {
+          "denom": "luna",
+          "exponent": 6,
+          "aliases": [
+            "lunc"
+          ]
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+      "name": "Luna Classic",
+      "display": "luna",
+      "symbol": "LUNC",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "terra",
+            "base_denom": "uluna",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-72",
+            "path": "transfer/channel-72/uluna"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.svg"
+      },
+      "coingecko_id": "terra-luna",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:800"
+      ]
+    },
+    {
+      "description": "The native token of JUNO Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+          "exponent": 0,
+          "aliases": [
+            "ujuno"
+          ]
+        },
+        {
+          "denom": "juno",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "name": "Juno",
+      "display": "juno",
+      "symbol": "JUNO",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "ujuno",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-42",
+            "path": "transfer/channel-42/ujuno"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.svg"
+      },
+      "coingecko_id": "juno-network",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:497"
+      ]
+    },
+    {
+      "description": "Wrapped Polkadot on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
+          "exponent": 0,
+          "aliases": [
+            "dot-planck"
+          ]
+        },
+        {
+          "denom": "dot",
+          "exponent": 10
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
+      "name": "Wrapped Polkadot",
+      "display": "dot",
+      "symbol": "DOT",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "polkadot",
+            "base_denom": "Planck"
+          },
+          "provider": "Polkadot Parachain"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "moonbeam",
+            "base_denom": "0xffffffff1fcacbd218edc0eba20fc2308c778080"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "dot-planck",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/dot-planck"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:773"
+      ]
+    },
+    {
+      "description": "The native EVM, governance and staking token of the Evmos Hub",
+      "denom_units": [
+        {
+          "denom": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
+          "exponent": 0,
+          "aliases": [
+            "aevmos"
+          ]
+        },
+        {
+          "denom": "evmos",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
+      "name": "Evmos",
+      "display": "evmos",
+      "symbol": "EVMOS",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "evmos",
+            "base_denom": "aevmos",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-204",
+            "path": "transfer/channel-204/aevmos"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg"
+      },
+      "coingecko_id": "evmos",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:722"
+      ]
+    },
+    {
+      "description": "The native staking and governance token of Kava",
+      "denom_units": [
+        {
+          "denom": "ibc/57AA1A70A4BC9769C525EBF6386F7A21536E04A79D62E1981EFCEF9428EBB205",
+          "exponent": 0,
+          "aliases": [
+            "ukava"
+          ]
+        },
+        {
+          "denom": "kava",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/57AA1A70A4BC9769C525EBF6386F7A21536E04A79D62E1981EFCEF9428EBB205",
+      "name": "Kava",
+      "display": "kava",
+      "symbol": "KAVA",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "kava",
+            "base_denom": "ukava",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-143",
+            "path": "transfer/channel-143/ukava"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/kava.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/kava.svg"
+      },
+      "coingecko_id": "kava",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:730"
+      ]
+    },
+    {
+      "description": "The native token of Secret Network",
+      "denom_units": [
+        {
+          "denom": "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
+          "exponent": 0,
+          "aliases": [
+            "uscrt"
+          ]
+        },
+        {
+          "denom": "scrt",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
+      "name": "Secret Network",
+      "display": "scrt",
+      "symbol": "SCRT",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "secretnetwork",
+            "base_denom": "uscrt",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-88",
+            "path": "transfer/channel-88/uscrt"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg"
+      },
+      "coingecko_id": "secret",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:584"
+      ]
+    },
+    {
+      "description": "The USD stablecoin of Terra Classic.",
+      "denom_units": [
+        {
+          "denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+          "exponent": 0,
+          "aliases": [
+            "microusd",
+            "uusd"
+          ]
+        },
+        {
+          "denom": "musd",
+          "exponent": 3,
+          "aliases": [
+            "milliusd"
+          ]
+        },
+        {
+          "denom": "ust",
+          "exponent": 6,
+          "aliases": [
+            "ustc"
+          ]
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+      "name": "TerraClassicUSD",
+      "display": "ust",
+      "symbol": "USTC",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "terra",
+            "base_denom": "uusd",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-72",
+            "path": "transfer/channel-72/uusd"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/ust.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/ust.svg"
+      },
+      "coingecko_id": "terrausd",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:560"
+      ]
+    },
+    {
+      "description": "The native token of Stargaze",
+      "denom_units": [
+        {
+          "denom": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
+          "exponent": 0,
+          "aliases": [
+            "ustars"
+          ]
+        },
+        {
+          "denom": "stars",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
+      "name": "Stargaze",
+      "display": "stars",
+      "symbol": "STARS",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "stargaze",
+            "base_denom": "ustars",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-75",
+            "path": "transfer/channel-75/ustars"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.svg"
+      },
+      "coingecko_id": "stargaze",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:604"
+      ]
+    },
+    {
+      "description": "The native token of Chihuahua Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
+          "exponent": 0,
+          "aliases": [
+            "uhuahua"
+          ]
+        },
+        {
+          "denom": "huahua",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
+      "name": "Chihuahua",
+      "display": "huahua",
+      "symbol": "HUAHUA",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "chihuahua",
+            "base_denom": "uhuahua",
+            "channel_id": "channel-7"
+          },
+          "chain": {
+            "channel_id": "channel-113",
+            "path": "transfer/channel-113/uhuahua"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/huahua.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/huahua.svg"
+      },
+      "coingecko_id": "chihuahua-token",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:605"
+      ]
+    },
+    {
+      "description": "The XPRT token is primarily a governance token for the Persistence chain.",
+      "denom_units": [
+        {
+          "denom": "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+          "exponent": 0,
+          "aliases": [
+            "uxprt"
+          ]
+        },
+        {
+          "denom": "xprt",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+      "name": "Persistence",
+      "display": "xprt",
+      "symbol": "XPRT",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "persistence",
+            "base_denom": "uxprt",
+            "channel_id": "channel-6"
+          },
+          "chain": {
+            "channel_id": "channel-4",
+            "path": "transfer/channel-4/uxprt"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg"
+      },
+      "coingecko_id": "persistence",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:15"
+      ]
+    },
+    {
+      "description": "pSTAKE is a liquid staking protocol unlocking the liquidity of staked assets.",
+      "denom_units": [
+        {
+          "denom": "ibc/8061A06D3BD4D52C4A28FFECF7150D370393AF0BA661C3776C54FF32836C3961",
+          "exponent": 0,
+          "aliases": [
+            "gravity0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",
+            "0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",
+            "ibc/A6E3AF63B3C906416A9AF7A556C59EA4BD50E617EFFE6299B99700CCB780E444"
+          ]
+        },
+        {
+          "denom": "pstake",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/8061A06D3BD4D52C4A28FFECF7150D370393AF0BA661C3776C54FF32836C3961",
+      "name": "pSTAKE Finance",
+      "display": "pstake",
+      "symbol": "PSTAKE",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006"
+          },
+          "provider": "Gravity Bridge"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gravitybridge",
+            "base_denom": "gravity0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",
+            "channel_id": "channel-24"
+          },
+          "chain": {
+            "channel_id": "channel-38",
+            "path": "transfer/channel-38/gravity0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006"
+          }
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "persistence",
+            "base_denom": "ibc/A6E3AF63B3C906416A9AF7A556C59EA4BD50E617EFFE6299B99700CCB780E444",
+            "channel_id": "channel-6"
+          },
+          "chain": {
+            "channel_id": "channel-4",
+            "path": "transfer/channel-4/transfer/channel-38/gravity0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.svg"
+      },
+      "keywords": [
+        "canon",
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:648"
+      ]
+    },
+    {
+      "description": "Akash Token (AKT) is the Akash Network's native utility token, used as the primary means to govern, secure the blockchain, incentivize participants, and provide a default mechanism to store and exchange value.",
+      "denom_units": [
+        {
+          "denom": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+          "exponent": 0,
+          "aliases": [
+            "uakt"
+          ]
+        },
+        {
+          "denom": "akt",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "name": "Akash Network",
+      "display": "akt",
+      "symbol": "AKT",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "akash",
+            "base_denom": "uakt",
+            "channel_id": "channel-9"
+          },
+          "chain": {
+            "channel_id": "channel-1",
+            "path": "transfer/channel-1/uakt"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg"
+      },
+      "coingecko_id": "akash-network",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:3"
+      ]
+    },
+    {
+      "description": "REGEN coin is the token for the Regen Network Platform",
+      "denom_units": [
+        {
+          "denom": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+          "exponent": 0,
+          "aliases": [
+            "uregen"
+          ]
+        },
+        {
+          "denom": "regen",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "name": "Regen Network",
+      "display": "regen",
+      "symbol": "REGEN",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "regen",
+            "base_denom": "uregen",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-8",
+            "path": "transfer/channel-8/uregen"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/regen.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/regen.svg"
+      },
+      "coingecko_id": "regen",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:42"
+      ]
+    },
+    {
+      "description": "DVPN is the native token of the Sentinel Hub.",
+      "denom_units": [
+        {
+          "denom": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+          "exponent": 0,
+          "aliases": [
+            "udvpn"
+          ]
+        },
+        {
+          "denom": "dvpn",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "name": "Sentinel",
+      "display": "dvpn",
+      "symbol": "DVPN",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "sentinel",
+            "base_denom": "udvpn",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-2",
+            "path": "transfer/channel-2/udvpn"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/images/dvpn.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/images/dvpn.svg"
+      },
+      "coingecko_id": "sentinel",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:6"
+      ]
+    },
+    {
+      "description": "The IRIS token is the native governance token for the IrisNet chain.",
+      "denom_units": [
+        {
+          "denom": "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+          "exponent": 0,
+          "aliases": [
+            "uiris"
+          ]
+        },
+        {
+          "denom": "iris",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+      "name": "IRISnet",
+      "display": "iris",
+      "symbol": "IRIS",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "irisnet",
+            "base_denom": "uiris",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-6",
+            "path": "transfer/channel-6/uiris"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.svg"
+      },
+      "coingecko_id": "iris-network",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:8"
+      ]
+    },
+    {
+      "description": "IOV coin is the token for the Starname (IOV) Asset Name Service",
+      "denom_units": [
+        {
+          "denom": "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+          "exponent": 0,
+          "aliases": [
+            "uiov"
+          ]
+        },
+        {
+          "denom": "iov",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "name": "Starname",
+      "display": "iov",
+      "symbol": "IOV",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "starname",
+            "base_denom": "uiov",
+            "channel_id": "channel-2"
+          },
+          "chain": {
+            "channel_id": "channel-15",
+            "path": "transfer/channel-15/uiov"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.svg"
+      },
+      "coingecko_id": "starname",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:197"
+      ]
+    },
+    {
+      "description": "e-Money NGM staking token. In addition to earning staking rewards the token is bought back and burned based on e-Money stablecoin inflation.",
+      "denom_units": [
+        {
+          "denom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+          "exponent": 0,
+          "aliases": [
+            "ungm"
+          ]
+        },
+        {
+          "denom": "ngm",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "name": "e-Money",
+      "display": "ngm",
+      "symbol": "NGM",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "emoney",
+            "base_denom": "ungm",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-37",
+            "path": "transfer/channel-37/ungm"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.svg"
+      },
+      "coingecko_id": "e-money",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:463"
+      ]
+    },
+    {
+      "description": "e-Money EUR stablecoin. Audited and backed by fiat EUR deposits and government bonds.",
+      "denom_units": [
+        {
+          "denom": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+          "exponent": 0,
+          "aliases": [
+            "eeur"
+          ]
+        },
+        {
+          "denom": "eur",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "name": "e-Money EUR",
+      "display": "eur",
+      "symbol": "EEUR",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "emoney",
+            "base_denom": "eeur",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-37",
+            "path": "transfer/channel-37/eeur"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.svg"
+      },
+      "coingecko_id": "e-money-eur",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:481"
+      ]
+    },
+    {
+      "description": "LIKE is the native staking and governance token of LikeCoin chain, a Decentralized Publishing Infrastructure to empower content ownership, authenticity, and provenance.",
+      "denom_units": [
+        {
+          "denom": "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
+          "exponent": 0,
+          "aliases": [
+            "nanolike"
+          ]
+        },
+        {
+          "denom": "like",
+          "exponent": 9
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
+      "name": "LikeCoin",
+      "display": "like",
+      "symbol": "LIKE",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "likecoin",
+            "base_denom": "nanolike",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-53",
+            "path": "transfer/channel-53/nanolike"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.svg"
+      },
+      "coingecko_id": "likecoin",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:553"
+      ]
+    },
+    {
+      "description": "The native token of IXO Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B",
+          "exponent": 0,
+          "aliases": [
+            "uixo"
+          ]
+        },
+        {
+          "denom": "ixo",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B",
+      "name": "IXO",
+      "display": "ixo",
+      "symbol": "IXO",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "impacthub",
+            "base_denom": "uixo",
+            "channel_id": "channel-4"
+          },
+          "chain": {
+            "channel_id": "channel-38",
+            "path": "transfer/channel-38/uixo"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.svg"
+      },
+      "coingecko_id": "ixo",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:558"
+      ]
+    },
+    {
+      "description": "The BCNA coin is the transactional token within the BitCanna network, serving the legal cannabis industry through its payment network, supply chain and trust network.",
+      "denom_units": [
+        {
+          "denom": "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5",
+          "exponent": 0,
+          "aliases": [
+            "ubcna"
+          ]
+        },
+        {
+          "denom": "bcna",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5",
+      "name": "BitCanna",
+      "display": "bcna",
+      "symbol": "BCNA",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "bitcanna",
+            "base_denom": "ubcna",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-51",
+            "path": "transfer/channel-51/ubcna"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.svg"
+      },
+      "coingecko_id": "bitcanna",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:572"
+      ]
+    },
+    {
+      "description": "BitSong Native Token",
+      "denom_units": [
+        {
+          "denom": "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+          "exponent": 0,
+          "aliases": [
+            "ubtsg"
+          ]
+        },
+        {
+          "denom": "btsg",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+      "name": "BitSong",
+      "display": "btsg",
+      "symbol": "BTSG",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "bitsong",
+            "base_denom": "ubtsg",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-73",
+            "path": "transfer/channel-73/ubtsg"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.svg"
+      },
+      "coingecko_id": "bitsong",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:574"
+      ]
+    },
+    {
+      "description": "The native token of Ki Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
+          "exponent": 0,
+          "aliases": [
+            "uxki"
+          ]
+        },
+        {
+          "denom": "xki",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
+      "name": "Ki",
+      "display": "xki",
+      "symbol": "XKI",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "kichain",
+            "base_denom": "uxki",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-77",
+            "path": "transfer/channel-77/uxki"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.svg"
+      },
+      "coingecko_id": "ki",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:577"
+      ]
+    },
+    {
+      "description": "Panacea is a public blockchain launched by MediBloc, which is the key infrastructure for reinventing the patient-centered healthcare data ecosystem",
+      "denom_units": [
+        {
+          "denom": "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB",
+          "exponent": 0,
+          "aliases": [
+            "umed"
+          ]
+        },
+        {
+          "denom": "med",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB",
+      "name": "MediBloc",
+      "display": "med",
+      "symbol": "MED",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "panacea",
+            "base_denom": "umed",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-82",
+            "path": "transfer/channel-82/umed"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/panacea/images/med.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/panacea/images/med.svg"
+      },
+      "coingecko_id": "medibloc",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:587"
+      ]
+    },
+    {
+      "description": "The staking token of Bostrom",
+      "denom_units": [
+        {
+          "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
+          "exponent": 0,
+          "aliases": [
+            "boot"
+          ]
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
+      "name": "Bostrom",
+      "display": "boot",
+      "symbol": "BOOT",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "bostrom",
+            "base_denom": "boot",
+            "channel_id": "channel-2"
+          },
+          "chain": {
+            "channel_id": "channel-95",
+            "path": "transfer/channel-95/boot"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/boot.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/boot.svg"
+      },
+      "coingecko_id": "bostrom",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5:912"
+      ]
+    },
+    {
+      "description": "Native Token of Comdex Protocol",
+      "denom_units": [
+        {
+          "denom": "ibc/EA3E1640F9B1532AB129A571203A0B9F789A7F14BB66E350DCBFA18E1A1931F0",
+          "exponent": 0,
+          "aliases": [
+            "ucmdx"
+          ]
+        },
+        {
+          "denom": "cmdx",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/EA3E1640F9B1532AB129A571203A0B9F789A7F14BB66E350DCBFA18E1A1931F0",
+      "name": "Comdex",
+      "display": "cmdx",
+      "symbol": "CMDX",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "comdex",
+            "base_denom": "ucmdx",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-87",
+            "path": "transfer/channel-87/ucmdx"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.svg"
+      },
+      "coingecko_id": "comdex",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:600"
+      ]
+    },
+    {
+      "description": "Native token for the cheqd network",
+      "denom_units": [
+        {
+          "denom": "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
+          "exponent": 0,
+          "aliases": [
+            "ncheq"
+          ]
+        },
+        {
+          "denom": "cheq",
+          "exponent": 9
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
+      "name": "cheqd",
+      "display": "cheq",
+      "symbol": "CHEQ",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "cheqd",
+            "base_denom": "ncheq",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-108",
+            "path": "transfer/channel-108/ncheq"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.svg"
+      },
+      "coingecko_id": "cheqd-network",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:602"
+      ]
+    },
+    {
+      "description": "Native token of the Lum Network",
+      "denom_units": [
+        {
+          "denom": "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2",
+          "exponent": 0,
+          "aliases": [
+            "ulum"
+          ]
+        },
+        {
+          "denom": "lum",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2",
+      "name": "Lum",
+      "display": "lum",
+      "symbol": "LUM",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "lumnetwork",
+            "base_denom": "ulum",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-115",
+            "path": "transfer/channel-115/ulum"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/images/lum.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/images/lum.svg"
+      },
+      "coingecko_id": "lum-network",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:608"
+      ]
+    },
+    {
+      "description": "The native token of Vidulum",
+      "denom_units": [
+        {
+          "denom": "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD",
+          "exponent": 0,
+          "aliases": [
+            "uvdl"
+          ]
+        },
+        {
+          "denom": "vdl",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD",
+      "name": "Vidulum",
+      "display": "vdl",
+      "symbol": "VDL",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "vidulum",
+            "base_denom": "uvdl",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-124",
+            "path": "transfer/channel-124/uvdl"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/vidulum/images/vdl.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/vidulum/images/vdl.svg"
+      },
+      "coingecko_id": "vidulum",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:613"
+      ]
+    },
+    {
+      "description": "The native token of Desmos",
+      "denom_units": [
+        {
+          "denom": "ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C",
+          "exponent": 0,
+          "aliases": [
+            "udsm"
+          ]
+        },
+        {
+          "denom": "dsm",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C",
+      "name": "Desmos",
+      "display": "dsm",
+      "symbol": "DSM",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "desmos",
+            "base_denom": "udsm",
+            "channel_id": "channel-2"
+          },
+          "chain": {
+            "channel_id": "channel-135",
+            "path": "transfer/channel-135/udsm"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.svg"
+      },
+      "coingecko_id": "desmos",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:619"
+      ]
+    },
+    {
+      "description": "Native token of Dig Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/307E5C96C8F60D1CBEE269A9A86C0834E1DB06F2B3788AE4F716EDB97A48B97D",
+          "exponent": 0,
+          "aliases": [
+            "udig"
+          ]
+        },
+        {
+          "denom": "dig",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/307E5C96C8F60D1CBEE269A9A86C0834E1DB06F2B3788AE4F716EDB97A48B97D",
+      "name": "Dig Chain",
+      "display": "dig",
+      "symbol": "DIG",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "dig",
+            "base_denom": "udig",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-128",
+            "path": "transfer/channel-128/udig"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dig/images/dig.png"
+      },
+      "coingecko_id": "dig-chain",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:621"
+      ]
+    },
+    {
+      "description": "Somm Token (SOMM) is the native staking token of the Sommelier Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
+          "exponent": 0,
+          "aliases": [
+            "microsomm",
+            "usomm"
+          ]
+        },
+        {
+          "denom": "msomm",
+          "exponent": 3,
+          "aliases": [
+            "millisomm"
+          ]
+        },
+        {
+          "denom": "somm",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
+      "name": "Somm",
+      "display": "somm",
+      "symbol": "SOMM",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "sommelier",
+            "base_denom": "usomm",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-165",
+            "path": "transfer/channel-165/usomm"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.svg"
+      },
+      "coingecko_id": "sommelier",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:627"
+      ]
+    },
+    {
+      "description": "The native token of BandChain",
+      "denom_units": [
+        {
+          "denom": "ibc/F867AE2112EFE646EC71A25CD2DFABB8927126AC1E19F1BBF0FF693A4ECA05DE",
+          "exponent": 0,
+          "aliases": [
+            "uband"
+          ]
+        },
+        {
+          "denom": "band",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/F867AE2112EFE646EC71A25CD2DFABB8927126AC1E19F1BBF0FF693A4ECA05DE",
+      "name": "Band Protocol",
+      "display": "band",
+      "symbol": "BAND",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "bandchain",
+            "base_denom": "uband",
+            "channel_id": "channel-83"
+          },
+          "chain": {
+            "channel_id": "channel-148",
+            "path": "transfer/channel-148/uband"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.svg"
+      },
+      "coingecko_id": "band-protocol",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:626"
+      ]
+    },
+    {
+      "description": "The native token of Konstellation Network",
+      "denom_units": [
+        {
+          "denom": "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593",
+          "exponent": 0,
+          "aliases": [
+            "udarc"
+          ]
+        },
+        {
+          "denom": "darc",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593",
+      "name": "DARC",
+      "display": "darc",
+      "symbol": "DARC",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "konstellation",
+            "base_denom": "udarc",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-171",
+            "path": "transfer/channel-171/udarc"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.svg"
+      },
+      "coingecko_id": "darcmatter-coin",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:637"
+      ]
+    },
+    {
+      "description": "The native token of Umee",
+      "denom_units": [
+        {
+          "denom": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
+          "exponent": 0,
+          "aliases": [
+            "uumee"
+          ]
+        },
+        {
+          "denom": "umee",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
+      "name": "Umee",
+      "display": "umee",
+      "symbol": "UMEE",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "umee",
+            "base_denom": "uumee",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-184",
+            "path": "transfer/channel-184/uumee"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/images/umee.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/images/umee.svg"
+      },
+      "coingecko_id": "umee",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:641"
+      ]
+    },
+    {
+      "description": "The native token of Gravity Bridge",
+      "denom_units": [
+        {
+          "denom": "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
+          "exponent": 0,
+          "aliases": [
+            "ugraviton"
+          ]
+        },
+        {
+          "denom": "graviton",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
+      "name": "Graviton",
+      "display": "graviton",
+      "symbol": "GRAV",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gravitybridge",
+            "base_denom": "ugraviton",
+            "channel_id": "channel-10"
+          },
+          "chain": {
+            "channel_id": "channel-144",
+            "path": "transfer/channel-144/ugraviton"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.svg"
+      },
+      "coingecko_id": "graviton",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:625"
+      ]
+    },
+    {
+      "description": "The native token of Decentr",
+      "denom_units": [
+        {
+          "denom": "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84",
+          "exponent": 0,
+          "aliases": [
+            "udec"
+          ]
+        },
+        {
+          "denom": "dec",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84",
+      "name": "Decentr",
+      "display": "dec",
+      "symbol": "DEC",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "decentr",
+            "base_denom": "udec",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-181",
+            "path": "transfer/channel-181/udec"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.svg"
+      },
+      "coingecko_id": "decentr",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:644"
+      ]
+    },
+    {
+      "description": "The native token cw20 for Marble DAO on Juno Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/F6B691D5F7126579DDC87357B09D653B47FDCE0A3383FF33C8D8B544FE29A8A6",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl"
+          ]
+        },
+        {
+          "denom": "marble",
+          "exponent": 3
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl",
+      "base": "ibc/F6B691D5F7126579DDC87357B09D653B47FDCE0A3383FF33C8D8B544FE29A8A6",
+      "name": "Marble",
+      "display": "marble",
+      "symbol": "MARBLE",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.svg"
+      },
+      "coingecko_id": "marble",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:649"
+      ]
+    },
+    {
+      "description": "The native governance token of Carbon",
+      "denom_units": [
+        {
+          "denom": "ibc/8FEFAE6AECF6E2A255585617F781F35A8D5709A545A804482A261C0C9548A9D3",
+          "exponent": 0,
+          "aliases": [
+            "swth"
+          ]
+        },
+        {
+          "denom": "dswth",
+          "exponent": 8,
+          "aliases": [
+            "SWTH"
+          ]
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/8FEFAE6AECF6E2A255585617F781F35A8D5709A545A804482A261C0C9548A9D3",
+      "name": "Carbon",
+      "display": "dswth",
+      "symbol": "SWTH",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "carbon",
+            "base_denom": "swth",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-188",
+            "path": "transfer/channel-188/swth"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.svg"
+      },
+      "coingecko_id": "switcheo",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:651"
+      ]
+    },
+    {
+      "description": "The native token of Cerberus Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
+          "exponent": 0,
+          "aliases": [
+            "ucrbrus"
+          ]
+        },
+        {
+          "denom": "crbrus",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
+      "name": "Cerberus",
+      "display": "crbrus",
+      "symbol": "CRBRUS",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "cerberus",
+            "base_denom": "ucrbrus",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-212",
+            "path": "transfer/channel-212/ucrbrus"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/images/crbrus.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/images/crbrus.svg"
+      },
+      "coingecko_id": "cerberus-2",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:662"
+      ]
+    },
+    {
+      "description": "The native staking and governance token of the Fetch Hub.",
+      "denom_units": [
+        {
+          "denom": "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
+          "exponent": 0,
+          "aliases": [
+            "afet"
+          ]
+        },
+        {
+          "denom": "fet",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
+      "name": "fetch-ai",
+      "display": "fet",
+      "symbol": "FET",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "fetchhub",
+            "base_denom": "afet",
+            "channel_id": "channel-10"
+          },
+          "chain": {
+            "channel_id": "channel-229",
+            "path": "transfer/channel-229/afet"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.svg"
+      },
+      "coingecko_id": "fetch-ai",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:681"
+      ]
+    },
+    {
+      "description": "The native token of Asset Mantle",
+      "denom_units": [
+        {
+          "denom": "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
+          "exponent": 0,
+          "aliases": [
+            "umntl"
+          ]
+        },
+        {
+          "denom": "mntl",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
+      "name": "AssetMantle",
+      "display": "mntl",
+      "symbol": "MNTL",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "assetmantle",
+            "base_denom": "umntl",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-232",
+            "path": "transfer/channel-232/umntl"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/images/mntl.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/images/mntl.svg"
+      },
+      "coingecko_id": "assetmantle",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:686"
+      ]
+    },
+    {
+      "description": "The native token cw20 for Neta on Juno Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr"
+          ]
+        },
+        {
+          "denom": "neta",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr",
+      "base": "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
+      "name": "Neta",
+      "display": "neta",
+      "symbol": "NETA",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.svg"
+      },
+      "coingecko_id": "neta",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:631"
+      ]
+    },
+    {
+      "description": "The INJ token is the native governance token for the Injective chain.",
+      "denom_units": [
+        {
+          "denom": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
+          "exponent": 0,
+          "aliases": [
+            "inj"
+          ]
+        },
+        {
+          "denom": "INJ",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
+      "name": "Injective",
+      "display": "INJ",
+      "symbol": "INJ",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "injective",
+            "base_denom": "inj",
+            "channel_id": "channel-8"
+          },
+          "chain": {
+            "channel_id": "channel-122",
+            "path": "transfer/channel-122/inj"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg"
+      },
+      "coingecko_id": "injective-protocol",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:725"
+      ]
+    },
+    {
+      "description": "The KRW stablecoin of Terra Classic.",
+      "denom_units": [
+        {
+          "denom": "ibc/204A582244FC241613DBB50B04D1D454116C58C4AF7866C186AA0D6EEAD42780",
+          "exponent": 0,
+          "aliases": [
+            "microkrw",
+            "ukrw"
+          ]
+        },
+        {
+          "denom": "mkrw",
+          "exponent": 3,
+          "aliases": [
+            "millikrw"
+          ]
+        },
+        {
+          "denom": "krt",
+          "exponent": 6,
+          "aliases": [
+            "krtc"
+          ]
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/204A582244FC241613DBB50B04D1D454116C58C4AF7866C186AA0D6EEAD42780",
+      "name": "TerraClassicKRW",
+      "display": "krt",
+      "symbol": "KRTC",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "terra",
+            "base_denom": "ukrw",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-72",
+            "path": "transfer/channel-72/ukrw"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/krt.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/krt.svg"
+      },
+      "coingecko_id": "terrakrw",
+      "keywords": [
+        "osmosis-price:ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC:581"
+      ]
+    },
+    {
+      "description": "TICK coin is the token for the Microtick Price Discovery & Oracle App",
+      "denom_units": [
+        {
+          "denom": "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8",
+          "exponent": 0,
+          "aliases": [
+            "utick"
+          ]
+        },
+        {
+          "denom": "tick",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8",
+      "name": "Microtick",
+      "display": "tick",
+      "symbol": "TICK",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "microtick",
+            "base_denom": "utick",
+            "channel_id": "channel-16"
+          },
+          "chain": {
+            "channel_id": "channel-39",
+            "path": "transfer/channel-39/utick"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:547"
+      ]
+    },
+    {
+      "description": "Rowan Token (ROWAN) is the Sifchain Network's native utility token, used as the primary means to govern, provide liquidity, secure the blockchain, incentivize participants, and provide a default mechanism to store and exchange value.",
+      "denom_units": [
+        {
+          "denom": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
+          "exponent": 0,
+          "aliases": [
+            "rowan"
+          ]
+        },
+        {
+          "denom": "ROWAN",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
+      "name": "Sifchain Rowan",
+      "display": "ROWAN",
+      "symbol": "ROWAN",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "sifchain",
+            "base_denom": "rowan",
+            "channel_id": "channel-17"
+          },
+          "chain": {
+            "channel_id": "channel-47",
+            "path": "transfer/channel-47/rowan"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.svg"
+      },
+      "coingecko_id": "sifchain",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:629"
+      ]
+    },
+    {
+      "description": "The native token of Shentu",
+      "denom_units": [
+        {
+          "denom": "ibc/7ED954CFFFC06EE8419387F3FC688837FF64EF264DE14219935F724EEEDBF8D3",
+          "exponent": 0,
+          "aliases": [
+            "uctk"
+          ]
+        },
+        {
+          "denom": "ctk",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/7ED954CFFFC06EE8419387F3FC688837FF64EF264DE14219935F724EEEDBF8D3",
+      "name": "Shentu",
+      "display": "ctk",
+      "symbol": "CTK",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "shentu",
+            "base_denom": "uctk",
+            "channel_id": "channel-8"
+          },
+          "chain": {
+            "channel_id": "channel-146",
+            "path": "transfer/channel-146/uctk"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/images/ctk.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/images/ctk.svg"
+      },
+      "coingecko_id": "certik",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:1020"
+      ]
+    },
+    {
+      "description": "Hope Galaxy is an NFT collection based on its own native Token $HOPE, a cw20 token on Juno chain.",
+      "denom_units": [
+        {
+          "denom": "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1re3x67ppxap48ygndmrc7har2cnc7tcxtm9nplcas4v0gc3wnmvs3s807z"
+          ]
+        },
+        {
+          "denom": "hope",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1re3x67ppxap48ygndmrc7har2cnc7tcxtm9nplcas4v0gc3wnmvs3s807z",
+      "base": "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B",
+      "name": "Hope Galaxy",
+      "display": "hope",
+      "symbol": "HOPE",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1re3x67ppxap48ygndmrc7har2cnc7tcxtm9nplcas4v0gc3wnmvs3s807z",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1re3x67ppxap48ygndmrc7har2cnc7tcxtm9nplcas4v0gc3wnmvs3s807z"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.svg"
+      },
+      "coingecko_id": "hope-galaxy",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:653"
+      ]
+    },
+    {
+      "description": "Racoon aims to simplify accessibility to AI, NFTs and Gambling on the Cosmos Ecosystem",
+      "denom_units": [
+        {
+          "denom": "ibc/6BDB4C8CCD45033F9604E4B93ED395008A753E01EECD6992E7D1EA23D9D3B788",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa"
+          ]
+        },
+        {
+          "denom": "rac",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa",
+      "base": "ibc/6BDB4C8CCD45033F9604E4B93ED395008A753E01EECD6992E7D1EA23D9D3B788",
+      "name": "Racoon",
+      "display": "rac",
+      "symbol": "RAC",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.svg"
+      },
+      "coingecko_id": "racoon",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:669"
+      ]
+    },
+    {
+      "description": "Frax's fractional-algorithmic stablecoin on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE",
+          "exponent": 0,
+          "aliases": [
+            "frax-wei"
+          ]
+        },
+        {
+          "denom": "frax",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE",
+      "name": "Frax",
+      "display": "frax",
+      "symbol": "FRAX",
+      "traces": [
+        {
+          "type": "synthetic",
+          "counterparty": {
+            "chain_name": "forex",
+            "base_denom": "USD"
+          },
+          "provider": "Frax Protocol"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x853d955acef822db058eb8505911ed77f175b99e"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "frax-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/frax-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/frax.svg"
+      },
+      "keywords": [
+        "osmosis-info",
+        "osmosis-price:ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858:679"
+      ]
+    },
+    {
+      "description": "Gravity Bridge WBTC",
+      "denom_units": [
+        {
+          "denom": "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796",
+          "exponent": 0,
+          "aliases": [
+            "gravity0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+          ]
+        },
+        {
+          "denom": "gwbtc",
+          "exponent": 8
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796",
+      "name": "Wrapped Bitcoin",
+      "display": "gwbtc",
+      "symbol": "WBTC.grv",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "bitcoin",
+            "base_denom": "sat"
+          },
+          "provider": "BitGo, Kyber, and Ren"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
+          },
+          "provider": "Gravity Bridge"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gravitybridge",
+            "base_denom": "gravity0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+            "channel_id": "channel-10"
+          },
+          "chain": {
+            "channel_id": "channel-144",
+            "path": "transfer/channel-144/gravity0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/wbtc.grv.svg"
+      },
+      "keywords": [
+        "osmosis-price:ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:694"
+      ]
+    },
+    {
+      "description": "Gravity Bridge WETH",
+      "denom_units": [
+        {
+          "denom": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
+          "exponent": 0,
+          "aliases": [
+            "gravity0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+          ]
+        },
+        {
+          "denom": "gweth",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
+      "name": "Wrapped Ethereum",
+      "display": "gweth",
+      "symbol": "WETH.grv",
+      "traces": [
+        {
+          "type": "wrapped",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "wei"
+          },
+          "provider": "Ethereum"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+          },
+          "provider": "Gravity Bridge"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gravitybridge",
+            "base_denom": "gravity0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+            "channel_id": "channel-10"
+          },
+          "chain": {
+            "channel_id": "channel-144",
+            "path": "transfer/channel-144/gravity0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/weth.grv.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:634"
+      ]
+    },
+    {
+      "description": "Gravity Bridge USDC",
+      "denom_units": [
+        {
+          "denom": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
+          "exponent": 0,
+          "aliases": [
+            "gravity0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+          ]
+        },
+        {
+          "denom": "gusdc",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
+      "name": "USD Coin",
+      "display": "gusdc",
+      "symbol": "USDC.grv",
+      "traces": [
+        {
+          "type": "synthetic",
+          "counterparty": {
+            "chain_name": "forex",
+            "base_denom": "USD"
+          },
+          "provider": "Circle"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+          },
+          "provider": "Gravity Bridge"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gravitybridge",
+            "base_denom": "gravity0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            "channel_id": "channel-10"
+          },
+          "chain": {
+            "channel_id": "channel-144",
+            "path": "transfer/channel-144/gravity0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.grv.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858:872"
+      ]
+    },
+    {
+      "description": "Gravity Bridge DAI",
+      "denom_units": [
+        {
+          "denom": "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5",
+          "exponent": 0,
+          "aliases": [
+            "gravity0x6B175474E89094C44Da98b954EedeAC495271d0F"
+          ]
+        },
+        {
+          "denom": "gdai",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5",
+      "name": "Dai Stablecoin",
+      "display": "gdai",
+      "symbol": "DAI.grv",
+      "traces": [
+        {
+          "type": "synthetic",
+          "counterparty": {
+            "chain_name": "forex",
+            "base_denom": "USD"
+          },
+          "provider": "MakerDAO"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x6b175474e89094c44da98b954eedeac495271d0f"
+          },
+          "provider": "Gravity Bridge"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gravitybridge",
+            "base_denom": "gravity0x6B175474E89094C44Da98b954EedeAC495271d0F",
+            "channel_id": "channel-10"
+          },
+          "chain": {
+            "channel_id": "channel-144",
+            "path": "transfer/channel-144/gravity0x6B175474E89094C44Da98b954EedeAC495271d0F"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/dai.grv.svg"
+      },
+      "keywords": [
+        "osmosis-price:ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858:702"
+      ]
+    },
+    {
+      "description": "Gravity Bridge USDT",
+      "denom_units": [
+        {
+          "denom": "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
+          "exponent": 0,
+          "aliases": [
+            "gravity0xdAC17F958D2ee523a2206206994597C13D831ec7"
+          ]
+        },
+        {
+          "denom": "gusdt",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
+      "name": "Tether USD",
+      "display": "gusdt",
+      "symbol": "USDT.grv",
+      "traces": [
+        {
+          "type": "synthetic",
+          "counterparty": {
+            "chain_name": "forex",
+            "base_denom": "USD"
+          },
+          "provider": "Tether"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+          },
+          "provider": "Gravity Bridge"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gravitybridge",
+            "base_denom": "gravity0xdAC17F958D2ee523a2206206994597C13D831ec7",
+            "channel_id": "channel-10"
+          },
+          "chain": {
+            "channel_id": "channel-144",
+            "path": "transfer/channel-144/gravity0xdAC17F958D2ee523a2206206994597C13D831ec7"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdt.grv.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4:873"
+      ]
+    },
+    {
+      "description": "The native token of Marble DEX on Juno Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/DB9755CB6FE55192948AE074D18FA815E1429D3D374D5BDA8D89623C6CF235C3",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq"
+          ]
+        },
+        {
+          "denom": "block",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
+      "base": "ibc/DB9755CB6FE55192948AE074D18FA815E1429D3D374D5BDA8D89623C6CF235C3",
+      "name": "Block",
+      "display": "block",
+      "symbol": "BLOCK",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/block.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/block.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:691"
+      ]
+    },
+    {
+      "description": "Hash is the staking token of the Provenance Blockchain",
+      "denom_units": [
+        {
+          "denom": "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
+          "exponent": 0,
+          "aliases": [
+            "nhash"
+          ]
+        },
+        {
+          "denom": "hash",
+          "exponent": 9
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
+      "name": "Hash",
+      "display": "hash",
+      "symbol": "HASH",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "provenance",
+            "base_denom": "nhash",
+            "channel_id": "channel-7"
+          },
+          "chain": {
+            "channel_id": "channel-222",
+            "path": "transfer/channel-222/nhash"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/prov.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/prov.svg"
+      },
+      "coingecko_id": "provenance-blockchain",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:693"
+      ]
+    },
+    {
+      "description": "GLX is the staking token of the Galaxy Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
+          "exponent": 0,
+          "aliases": [
+            "uglx"
+          ]
+        },
+        {
+          "denom": "glx",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
+      "name": "Galaxy",
+      "display": "glx",
+      "symbol": "GLX",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "galaxy",
+            "base_denom": "uglx",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-236",
+            "path": "transfer/channel-236/uglx"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/galaxy/images/glx.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/galaxy/images/glx.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:697"
+      ]
+    },
+    {
+      "description": "The DAO token to build consensus among Hong Kong People",
+      "denom_units": [
+        {
+          "denom": "ibc/52E12CF5CA2BB903D84F5298B4BFD725D66CAB95E09AA4FC75B2904CA5485FEB",
+          "exponent": 0,
+          "aliases": [
+            "dhk",
+            "cw20:juno1tdjwrqmnztn2j3sj2ln9xnyps5hs48q3ddwjrz7jpv6mskappjys5czd49"
+          ]
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1tdjwrqmnztn2j3sj2ln9xnyps5hs48q3ddwjrz7jpv6mskappjys5czd49",
+      "base": "ibc/52E12CF5CA2BB903D84F5298B4BFD725D66CAB95E09AA4FC75B2904CA5485FEB",
+      "name": "DHK",
+      "display": "dhk",
+      "symbol": "DHK",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1tdjwrqmnztn2j3sj2ln9xnyps5hs48q3ddwjrz7jpv6mskappjys5czd49",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1tdjwrqmnztn2j3sj2ln9xnyps5hs48q3ddwjrz7jpv6mskappjys5czd49"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/dhk.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/dhk.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:695"
+      ]
+    },
+    {
+      "description": "Token governance for Junoswap",
+      "denom_units": [
+        {
+          "denom": "ibc/00B6E60AD3D65CBEF5579AC8AF609527C0B57535B6E32D96C80A735344FD9DCC",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g"
+          ]
+        },
+        {
+          "denom": "raw",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g",
+      "base": "ibc/00B6E60AD3D65CBEF5579AC8AF609527C0B57535B6E32D96C80A735344FD9DCC",
+      "name": "JunoSwap",
+      "display": "raw",
+      "symbol": "RAW",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/raw.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/raw.svg"
+      },
+      "coingecko_id": "junoswap-raw-dao",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7:699"
+      ]
+    },
+    {
+      "description": "MEME Token (MEME) is the native staking token of the MEME Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/67C89B8B0A70C08F093C909A4DD996DD10E0494C87E28FD9A551697BF173D4CA",
+          "exponent": 0,
+          "aliases": [
+            "umeme"
+          ]
+        },
+        {
+          "denom": "meme",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/67C89B8B0A70C08F093C909A4DD996DD10E0494C87E28FD9A551697BF173D4CA",
+      "name": "MEME",
+      "display": "meme",
+      "symbol": "MEME",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "meme",
+            "base_denom": "umeme",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-238",
+            "path": "transfer/channel-238/umeme"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/meme/images/meme.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/meme/images/meme.svg"
+      },
+      "coingecko_id": "meme-network",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:701"
+      ]
+    },
+    {
+      "description": "Profit sharing token for Another.Software validator. Hold and receive dividends from Another.Software validator commissions!",
+      "denom_units": [
+        {
+          "denom": "ibc/AA1C80225BCA7B32ED1FC6ABF8B8E899BEB48ECDB4B417FD69873C6D715F97E7",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno17wzaxtfdw5em7lc94yed4ylgjme63eh73lm3lutp2rhcxttyvpwsypjm4w"
+          ]
+        },
+        {
+          "denom": "asvt",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno17wzaxtfdw5em7lc94yed4ylgjme63eh73lm3lutp2rhcxttyvpwsypjm4w",
+      "base": "ibc/AA1C80225BCA7B32ED1FC6ABF8B8E899BEB48ECDB4B417FD69873C6D715F97E7",
+      "name": "Another.Software Validator Token",
+      "display": "asvt",
+      "symbol": "ASVT",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno17wzaxtfdw5em7lc94yed4ylgjme63eh73lm3lutp2rhcxttyvpwsypjm4w",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno17wzaxtfdw5em7lc94yed4ylgjme63eh73lm3lutp2rhcxttyvpwsypjm4w"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/asvt.png"
+      },
+      "keywords": [
+        "osmosis-price:ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:771"
+      ]
+    },
+    {
+      "description": "DAO dedicated to building tools on the Juno Network",
+      "denom_units": [
+        {
+          "denom": "ibc/0CB9DB3441D0D50F35699DEE22B9C965487E83FB2D9F483D1CC5CA34E856C484",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1n7n7d5088qlzlj37e9mgmkhx6dfgtvt02hqxq66lcap4dxnzdhwqfmgng3"
+          ]
+        },
+        {
+          "denom": "joe",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1n7n7d5088qlzlj37e9mgmkhx6dfgtvt02hqxq66lcap4dxnzdhwqfmgng3",
+      "base": "ibc/0CB9DB3441D0D50F35699DEE22B9C965487E83FB2D9F483D1CC5CA34E856C484",
+      "name": "JoeDAO",
+      "display": "joe",
+      "symbol": "JOE",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1n7n7d5088qlzlj37e9mgmkhx6dfgtvt02hqxq66lcap4dxnzdhwqfmgng3",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1n7n7d5088qlzlj37e9mgmkhx6dfgtvt02hqxq66lcap4dxnzdhwqfmgng3"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/joe.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:718"
+      ]
+    },
+    {
+      "description": "The native staking token of Terra.",
+      "denom_units": [
+        {
+          "denom": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
+          "exponent": 0,
+          "aliases": [
+            "uluna"
+          ]
+        },
+        {
+          "denom": "luna",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
+      "name": "Luna",
+      "display": "luna",
+      "symbol": "LUNA",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "terra2",
+            "base_denom": "uluna",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-251",
+            "path": "transfer/channel-251/uluna"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.svg"
+      },
+      "coingecko_id": "terra-luna-2",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:726"
+      ]
+    },
+    {
+      "description": "Native token of Rizon Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/2716E3F2E146664BEFA9217F1A03BFCEDBCD5178B3C71CACB1A0D7584451D219",
+          "exponent": 0,
+          "aliases": [
+            "uatolo"
+          ]
+        },
+        {
+          "denom": "atolo",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/2716E3F2E146664BEFA9217F1A03BFCEDBCD5178B3C71CACB1A0D7584451D219",
+      "name": "Rizon Chain",
+      "display": "atolo",
+      "symbol": "ATOLO",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "rizon",
+            "base_denom": "uatolo",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-221",
+            "path": "transfer/channel-221/uatolo"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.svg"
+      },
+      "coingecko_id": "rizon",
+      "keywords": [
+        "osmosis-price:uosmo:729"
+      ]
+    },
+    {
+      "description": "Governance token of Kava Lend Protocol",
+      "denom_units": [
+        {
+          "denom": "ibc/D6C28E07F7343360AC41E15DDD44D79701DDCA2E0C2C41279739C8D4AE5264BC",
+          "exponent": 0,
+          "aliases": [
+            "hard"
+          ]
+        },
+        {
+          "denom": "HARD",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/D6C28E07F7343360AC41E15DDD44D79701DDCA2E0C2C41279739C8D4AE5264BC",
+      "name": "Hard",
+      "display": "HARD",
+      "symbol": "HARD",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "kava",
+            "base_denom": "hard",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-143",
+            "path": "transfer/channel-143/hard"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.svg"
+      },
+      "coingecko_id": "kava-lend"
+    },
+    {
+      "description": "Governance token of Kava Swap Protocol",
+      "denom_units": [
+        {
+          "denom": "ibc/70CF1A54E23EA4E480DEDA9E12082D3FD5684C3483CBDCE190C5C807227688C5",
+          "exponent": 0,
+          "aliases": [
+            "swp"
+          ]
+        },
+        {
+          "denom": "SWP",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/70CF1A54E23EA4E480DEDA9E12082D3FD5684C3483CBDCE190C5C807227688C5",
+      "name": "Swap",
+      "display": "SWP",
+      "symbol": "SWP",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "kava",
+            "base_denom": "swp",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-143",
+            "path": "transfer/channel-143/swp"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.svg"
+      },
+      "coingecko_id": "kava-swap"
+    },
+    {
+      "description": "Chainlink on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
+          "exponent": 0,
+          "aliases": [
+            "link-wei"
+          ]
+        },
+        {
+          "denom": "link",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
+      "name": "Chainlink",
+      "display": "link",
+      "symbol": "LINK",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x514910771af9ca656af840dff83e8264ecf986ca"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "link-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/link-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/link.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/link.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:731"
+      ]
+    },
+    {
+      "description": "L1 coin is the GenesisL1 blockchain utility, governance and EVM token",
+      "denom_units": [
+        {
+          "denom": "ibc/F16FDC11A7662B86BC0B9CE61871CBACF7C20606F95E86260FD38915184B75B4",
+          "exponent": 0,
+          "aliases": [
+            "el1"
+          ]
+        },
+        {
+          "denom": "l1",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/F16FDC11A7662B86BC0B9CE61871CBACF7C20606F95E86260FD38915184B75B4",
+      "name": "GenesisL1",
+      "display": "l1",
+      "symbol": "L1",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "genesisl1",
+            "base_denom": "el1",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-253",
+            "path": "transfer/channel-253/el1"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/genesisl1/images/l1.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/genesisl1/images/l1.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:732"
+      ]
+    },
+    {
+      "description": "Aave on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/384E5DD50BDE042E1AAF51F312B55F08F95BC985C503880189258B4D9374CBBE",
+          "exponent": 0,
+          "aliases": [
+            "aave-wei"
+          ]
+        },
+        {
+          "denom": "aave",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/384E5DD50BDE042E1AAF51F312B55F08F95BC985C503880189258B4D9374CBBE",
+      "name": "Aave",
+      "display": "aave",
+      "symbol": "AAVE",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "aave-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/aave-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/aave.svg"
+      }
+    },
+    {
+      "description": "ApeCoin on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/F83CC6471DA4D4B508F437244F10B9E4C68975344E551A2DEB6B8617AB08F0D4",
+          "exponent": 0,
+          "aliases": [
+            "ape-wei"
+          ]
+        },
+        {
+          "denom": "ape",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/F83CC6471DA4D4B508F437244F10B9E4C68975344E551A2DEB6B8617AB08F0D4",
+      "name": "ApeCoin",
+      "display": "ape",
+      "symbol": "APE",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x4d224452801aced8b2f0aebe155379bb5d594381"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "ape-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/ape-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/ape.svg"
+      }
+    },
+    {
+      "description": "Axie Infinity Shard on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/6C0CB8653012DC2BC1820FD0B6B3AFF8A07D18630BDAEE066FEFB2D92F477C24",
+          "exponent": 0,
+          "aliases": [
+            "axs-wei"
+          ]
+        },
+        {
+          "denom": "axs",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/6C0CB8653012DC2BC1820FD0B6B3AFF8A07D18630BDAEE066FEFB2D92F477C24",
+      "name": "Axie Infinity Shard",
+      "display": "axs",
+      "symbol": "AXS",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "axs-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/axs-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/axs.svg"
+      }
+    },
+    {
+      "description": "Maker on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3",
+          "exponent": 0,
+          "aliases": [
+            "mkr-wei"
+          ]
+        },
+        {
+          "denom": "mkr",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3",
+      "name": "Maker",
+      "display": "mkr",
+      "symbol": "MKR",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "mkr-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/mkr-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/mkr.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:733"
+      ]
+    },
+    {
+      "description": "Rai Reflex Index on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/BD796662F8825327D41C96355DF62045A5BA225BAE31C0A86289B9D88ED3F44E",
+          "exponent": 0,
+          "aliases": [
+            "rai-wei"
+          ]
+        },
+        {
+          "denom": "rai",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/BD796662F8825327D41C96355DF62045A5BA225BAE31C0A86289B9D88ED3F44E",
+      "name": "Rai Reflex Index",
+      "display": "rai",
+      "symbol": "RAI",
+      "traces": [
+        {
+          "type": "synthetic",
+          "counterparty": {
+            "chain_name": "forex",
+            "base_denom": "USD"
+          },
+          "provider": "RAI Finance"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x03ab458634910aad20ef5f1c8ee96f1d6ac54919"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "rai-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/rai-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/rai.svg"
+      }
+    },
+    {
+      "description": "Shiba Inu on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/19305E20681911F14D1FB275E538CDE524C3BF88CF9AE5D5F78F4D4DA05E85B2",
+          "exponent": 0,
+          "aliases": [
+            "shib-wei"
+          ]
+        },
+        {
+          "denom": "shib",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/19305E20681911F14D1FB275E538CDE524C3BF88CF9AE5D5F78F4D4DA05E85B2",
+      "name": "Shiba Inu",
+      "display": "shib",
+      "symbol": "SHIB",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "shib-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/shib-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/shib.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:880"
+      ]
+    },
+    {
+      "description": "Uniswap on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/AE2719773D6FCDD05AC17B1ED63F672F5F9D84144A61965F348C86C2A83AD161",
+          "exponent": 0,
+          "aliases": [
+            "uni-wei"
+          ]
+        },
+        {
+          "denom": "uni",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/AE2719773D6FCDD05AC17B1ED63F672F5F9D84144A61965F348C86C2A83AD161",
+      "name": "Uniswap",
+      "display": "uni",
+      "symbol": "UNI",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "uni-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/uni-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/uni.svg"
+      }
+    },
+    {
+      "description": "Chain on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/B901BEC1B71D0573E6EE874FEC39E2DF4C2BDB1DB74CB3DA0A9CACC4A435B0EC",
+          "exponent": 0,
+          "aliases": [
+            "xcn-wei"
+          ]
+        },
+        {
+          "denom": "xcn",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/B901BEC1B71D0573E6EE874FEC39E2DF4C2BDB1DB74CB3DA0A9CACC4A435B0EC",
+      "name": "Chain",
+      "display": "xcn",
+      "symbol": "XCN",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xa2cd3d43c775978a96bdbf12d733d5a1ed94fb18"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "xcn-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/xcn-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/xcn.svg"
+      }
+    },
+    {
+      "description": "The native staking and governance token of the Kujira chain.",
+      "denom_units": [
+        {
+          "denom": "ibc/BB6BCDB515050BAE97516111873CCD7BCF1FD0CCB723CC12F3C4F704D6C646CE",
+          "exponent": 0,
+          "aliases": [
+            "ukuji"
+          ]
+        },
+        {
+          "denom": "kuji",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/BB6BCDB515050BAE97516111873CCD7BCF1FD0CCB723CC12F3C4F704D6C646CE",
+      "name": "Kuji",
+      "display": "kuji",
+      "symbol": "KUJI",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "kujira",
+            "base_denom": "ukuji",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-259",
+            "path": "transfer/channel-259/ukuji"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.svg"
+      },
+      "coingecko_id": "kujira",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:744"
+      ]
+    },
+    {
+      "description": "The native token of Tgrade",
+      "denom_units": [
+        {
+          "denom": "ibc/1E09CB0F506ACF12FDE4683FB6B34DA62FB4BE122641E0D93AAF98A87675676C",
+          "exponent": 0,
+          "aliases": [
+            "utgd"
+          ]
+        },
+        {
+          "denom": "tgd",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/1E09CB0F506ACF12FDE4683FB6B34DA62FB4BE122641E0D93AAF98A87675676C",
+      "name": "Tgrade",
+      "display": "tgd",
+      "symbol": "TGD",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "tgrade",
+            "base_denom": "utgd",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-263",
+            "path": "transfer/channel-263/utgd"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/tgrade/images/tgrade-symbol-gradient.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/tgrade/images/tgrade-symbol-gradient.svg"
+      },
+      "coingecko_id": "tgrade",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:769"
+      ]
+    },
+    {
+      "description": "Echelon - a scalable EVM on Cosmos, built on Proof-of-Stake with fast-finality that prioritizes interoperability and novel economics",
+      "denom_units": [
+        {
+          "denom": "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
+          "exponent": 0,
+          "aliases": [
+            "aechelon"
+          ]
+        },
+        {
+          "denom": "echelon",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
+      "name": "Echelon",
+      "display": "echelon",
+      "symbol": "ECH",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "echelon",
+            "base_denom": "aechelon",
+            "channel_id": "channel-11"
+          },
+          "chain": {
+            "channel_id": "channel-403",
+            "path": "transfer/channel-403/aechelon"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/ech.svg"
+      },
+      "coingecko_id": "echelon",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:848"
+      ]
+    },
+    {
+      "description": "Staking and goverance token for ODIN Protocol",
+      "denom_units": [
+        {
+          "denom": "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
+          "exponent": 0,
+          "aliases": [
+            "loki"
+          ]
+        },
+        {
+          "denom": "odin",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
+      "name": "ODIN",
+      "display": "odin",
+      "symbol": "ODIN",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "odin",
+            "base_denom": "loki",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-258",
+            "path": "transfer/channel-258/loki"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.svg"
+      },
+      "coingecko_id": "odin-protocol",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:777"
+      ]
+    },
+    {
+      "description": "GEO token for ODIN Protocol",
+      "denom_units": [
+        {
+          "denom": "ibc/9B6FBABA36BB4A3BF127AE5E96B572A5197FD9F3111D895D8919B07BC290764A",
+          "exponent": 0,
+          "aliases": [
+            "mGeo"
+          ]
+        },
+        {
+          "denom": "geo",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/9B6FBABA36BB4A3BF127AE5E96B572A5197FD9F3111D895D8919B07BC290764A",
+      "name": "GEO",
+      "display": "geo",
+      "symbol": "GEO",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "odin",
+            "base_denom": "mGeo",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-258",
+            "path": "transfer/channel-258/mGeo"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/geo.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/geo.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:787"
+      ]
+    },
+    {
+      "description": "O9W token for ODIN Protocol",
+      "denom_units": [
+        {
+          "denom": "ibc/0CD46223FEABD2AEAAAF1F057D01E63BCA79B7D4BD6B68F1EB973A987344695D",
+          "exponent": 0,
+          "aliases": [
+            "mO9W"
+          ]
+        },
+        {
+          "denom": "O9W",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/0CD46223FEABD2AEAAAF1F057D01E63BCA79B7D4BD6B68F1EB973A987344695D",
+      "name": "O9W",
+      "display": "O9W",
+      "symbol": "O9W",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "odin",
+            "base_denom": "mO9W",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-258",
+            "path": "transfer/channel-258/mO9W"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/o9w.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/o9w.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:805"
+      ]
+    },
+    {
+      "description": "ELEVENPARIS loyalty token on KiChain",
+      "denom_units": [
+        {
+          "denom": "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
+          "exponent": 0,
+          "aliases": [
+            "cw20:ki1dt3lk455ed360pna38fkhqn0p8y44qndsr77qu73ghyaz2zv4whq83mwdy"
+          ]
+        },
+        {
+          "denom": "lvn",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "ki1dt3lk455ed360pna38fkhqn0p8y44qndsr77qu73ghyaz2zv4whq83mwdy",
+      "base": "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
+      "name": "LVN",
+      "display": "lvn",
+      "symbol": "LVN",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "kichain",
+            "base_denom": "cw20:ki1dt3lk455ed360pna38fkhqn0p8y44qndsr77qu73ghyaz2zv4whq83mwdy",
+            "port": "wasm.ki1hzz0s0ucrhdp6tue2lxk3c03nj6f60qy463we7lgx0wudd72ctmsd9kgha",
+            "channel_id": "channel-18"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-261",
+            "path": "transfer/channel-261/cw20:ki1dt3lk455ed360pna38fkhqn0p8y44qndsr77qu73ghyaz2zv4whq83mwdy"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/lvn.png"
+      },
+      "coingecko_id": "lvn",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E:772"
+      ]
+    },
+    {
+      "description": "Wrapped Moonbeam on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",
+          "exponent": 0,
+          "aliases": [
+            "wglmr-wei"
+          ]
+        },
+        {
+          "denom": "wglmr",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",
+      "name": "Wrapped Moonbeam",
+      "display": "wglmr",
+      "symbol": "GLMR",
+      "traces": [
+        {
+          "type": "wrapped",
+          "counterparty": {
+            "chain_name": "moonbeam",
+            "base_denom": "Wei"
+          },
+          "provider": "Moonbeam"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "moonbeam",
+            "base_denom": "0xacc15dc74880c9944775448304b263d191c6077f"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "wglmr-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/wglmr-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/moonbeam/images/glmr.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/moonbeam/images/glmr.svg"
+      },
+      "keywords": [
+        "osmosis-price:uosmo:825"
+      ]
+    },
+    {
+      "description": "DeFi gaming platform built on Juno",
+      "denom_units": [
+        {
+          "denom": "ibc/52C57FCA7D6854AA178E7A183DDBE4EF322B904B1D719FC485F6FFBC1F72A19E",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se"
+          ]
+        },
+        {
+          "denom": "glto",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se",
+      "base": "ibc/52C57FCA7D6854AA178E7A183DDBE4EF322B904B1D719FC485F6FFBC1F72A19E",
+      "name": "Gelotto",
+      "display": "glto",
+      "symbol": "GLTO",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/glto.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/glto.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:778"
+      ]
+    },
+    {
+      "description": "Gelotto Year 1 Grand Prize Token",
+      "denom_units": [
+        {
+          "denom": "ibc/7C781B4C2082CD62129A972D47486D78EC17155C299270E3C89348EA026BEAF8",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1gz8cf86zr4vw9cjcyyv432vgdaecvr9n254d3uwwkx9rermekddsxzageh"
+          ]
+        },
+        {
+          "denom": "gkey",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1gz8cf86zr4vw9cjcyyv432vgdaecvr9n254d3uwwkx9rermekddsxzageh",
+      "base": "ibc/7C781B4C2082CD62129A972D47486D78EC17155C299270E3C89348EA026BEAF8",
+      "name": "GKey",
+      "display": "gkey",
+      "symbol": "GKEY",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1gz8cf86zr4vw9cjcyyv432vgdaecvr9n254d3uwwkx9rermekddsxzageh",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1gz8cf86zr4vw9cjcyyv432vgdaecvr9n254d3uwwkx9rermekddsxzageh"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/gkey.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/gkey.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:790"
+      ]
+    },
+    {
+      "description": "The native token of Crescent",
+      "denom_units": [
+        {
+          "denom": "ibc/5A7C219BA5F7582B99629BA3B2A01A61BFDA0F6FD1FE95B5366F7334C4BC0580",
+          "exponent": 0,
+          "aliases": [
+            "ucre"
+          ]
+        },
+        {
+          "denom": "cre",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/5A7C219BA5F7582B99629BA3B2A01A61BFDA0F6FD1FE95B5366F7334C4BC0580",
+      "name": "Crescent",
+      "display": "cre",
+      "symbol": "CRE",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "crescent",
+            "base_denom": "ucre",
+            "channel_id": "channel-9"
+          },
+          "chain": {
+            "channel_id": "channel-297",
+            "path": "transfer/channel-297/ucre"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.svg"
+      },
+      "coingecko_id": "crescent-network",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:786"
+      ]
+    },
+    {
+      "description": "The native token of LumenX Network",
+      "denom_units": [
+        {
+          "denom": "ibc/FFA652599C77E853F017193E36B5AB2D4D9AFC4B54721A74904F80C9236BF3B7",
+          "exponent": 0,
+          "aliases": [
+            "ulumen"
+          ]
+        },
+        {
+          "denom": "lumen",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/FFA652599C77E853F017193E36B5AB2D4D9AFC4B54721A74904F80C9236BF3B7",
+      "name": "LUMEN",
+      "display": "lumen",
+      "symbol": "LUMEN",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "lumenx",
+            "base_denom": "ulumen",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-286",
+            "path": "transfer/channel-286/ulumen"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumenx/images/lumen.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumenx/images/lumen.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:788"
+      ]
+    },
+    {
+      "description": "The native token of Oraichain",
+      "denom_units": [
+        {
+          "denom": "ibc/161D7D62BAB3B9C39003334F1671208F43C06B643CC9EDBBE82B64793C857F1D",
+          "exponent": 0,
+          "aliases": [
+            "orai"
+          ]
+        },
+        {
+          "denom": "ORAI",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/161D7D62BAB3B9C39003334F1671208F43C06B643CC9EDBBE82B64793C857F1D",
+      "name": "Oraichain",
+      "display": "ORAI",
+      "symbol": "ORAI",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "oraichain",
+            "base_denom": "orai",
+            "channel_id": "channel-13"
+          },
+          "chain": {
+            "channel_id": "channel-216",
+            "path": "transfer/channel-216/orai"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.svg"
+      },
+      "coingecko_id": "oraichain-token",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:799"
+      ]
+    },
+    {
+      "description": "The native token of the Cudos blockchain",
+      "denom_units": [
+        {
+          "denom": "ibc/E09ED39F390EC51FA9F3F69BEA08B5BBE6A48B3057B2B1C3467FAAE9E58B021B",
+          "exponent": 0,
+          "aliases": [
+            "attocudos",
+            "acudos"
+          ]
+        },
+        {
+          "denom": "cudos",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/E09ED39F390EC51FA9F3F69BEA08B5BBE6A48B3057B2B1C3467FAAE9E58B021B",
+      "name": "Cudos",
+      "display": "cudos",
+      "symbol": "CUDOS",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "cudos",
+            "base_denom": "acudos",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-298",
+            "path": "transfer/channel-298/acudos"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.svg"
+      },
+      "coingecko_id": "cudos",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:796"
+      ]
+    },
+    {
+      "description": "The native stablecoin of Kava",
+      "denom_units": [
+        {
+          "denom": "ibc/C78F65E1648A3DFE0BAEB6C4CDA69CC2A75437F1793C0E6386DFDA26393790AE",
+          "exponent": 0,
+          "aliases": [
+            "usdx"
+          ]
+        },
+        {
+          "denom": "USDX",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/C78F65E1648A3DFE0BAEB6C4CDA69CC2A75437F1793C0E6386DFDA26393790AE",
+      "name": "USDX",
+      "display": "USDX",
+      "symbol": "USDX",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "kava",
+            "base_denom": "usdx",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-143",
+            "path": "transfer/channel-143/usdx"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/usdx.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/usdx.svg"
+      },
+      "coingecko_id": "usdx",
+      "keywords": [
+        "osmosis-price:ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858:792"
+      ]
+    },
+    {
+      "description": "BLD is the token used to secure the Agoric chain through staking and to backstop Inter Protocol.",
+      "denom_units": [
+        {
+          "denom": "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
+          "exponent": 0,
+          "aliases": [
+            "ubld"
+          ]
+        },
+        {
+          "denom": "bld",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
+      "name": "Agoric",
+      "display": "bld",
+      "symbol": "BLD",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "agoric",
+            "base_denom": "ubld",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-320",
+            "path": "transfer/channel-320/ubld"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/bld.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/bld.svg"
+      },
+      "coingecko_id": "agoric",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:795"
+      ]
+    },
+    {
+      "description": "IST is the stable token used by the Agoric chain for execution fees and commerce.",
+      "denom_units": [
+        {
+          "denom": "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
+          "exponent": 0,
+          "aliases": [
+            "uist"
+          ]
+        },
+        {
+          "denom": "ist",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
+      "name": "Inter Stable Token",
+      "display": "ist",
+      "symbol": "IST",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "agoric",
+            "base_denom": "uist",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-320",
+            "path": "transfer/channel-320/uist"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/ist.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/ist.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:837"
+      ]
+    },
+    {
+      "description": "Staking derivative seJUNO for staked JUNO",
+      "denom_units": [
+        {
+          "denom": "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv"
+          ]
+        },
+        {
+          "denom": "sejuno",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
+      "base": "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B",
+      "name": "StakeEasy seJUNO",
+      "display": "sejuno",
+      "symbol": "SEJUNO",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.svg"
+      },
+      "coingecko_id": "stakeeasy-juno-derivative",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED:807"
+      ]
+    },
+    {
+      "description": "Staking derivative bJUNO for staked JUNO",
+      "denom_units": [
+        {
+          "denom": "ibc/C2DF5C3949CA835B221C575625991F09BAB4E48FB9C11A4EE357194F736111E3",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3"
+          ]
+        },
+        {
+          "denom": "bjuno",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
+      "base": "ibc/C2DF5C3949CA835B221C575625991F09BAB4E48FB9C11A4EE357194F736111E3",
+      "name": "StakeEasy bJUNO",
+      "display": "bjuno",
+      "symbol": "BJUNO",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.svg"
+      },
+      "coingecko_id": "stakeeasy-bjuno"
+    },
+    {
+      "description": "The native token of Stride",
+      "denom_units": [
+        {
+          "denom": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
+          "exponent": 0,
+          "aliases": [
+            "ustrd"
+          ]
+        },
+        {
+          "denom": "strd",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
+      "name": "Stride",
+      "display": "strd",
+      "symbol": "STRD",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "stride",
+            "base_denom": "ustrd",
+            "channel_id": "channel-5"
+          },
+          "chain": {
+            "channel_id": "channel-326",
+            "path": "transfer/channel-326/ustrd"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg"
+      },
+      "coingecko_id": "stride",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:806"
+      ]
+    },
+    {
+      "description": "The native staking and governance token of the Cosmos Hub.",
+      "denom_units": [
+        {
+          "denom": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
+          "exponent": 0,
+          "aliases": [
+            "stuatom"
+          ]
+        },
+        {
+          "denom": "statom",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
+      "name": "stATOM",
+      "display": "statom",
+      "symbol": "stATOM",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "cosmoshub",
+            "base_denom": "uatom"
+          },
+          "provider": "Stride"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "stride",
+            "base_denom": "stuatom",
+            "channel_id": "channel-5"
+          },
+          "chain": {
+            "channel_id": "channel-326",
+            "path": "transfer/channel-326/stuatom"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg"
+      },
+      "coingecko_id": "stride-staked-atom",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:803"
+      ]
+    },
+    {
+      "description": "The native token of Stargaze",
+      "denom_units": [
+        {
+          "denom": "ibc/5DD1F95ED336014D00CE2520977EC71566D282F9749170ADC83A392E0EA7426A",
+          "exponent": 0,
+          "aliases": [
+            "stustars"
+          ]
+        },
+        {
+          "denom": "ststars",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/5DD1F95ED336014D00CE2520977EC71566D282F9749170ADC83A392E0EA7426A",
+      "name": "stSTARS",
+      "display": "ststars",
+      "symbol": "stSTARS",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "stargaze",
+            "base_denom": "ustars"
+          },
+          "provider": "Stride"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "stride",
+            "base_denom": "stustars",
+            "channel_id": "channel-5"
+          },
+          "chain": {
+            "channel_id": "channel-326",
+            "path": "transfer/channel-326/stustars"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/ststars.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/ststars.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4:810"
+      ]
+    },
+    {
+      "description": "Solarbank DAO Governance Token for speeding up the shift to renewable and green energy",
+      "denom_units": [
+        {
+          "denom": "ibc/C3FC4DED273E7D1DD2E7BAA3317EC9A53CD3252B577AA33DC00D9DF2BDF3ED5C",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno159q8t5g02744lxq8lfmcn6f78qqulq9wn3y9w7lxjgkz4e0a6kvsfvapse"
+          ]
+        },
+        {
+          "denom": "solar",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno159q8t5g02744lxq8lfmcn6f78qqulq9wn3y9w7lxjgkz4e0a6kvsfvapse",
+      "base": "ibc/C3FC4DED273E7D1DD2E7BAA3317EC9A53CD3252B577AA33DC00D9DF2BDF3ED5C",
+      "name": "Solarbank DAO",
+      "display": "solar",
+      "symbol": "SOLAR",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno159q8t5g02744lxq8lfmcn6f78qqulq9wn3y9w7lxjgkz4e0a6kvsfvapse",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno159q8t5g02744lxq8lfmcn6f78qqulq9wn3y9w7lxjgkz4e0a6kvsfvapse"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:941"
+      ]
+    },
+    {
+      "description": "StakeEasy governance token",
+      "denom_units": [
+        {
+          "denom": "ibc/18A676A074F73B9B42DA4F9DFC8E5AEF334C9A6636DDEC8D34682F52F1DECDF6",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf"
+          ]
+        },
+        {
+          "denom": "seasy",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf",
+      "base": "ibc/18A676A074F73B9B42DA4F9DFC8E5AEF334C9A6636DDEC8D34682F52F1DECDF6",
+      "name": "StakeEasy SEASY",
+      "display": "seasy",
+      "symbol": "SEASY",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.svg"
+      },
+      "coingecko_id": "seasy",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:808"
+      ]
+    },
+    {
+      "description": "The native token of Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
+          "exponent": 0,
+          "aliases": [
+            "uaxl"
+          ]
+        },
+        {
+          "denom": "axl",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
+      "name": "Axelar",
+      "display": "axl",
+      "symbol": "AXL",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "uaxl",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/uaxl"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.svg"
+      },
+      "coingecko_id": "axelar",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:812"
+      ]
+    },
+    {
+      "description": "REBUS, the native coin of the Rebus chain.",
+      "denom_units": [
+        {
+          "denom": "ibc/A1AC7F9EE2F643A68E3A35BCEB22040120BEA4059773BB56985C76BDFEBC71D9",
+          "exponent": 0,
+          "aliases": [
+            "arebus"
+          ]
+        },
+        {
+          "denom": "rebus",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/A1AC7F9EE2F643A68E3A35BCEB22040120BEA4059773BB56985C76BDFEBC71D9",
+      "name": "Rebus",
+      "display": "rebus",
+      "symbol": "REBUS",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "rebus",
+            "base_denom": "arebus",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-355",
+            "path": "transfer/channel-355/arebus"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.svg"
+      },
+      "coingecko_id": "rebus",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:813"
+      ]
+    },
+    {
+      "description": "The native token of Teritori",
+      "denom_units": [
+        {
+          "denom": "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
+          "exponent": 0,
+          "aliases": [
+            "utori"
+          ]
+        },
+        {
+          "denom": "tori",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
+      "name": "Teritori",
+      "display": "tori",
+      "symbol": "TORI",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "teritori",
+            "base_denom": "utori",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-362",
+            "path": "transfer/channel-362/utori"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/teritori/images/utori.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/teritori/images/utori.svg"
+      },
+      "coingecko_id": "teritori",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:816"
+      ]
+    },
+    {
+      "description": "The native token of JUNO Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/84502A75BCA4A5F68D464C00B3F610CE2585847D59B52E5FFB7C3C9D2DDCD3FE",
+          "exponent": 0,
+          "aliases": [
+            "stujuno"
+          ]
+        },
+        {
+          "denom": "stjuno",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/84502A75BCA4A5F68D464C00B3F610CE2585847D59B52E5FFB7C3C9D2DDCD3FE",
+      "name": "stJUNO",
+      "display": "stjuno",
+      "symbol": "stJUNO",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "ujuno"
+          },
+          "provider": "Stride"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "stride",
+            "base_denom": "stujuno",
+            "channel_id": "channel-5"
+          },
+          "chain": {
+            "channel_id": "channel-326",
+            "path": "transfer/channel-326/stujuno"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED:817"
+      ]
+    },
+    {
+      "description": "The native token of Osmosis",
+      "denom_units": [
+        {
+          "denom": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
+          "exponent": 0,
+          "aliases": [
+            "stuosmo"
+          ]
+        },
+        {
+          "denom": "stosmo",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
+      "name": "stOSMO",
+      "display": "stosmo",
+      "symbol": "stOSMO",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "osmosis",
+            "base_denom": "uosmo"
+          },
+          "provider": "Stride"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "stride",
+            "base_denom": "stuosmo",
+            "channel_id": "channel-5"
+          },
+          "chain": {
+            "channel_id": "channel-326",
+            "path": "transfer/channel-326/stuosmo"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:833"
+      ]
+    },
+    {
+      "description": "The native token cw20 for MuseDAO on Juno Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/6B982170CE024689E8DD0E7555B129B488005130D4EDA426733D552D10B36D8F",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3"
+          ]
+        },
+        {
+          "denom": "muse",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3",
+      "base": "ibc/6B982170CE024689E8DD0E7555B129B488005130D4EDA426733D552D10B36D8F",
+      "name": "MuseDAO",
+      "display": "muse",
+      "symbol": "MUSE",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/muse.png"
+      }
+    },
+    {
+      "description": "The native token of Lambda",
+      "denom_units": [
+        {
+          "denom": "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB",
+          "exponent": 0,
+          "aliases": [
+            "ulamb"
+          ]
+        },
+        {
+          "denom": "lamb",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB",
+      "name": "Lambda",
+      "display": "lamb",
+      "symbol": "LAMB",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "lambda",
+            "base_denom": "ulamb",
+            "channel_id": "channel-2"
+          },
+          "chain": {
+            "channel_id": "channel-378",
+            "path": "transfer/channel-378/ulamb"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.svg"
+      },
+      "coingecko_id": "lambda",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:826"
+      ]
+    },
+    {
+      "description": "The native over-collateralized stablecoin from the Kujira chain.",
+      "denom_units": [
+        {
+          "denom": "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
+          "exponent": 0,
+          "aliases": [
+            "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+          ]
+        },
+        {
+          "denom": "usk",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
+      "name": "USK",
+      "display": "USK",
+      "symbol": "USK",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "kujira",
+            "base_denom": "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-259",
+            "path": "transfer/channel-259/factory:kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7:uusk"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/usk.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/usk.svg"
+      },
+      "coingecko_id": "usk",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:827"
+      ]
+    },
+    {
+      "description": "Staking and governance coin for the Unification Blockchain",
+      "denom_units": [
+        {
+          "denom": "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
+          "exponent": 0,
+          "aliases": [
+            "nund"
+          ]
+        },
+        {
+          "denom": "FUND",
+          "exponent": 9
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
+      "name": "Unification Network",
+      "display": "FUND",
+      "symbol": "FUND",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "unification",
+            "base_denom": "nund",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-382",
+            "path": "transfer/channel-382/nund"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/unification/images/fund.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/unification/images/fund.svg"
+      },
+      "coingecko_id": "unification",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:830"
+      ]
+    },
+    {
+      "description": "The native staking and governance token of Jackal.",
+      "denom_units": [
+        {
+          "denom": "ibc/8E697BDABE97ACE8773C6DF7402B2D1D5104DD1EEABE12608E3469B7F64C15BA",
+          "exponent": 0,
+          "aliases": [
+            "ujkl"
+          ]
+        },
+        {
+          "denom": "jkl",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/8E697BDABE97ACE8773C6DF7402B2D1D5104DD1EEABE12608E3469B7F64C15BA",
+      "name": "Jackal",
+      "display": "jkl",
+      "symbol": "JKL",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "jackal",
+            "base_denom": "ujkl",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-412",
+            "path": "transfer/channel-412/ujkl"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/jackal/images/jkl.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/jackal/images/jkl.svg"
+      },
+      "coingecko_id": "jackal-protocol",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:832"
+      ]
+    },
+    {
+      "description": "The native token cw20 for Alter on Secret Network",
+      "denom_units": [
+        {
+          "denom": "ibc/A6383B6CF5EA23E067666C06BC34E2A96869927BD9744DC0C1643E589C710AA3",
+          "exponent": 0,
+          "aliases": [
+            "cw20:secret12rcvz0umvk875kd6a803txhtlu7y0pnd73kcej"
+          ]
+        },
+        {
+          "denom": "alter",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/A6383B6CF5EA23E067666C06BC34E2A96869927BD9744DC0C1643E589C710AA3",
+      "name": "Alter",
+      "display": "alter",
+      "symbol": "ALTER",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "secretnetwork",
+            "base_denom": "cw20:secret12rcvz0umvk875kd6a803txhtlu7y0pnd73kcej",
+            "port": "wasm.secret1tqmms5awftpuhalcv5h5mg76fa0tkdz4jv9ex4",
+            "channel_id": "channel-44"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-476",
+            "path": "transfer/channel-476/cw20:secret12rcvz0umvk875kd6a803txhtlu7y0pnd73kcej"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/alter.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/alter.svg"
+      },
+      "coingecko_id": "alter",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:845"
+      ]
+    },
+    {
+      "description": "The native token cw20 for Button on Secret Network",
+      "denom_units": [
+        {
+          "denom": "ibc/1FBA9E763B8679BEF7BAAAF2D16BCA78C3B297D226C3F31312C769D7B8F992D8",
+          "exponent": 0,
+          "aliases": [
+            "cw20:secret1yxcexylwyxlq58umhgsjgstgcg2a0ytfy4d9lt"
+          ]
+        },
+        {
+          "denom": "butt",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "secret1yxcexylwyxlq58umhgsjgstgcg2a0ytfy4d9lt",
+      "base": "ibc/1FBA9E763B8679BEF7BAAAF2D16BCA78C3B297D226C3F31312C769D7B8F992D8",
+      "name": "Button",
+      "display": "butt",
+      "symbol": "BUTT",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "secretnetwork",
+            "base_denom": "cw20:secret1yxcexylwyxlq58umhgsjgstgcg2a0ytfy4d9lt",
+            "port": "wasm.secret1tqmms5awftpuhalcv5h5mg76fa0tkdz4jv9ex4",
+            "channel_id": "channel-44"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-476",
+            "path": "transfer/channel-476/cw20:secret1yxcexylwyxlq58umhgsjgstgcg2a0ytfy4d9lt"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/butt.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/butt.svg"
+      },
+      "coingecko_id": "buttcoin-2",
+      "keywords": [
+        "osmosis-price:uosmo:985"
+      ]
+    },
+    {
+      "description": "The native token cw20 for Shade on Secret Network",
+      "denom_units": [
+        {
+          "denom": "ibc/71055835C7639739EAE03AACD1324FE162DBA41D09F197CB72D966D014225B1C",
+          "exponent": 0,
+          "aliases": [
+            "cw20:secret1qfql357amn448duf5gvp9gr48sxx9tsnhupu3d"
+          ]
+        },
+        {
+          "denom": "shd",
+          "exponent": 8
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "secret1qfql357amn448duf5gvp9gr48sxx9tsnhupu3d",
+      "base": "ibc/71055835C7639739EAE03AACD1324FE162DBA41D09F197CB72D966D014225B1C",
+      "name": "Shade (old)",
+      "display": "shd",
+      "symbol": "SHD(old)",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "secretnetwork",
+            "base_denom": "cw20:secret1qfql357amn448duf5gvp9gr48sxx9tsnhupu3d",
+            "port": "wasm.secret1tqmms5awftpuhalcv5h5mg76fa0tkdz4jv9ex4",
+            "channel_id": "channel-44"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-476",
+            "path": "transfer/channel-476/cw20:secret1qfql357amn448duf5gvp9gr48sxx9tsnhupu3d"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/shdold.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:846"
+      ]
+    },
+    {
+      "description": "The native token cw20 for SIENNA on Secret Network",
+      "denom_units": [
+        {
+          "denom": "ibc/9A8A93D04917A149C8AC7C16D3DA8F470D59E8D867499C4DA97450E1D7363213",
+          "exponent": 0,
+          "aliases": [
+            "cw20:secret1rgm2m5t530tdzyd99775n6vzumxa5luxcllml4"
+          ]
+        },
+        {
+          "denom": "sienna",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "secret1rgm2m5t530tdzyd99775n6vzumxa5luxcllml4",
+      "base": "ibc/9A8A93D04917A149C8AC7C16D3DA8F470D59E8D867499C4DA97450E1D7363213",
+      "name": "SIENNA",
+      "display": "sienna",
+      "symbol": "SIENNA",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "secretnetwork",
+            "base_denom": "cw20:secret1rgm2m5t530tdzyd99775n6vzumxa5luxcllml4",
+            "port": "wasm.secret1tqmms5awftpuhalcv5h5mg76fa0tkdz4jv9ex4",
+            "channel_id": "channel-44"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-476",
+            "path": "transfer/channel-476/cw20:secret1rgm2m5t530tdzyd99775n6vzumxa5luxcllml4"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/sienna.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/sienna.svg"
+      },
+      "coingecko_id": "sienna",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:853"
+      ]
+    },
+    {
+      "description": "The native token cw20 for SCRT Staking Derivatives on Secret Network",
+      "denom_units": [
+        {
+          "denom": "ibc/D0E5BF2940FB58D9B283A339032DE88111407AAD7D94A7F1F3EB78874F8616D4",
+          "exponent": 0,
+          "aliases": [
+            "cw20:secret1k6u0cy4feepm6pehnz804zmwakuwdapm69tuc4"
+          ]
+        },
+        {
+          "denom": "stkd-scrt",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "secret1k6u0cy4feepm6pehnz804zmwakuwdapm69tuc4",
+      "base": "ibc/D0E5BF2940FB58D9B283A339032DE88111407AAD7D94A7F1F3EB78874F8616D4",
+      "name": "SCRT Staking Derivatives",
+      "display": "stkd-scrt",
+      "symbol": "stkd-SCRT",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "secretnetwork",
+            "base_denom": "cw20:secret1k6u0cy4feepm6pehnz804zmwakuwdapm69tuc4",
+            "port": "wasm.secret1tqmms5awftpuhalcv5h5mg76fa0tkdz4jv9ex4",
+            "channel_id": "channel-44"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-476",
+            "path": "transfer/channel-476/cw20:secret1k6u0cy4feepm6pehnz804zmwakuwdapm69tuc4"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/stkd-scrt.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/stkd-scrt.svg"
+      },
+      "coingecko_id": "stkd-scrt",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A:854"
+      ]
+    },
+    {
+      "description": "BeeZee native blockchain",
+      "denom_units": [
+        {
+          "denom": "ibc/C822645522FC3EECF817609AA38C24B64D04F5C267A23BCCF8F2E3BC5755FA88",
+          "exponent": 0,
+          "aliases": [
+            "ubze"
+          ]
+        },
+        {
+          "denom": "bze",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/C822645522FC3EECF817609AA38C24B64D04F5C267A23BCCF8F2E3BC5755FA88",
+      "name": "BeeZee",
+      "display": "bze",
+      "symbol": "BZE",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "beezee",
+            "base_denom": "ubze",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-340",
+            "path": "transfer/channel-340/ubze"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/bze.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/bze.svg"
+      },
+      "coingecko_id": "bzedge",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:856"
+      ]
+    },
+    {
+      "description": "The native token cw20 for Fanfury on Juno Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/7CE5F388D661D82A0774E47B5129DA51CC7129BD1A70B5FA6BCEBB5B0A2FAEAF",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1cltgm8v842gu54srmejewghnd6uqa26lzkpa635wzra9m9xuudkqa2gtcz"
+          ]
+        },
+        {
+          "denom": "fury",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1cltgm8v842gu54srmejewghnd6uqa26lzkpa635wzra9m9xuudkqa2gtcz",
+      "base": "ibc/7CE5F388D661D82A0774E47B5129DA51CC7129BD1A70B5FA6BCEBB5B0A2FAEAF",
+      "name": "Fanfury",
+      "display": "fury",
+      "symbol": "FURY",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1cltgm8v842gu54srmejewghnd6uqa26lzkpa635wzra9m9xuudkqa2gtcz",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1cltgm8v842gu54srmejewghnd6uqa26lzkpa635wzra9m9xuudkqa2gtcz"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/fanfury.png"
+      },
+      "coingecko_id": "fanfury"
+    },
+    {
+      "description": "The native EVM, governance and staking token of the Acrechain",
+      "denom_units": [
+        {
+          "denom": "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
+          "exponent": 0,
+          "aliases": [
+            "aacre"
+          ]
+        },
+        {
+          "denom": "acre",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
+      "name": "Acre",
+      "display": "acre",
+      "symbol": "ACRE",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "acrechain",
+            "base_denom": "aacre",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-490",
+            "path": "transfer/channel-490/aacre"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/acre.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/acre.svg"
+      },
+      "coingecko_id": "arable-protocol",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:858"
+      ]
+    },
+    {
+      "description": "Stable Token of Harbor protocol on Comdex network",
+      "denom_units": [
+        {
+          "denom": "ibc/23CA6C8D1AB2145DD13EB1E089A2E3F960DC298B468CCE034E19E5A78B61136E",
+          "exponent": 0,
+          "aliases": [
+            "ucmst"
+          ]
+        },
+        {
+          "denom": "cmst",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/23CA6C8D1AB2145DD13EB1E089A2E3F960DC298B468CCE034E19E5A78B61136E",
+      "name": "CMST",
+      "display": "cmst",
+      "symbol": "CMST",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "comdex",
+            "base_denom": "ucmst",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-87",
+            "path": "transfer/channel-87/ucmst"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmst.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmst.svg"
+      },
+      "coingecko_id": "composite",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5:908"
+      ]
+    },
+    {
+      "description": "The native EVM, governance and staking token of the Imversed",
+      "denom_units": [
+        {
+          "denom": "ibc/92B223EBFA74DB99BEA92B23DEAA6050734FEEAABB84689CB8E1AE8F9C9F9AF4",
+          "exponent": 0,
+          "aliases": [
+            "aimv"
+          ]
+        },
+        {
+          "denom": "imv",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/92B223EBFA74DB99BEA92B23DEAA6050734FEEAABB84689CB8E1AE8F9C9F9AF4",
+      "name": "IMV",
+      "display": "imv",
+      "symbol": "IMV",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "imversed",
+            "base_denom": "aimv",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-517",
+            "path": "transfer/channel-517/aimv"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/imversed/images/imversed.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/imversed/images/imversed.svg"
+      },
+      "coingecko_id": "imv",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858:866"
+      ]
+    },
+    {
+      "description": "The native token of Medas Digital Network",
+      "denom_units": [
+        {
+          "denom": "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
+          "exponent": 0,
+          "aliases": [
+            "umedas"
+          ]
+        },
+        {
+          "denom": "medas",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
+      "name": "Medas Digital",
+      "display": "medas",
+      "symbol": "MEDAS",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "medasdigital",
+            "base_denom": "umedas",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-519",
+            "path": "transfer/channel-519/umedas"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/medasdigital/images/medas.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/medasdigital/images/medas.svg"
+      },
+      "keywords": [
+        "medas",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84:910"
+      ]
+    },
+    {
+      "description": "The native token cw20 for PHMN on Juno Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/D3B574938631B0A1BA704879020C696E514CFADAA7643CDE4BD5EB010BDE327B",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l"
+          ]
+        },
+        {
+          "denom": "phmn",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l",
+      "base": "ibc/D3B574938631B0A1BA704879020C696E514CFADAA7643CDE4BD5EB010BDE327B",
+      "name": "POSTHUMAN",
+      "display": "phmn",
+      "symbol": "PHMN",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/phmn.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/phmn.svg"
+      },
+      "coingecko_id": "posthuman",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:867"
+      ]
+    },
+    {
+      "description": "The native token cw20 for Amber on Secret Network",
+      "denom_units": [
+        {
+          "denom": "ibc/18A1B70E3205A48DE8590C0D11030E7146CDBF1048789261D53FFFD7527F8B55",
+          "exponent": 0,
+          "aliases": [
+            "cw20:secret1s09x2xvfd2lp2skgzm29w2xtena7s8fq98v852"
+          ]
+        },
+        {
+          "denom": "amber",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "secret1s09x2xvfd2lp2skgzm29w2xtena7s8fq98v852",
+      "base": "ibc/18A1B70E3205A48DE8590C0D11030E7146CDBF1048789261D53FFFD7527F8B55",
+      "name": "Amber",
+      "display": "amber",
+      "symbol": "AMBER",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "secretnetwork",
+            "base_denom": "cw20:secret1s09x2xvfd2lp2skgzm29w2xtena7s8fq98v852",
+            "port": "wasm.secret1tqmms5awftpuhalcv5h5mg76fa0tkdz4jv9ex4",
+            "channel_id": "channel-44"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-476",
+            "path": "transfer/channel-476/cw20:secret1s09x2xvfd2lp2skgzm29w2xtena7s8fq98v852"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/amber.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/amber.svg"
+      },
+      "keywords": [
+        "osmosis-price:uosmo:984"
+      ]
+    },
+    {
+      "description": "The native token of Onomy Protocol",
+      "denom_units": [
+        {
+          "denom": "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163",
+          "exponent": 0,
+          "aliases": [
+            "anom"
+          ]
+        },
+        {
+          "denom": "nom",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163",
+      "name": "Nom",
+      "display": "nom",
+      "symbol": "NOM",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "onomy",
+            "base_denom": "anom",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-525",
+            "path": "transfer/channel-525/anom"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/onomy/images/nom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/onomy/images/nom.svg"
+      },
+      "coingecko_id": "onomy-protocol",
+      "keywords": [
+        "dex",
+        "stablecoin",
+        "bridge",
+        "staking",
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:882"
+      ]
+    },
+    {
+      "description": "PSTAKE Liquid-Staked ATOM",
+      "denom_units": [
+        {
+          "denom": "ibc/CAA179E40F0266B0B29FB5EAA288FB9212E628822265D4141EBD1C47C3CBFCBC",
+          "exponent": 0,
+          "aliases": [
+            "stk/uatom"
+          ]
+        },
+        {
+          "denom": "stkatom",
+          "exponent": 6,
+          "aliases": [
+            "stk/atom"
+          ]
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/CAA179E40F0266B0B29FB5EAA288FB9212E628822265D4141EBD1C47C3CBFCBC",
+      "name": "PSTAKE staked ATOM",
+      "display": "stkatom",
+      "symbol": "stkATOM",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "persistence",
+            "base_denom": "stk/uatom",
+            "channel_id": "channel-6"
+          },
+          "chain": {
+            "channel_id": "channel-4",
+            "path": "transfer/channel-4/stk/uatom"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/stkatom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/stkatom.svg"
+      },
+      "coingecko_id": "stkatom",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:886"
+      ]
+    },
+    {
+      "description": "The native staking and governance token of the Dyson Protocol",
+      "denom_units": [
+        {
+          "denom": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
+          "exponent": 0,
+          "aliases": [
+            "dys"
+          ]
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
+      "name": "Dys",
+      "display": "dys",
+      "symbol": "DYS",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "dyson",
+            "base_denom": "dys",
+            "channel_id": "channel-2"
+          },
+          "chain": {
+            "channel_id": "channel-526",
+            "path": "transfer/channel-526/dys"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dyson/images/dys.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dyson/images/dys.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F:950"
+      ]
+    },
+    {
+      "description": "The native token cw20 for Hopers on Juno Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/D3ADAF73F84CDF205BCB72C142FDAEEA2C612AB853CEE6D6C06F184FA38B1099",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1u45shlp0q4gcckvsj06ss4xuvsu0z24a0d0vr9ce6r24pht4e5xq7q995n"
+          ]
+        },
+        {
+          "denom": "hopers",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1u45shlp0q4gcckvsj06ss4xuvsu0z24a0d0vr9ce6r24pht4e5xq7q995n",
+      "base": "ibc/D3ADAF73F84CDF205BCB72C142FDAEEA2C612AB853CEE6D6C06F184FA38B1099",
+      "name": "Hopers",
+      "display": "hopers",
+      "symbol": "HOPERS",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1u45shlp0q4gcckvsj06ss4xuvsu0z24a0d0vr9ce6r24pht4e5xq7q995n",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1u45shlp0q4gcckvsj06ss4xuvsu0z24a0d0vr9ce6r24pht4e5xq7q995n"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hopers.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hopers.svg"
+      },
+      "coingecko_id": "hopers-io ",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:894"
+      ]
+    },
+    {
+      "description": "Overcollateralized stable coin for Arable derivatives v1",
+      "denom_units": [
+        {
+          "denom": "ibc/5D270A584B1078FBE07D14570ED5E88EC1FEDA8518B76C322606291E6FD8286F",
+          "exponent": 0,
+          "aliases": [
+            "erc20/0x2Cbea61fdfDFA520Ee99700F104D5b75ADf50B0c"
+          ]
+        },
+        {
+          "denom": "arusd",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/5D270A584B1078FBE07D14570ED5E88EC1FEDA8518B76C322606291E6FD8286F",
+      "name": "Arable USD",
+      "display": "arusd",
+      "symbol": "arUSD",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "acrechain",
+            "base_denom": "erc20/0x2Cbea61fdfDFA520Ee99700F104D5b75ADf50B0c",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-490",
+            "path": "transfer/channel-490/erc20/0x2Cbea61fdfDFA520Ee99700F104D5b75ADf50B0c"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/arusd.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/arusd.svg"
+      },
+      "coingecko_id": "arable-usd",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858:895"
+      ]
+    },
+    {
+      "description": "The native EVM, governance and staking token of the Planq Network",
+      "denom_units": [
+        {
+          "denom": "ibc/B1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF",
+          "exponent": 0,
+          "aliases": [
+            "aplanq"
+          ]
+        },
+        {
+          "denom": "planq",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/B1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF",
+      "name": "Planq",
+      "display": "planq",
+      "symbol": "PLQ",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "planq",
+            "base_denom": "aplanq",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-492",
+            "path": "transfer/channel-492/aplanq"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/planq/images/planq.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/planq/images/planq.svg"
+      },
+      "coingecko_id": "planq",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:898"
+      ]
+    },
+    {
+      "description": "Wrapped FTM on Axelar.",
+      "denom_units": [
+        {
+          "denom": "ibc/5E2DFDF1734137302129EA1C1BA21A580F96F778D4F021815EA4F6DB378DA1A4",
+          "exponent": 0,
+          "aliases": [
+            "wftm-wei"
+          ]
+        },
+        {
+          "denom": "ftm",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/5E2DFDF1734137302129EA1C1BA21A580F96F778D4F021815EA4F6DB378DA1A4",
+      "name": "Wrapped FTM",
+      "display": "ftm",
+      "symbol": "FTM",
+      "traces": [
+        {
+          "type": "wrapped",
+          "counterparty": {
+            "chain_name": "fantom",
+            "base_denom": "wei"
+          },
+          "chain": {
+            "contract": "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83"
+          },
+          "provider": "Fantom"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "fantom",
+            "base_denom": "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "wftm-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/wftm-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/fantom/images/ftm.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:900"
+      ]
+    },
+    {
+      "description": "Canto is a Layer-1 blockchain built to deliver on the promise of DeFi",
+      "denom_units": [
+        {
+          "denom": "ibc/47CAF2DB8C016FAC960F33BC492FD8E454593B65CC59D70FA9D9F30424F9C32F",
+          "exponent": 0,
+          "aliases": [
+            "acanto"
+          ]
+        },
+        {
+          "denom": "canto",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/47CAF2DB8C016FAC960F33BC492FD8E454593B65CC59D70FA9D9F30424F9C32F",
+      "name": "Canto",
+      "display": "canto",
+      "symbol": "CANTO",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "canto",
+            "base_denom": "acanto",
+            "channel_id": "channel-5"
+          },
+          "chain": {
+            "channel_id": "channel-550",
+            "path": "transfer/channel-550/acanto"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/canto/images/canto.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/canto/images/canto.svg"
+      },
+      "coingecko_id": "canto",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:901"
+      ]
+    },
+    {
+      "description": "Quicksilver Liquid Staked STARS",
+      "denom_units": [
+        {
+          "denom": "ibc/46C83BB054E12E189882B5284542DB605D94C99827E367C9192CF0579CD5BC83",
+          "exponent": 0,
+          "aliases": [
+            "uqstars"
+          ]
+        },
+        {
+          "denom": "qstars",
+          "exponent": 6,
+          "aliases": []
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/46C83BB054E12E189882B5284542DB605D94C99827E367C9192CF0579CD5BC83",
+      "name": "Quicksilver Liquid Staked STARS",
+      "display": "qstars",
+      "symbol": "qSTARS",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "stargaze",
+            "base_denom": "ustars"
+          },
+          "provider": "Quicksilver"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "quicksilver",
+            "base_denom": "uqstars",
+            "channel_id": "channel-2"
+          },
+          "chain": {
+            "channel_id": "channel-522",
+            "path": "transfer/channel-522/uqstars"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qstars.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qstars.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4:903"
+      ]
+    },
+    {
+      "description": "WYND DAO Governance Token",
+      "denom_units": [
+        {
+          "denom": "ibc/2FBAC4BF296D7844796844B35978E5899984BA5A6314B2DD8F83C215550010B3",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9"
+          ]
+        },
+        {
+          "denom": "wynd",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
+      "base": "ibc/2FBAC4BF296D7844796844B35978E5899984BA5A6314B2DD8F83C215550010B3",
+      "name": "Wynd DAO Governance Token",
+      "display": "wynd",
+      "symbol": "WYND",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/wynd.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/wynd.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:902"
+      ]
+    },
+    {
+      "description": "Circle's stablecoin from Polygon on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/231FD77ECCB2DB916D314019DA30FE013202833386B1908A191D16989AD80B5A",
+          "exponent": 0,
+          "aliases": [
+            "polygon-uusdc"
+          ]
+        },
+        {
+          "denom": "polygon-usdc",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/231FD77ECCB2DB916D314019DA30FE013202833386B1908A191D16989AD80B5A",
+      "name": "USD Coin from Polygon",
+      "display": "polygon-usdc",
+      "symbol": "polygon.USDC",
+      "traces": [
+        {
+          "type": "synthetic",
+          "counterparty": {
+            "chain_name": "forex",
+            "base_denom": "USD"
+          },
+          "provider": "Circle"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "polygon",
+            "base_denom": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "polygon-uusdc",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/polygon-uusdc"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/polygon.usdc.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858:938"
+      ]
+    },
+    {
+      "description": "Circle's stablecoin from Avalanche on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/F17C9CA112815613C5B6771047A093054F837C3020CBA59DFFD9D780A8B2984C",
+          "exponent": 0,
+          "aliases": [
+            "avalanche-uusdc"
+          ]
+        },
+        {
+          "denom": "avalanche-usdc",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/F17C9CA112815613C5B6771047A093054F837C3020CBA59DFFD9D780A8B2984C",
+      "name": "USD Coin from Avalanche",
+      "display": "avalanche-usdc",
+      "symbol": "avalanche.USDC",
+      "traces": [
+        {
+          "type": "synthetic",
+          "counterparty": {
+            "chain_name": "forex",
+            "base_denom": "USD"
+          },
+          "provider": "Circle"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "avalanche",
+            "base_denom": "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "avalanche-uusdc",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/avalanche-uusdc"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/avalanche.usdc.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858:938"
+      ]
+    },
+    {
+      "description": "Mars protocol token",
+      "denom_units": [
+        {
+          "denom": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
+          "exponent": 0,
+          "aliases": [
+            "umars"
+          ]
+        },
+        {
+          "denom": "mars",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
+      "name": "Mars",
+      "display": "mars",
+      "symbol": "MARS",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "mars",
+            "base_denom": "umars",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-557",
+            "path": "transfer/channel-557/umars"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg"
+      },
+      "coingecko_id": "mars-protocol-a7fcbcfb-fd61-4017-92f0-7ee9f9cc6da3",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:907"
+      ]
+    },
+    {
+      "description": "Ciento Exchange Token",
+      "denom_units": [
+        {
+          "denom": "ibc/D38BB3DD46864694F009AF01DA5A815B3A875F8CC52FF5679BFFCC35DC7451D5",
+          "exponent": 0,
+          "aliases": [
+            "erc20/0xAE6D3334989a22A65228732446731438672418F2"
+          ]
+        },
+        {
+          "denom": "cnto",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/D38BB3DD46864694F009AF01DA5A815B3A875F8CC52FF5679BFFCC35DC7451D5",
+      "name": "Ciento Token",
+      "display": "cnto",
+      "symbol": "CNTO",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "acrechain",
+            "base_denom": "erc20/0xAE6D3334989a22A65228732446731438672418F2",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-490",
+            "path": "transfer/channel-490/erc20/0xAE6D3334989a22A65228732446731438672418F2"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/cnto.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/cnto.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858:909"
+      ]
+    },
+    {
+      "description": "The native staking token of Terra.",
+      "denom_units": [
+        {
+          "denom": "ibc/C491E7582E94AE921F6A029790083CDE1106C28F3F6C4AD7F1340544C13EC372",
+          "exponent": 0,
+          "aliases": [
+            "stuluna"
+          ]
+        },
+        {
+          "denom": "stluna",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/C491E7582E94AE921F6A029790083CDE1106C28F3F6C4AD7F1340544C13EC372",
+      "name": "stLUNA",
+      "display": "stluna",
+      "symbol": "stLUNA",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "terra2",
+            "base_denom": "uluna"
+          },
+          "provider": "Stride"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "stride",
+            "base_denom": "stuluna",
+            "channel_id": "channel-5"
+          },
+          "chain": {
+            "channel_id": "channel-326",
+            "path": "transfer/channel-326/stuluna"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stluna.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stluna.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-price:ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9:913"
+      ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "ibc/C5579A9595790017C600DD726276D978B9BF314CF82406CE342720A9C7911A01",
+          "exponent": 0,
+          "aliases": [
+            "staevmos"
+          ]
+        },
+        {
+          "denom": "stevmos",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/C5579A9595790017C600DD726276D978B9BF314CF82406CE342720A9C7911A01",
+      "name": "stEVMOS",
+      "display": "stevmos",
+      "symbol": "stEVMOS",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "evmos",
+            "base_denom": "uaevmos"
+          },
+          "provider": "Stride"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "stride",
+            "base_denom": "staevmos",
+            "channel_id": "channel-5"
+          },
+          "chain": {
+            "channel_id": "channel-326",
+            "path": "transfer/channel-326/staevmos"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stevmos.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stevmos.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A:922"
+      ]
+    },
+    {
+      "description": "nRide Token",
+      "denom_units": [
+        {
+          "denom": "ibc/E750D31033DC1CF4A044C3AA0A8117401316DC918FBEBC4E3D34F91B09D5F54C",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1qmlchtmjpvu0cr7u0tad2pq8838h6farrrjzp39eqa9xswg7teussrswlq"
+          ]
+        },
+        {
+          "denom": "nride",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1qmlchtmjpvu0cr7u0tad2pq8838h6farrrjzp39eqa9xswg7teussrswlq",
+      "base": "ibc/E750D31033DC1CF4A044C3AA0A8117401316DC918FBEBC4E3D34F91B09D5F54C",
+      "name": "nRide Token",
+      "display": "nride",
+      "symbol": "NRIDE",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1qmlchtmjpvu0cr7u0tad2pq8838h6farrrjzp39eqa9xswg7teussrswlq",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1qmlchtmjpvu0cr7u0tad2pq8838h6farrrjzp39eqa9xswg7teussrswlq"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/nride.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/nride.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:924"
+      ]
+    },
+    {
+      "description": "The native staking token of 8ball.",
+      "denom_units": [
+        {
+          "denom": "ibc/8BE73A810E22F80E5E850531A688600D63AE7392E7C2770AE758CAA4FD921B7F",
+          "exponent": 0,
+          "aliases": [
+            "uebl"
+          ]
+        },
+        {
+          "denom": "ebl",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/8BE73A810E22F80E5E850531A688600D63AE7392E7C2770AE758CAA4FD921B7F",
+      "name": "8ball",
+      "display": "ebl",
+      "symbol": "EBL",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "8ball",
+            "base_denom": "uebl",
+            "channel_id": "channel-16"
+          },
+          "chain": {
+            "channel_id": "channel-641",
+            "path": "transfer/channel-641/uebl"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/8ball/images/8ball.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/8ball/images/8ball.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:935"
+      ]
+    },
+    {
+      "description": "Quicksilver Liquid Staked ATOM",
+      "denom_units": [
+        {
+          "denom": "ibc/FA602364BEC305A696CBDF987058E99D8B479F0318E47314C49173E8838C5BAC",
+          "exponent": 0,
+          "aliases": [
+            "uqatom"
+          ]
+        },
+        {
+          "denom": "qatom",
+          "exponent": 6,
+          "aliases": []
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/FA602364BEC305A696CBDF987058E99D8B479F0318E47314C49173E8838C5BAC",
+      "name": "Quicksilver Liquid Staked ATOM",
+      "display": "qatom",
+      "symbol": "qATOM",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "cosmoshub",
+            "base_denom": "uatom"
+          },
+          "provider": "Quicksilver"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "quicksilver",
+            "base_denom": "uqatom",
+            "channel_id": "channel-2"
+          },
+          "chain": {
+            "channel_id": "channel-522",
+            "path": "transfer/channel-522/uqatom"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qatom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qatom.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:944"
+      ]
+    },
+    {
+      "description": "Governance Token of Harbor protocol on Comdex network",
+      "denom_units": [
+        {
+          "denom": "ibc/AD4DEA52408EA07C0C9E19444EC8DA84A274A70AD2687A710EFDDEB28BB2986A",
+          "exponent": 0,
+          "aliases": [
+            "uharbor"
+          ]
+        },
+        {
+          "denom": "harbor",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/AD4DEA52408EA07C0C9E19444EC8DA84A274A70AD2687A710EFDDEB28BB2986A",
+      "name": "Harbor",
+      "display": "harbor",
+      "symbol": "HARBOR",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "comdex",
+            "base_denom": "uharbor",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-87",
+            "path": "transfer/channel-87/uharbor"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/harbor.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/harbor.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:951"
+      ]
+    },
+    {
+      "description": "Quicksilver Liquid Staked REGEN",
+      "denom_units": [
+        {
+          "denom": "ibc/79A676508A2ECA1021EDDC7BB9CF70CEEC9514C478DA526A5A8B3E78506C2206",
+          "exponent": 0,
+          "aliases": [
+            "uqregen"
+          ]
+        },
+        {
+          "denom": "qregen",
+          "exponent": 6,
+          "aliases": []
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/79A676508A2ECA1021EDDC7BB9CF70CEEC9514C478DA526A5A8B3E78506C2206",
+      "name": "Quicksilver Liquid Staked Regen",
+      "display": "qregen",
+      "symbol": "qREGEN",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "regen",
+            "base_denom": "uregen"
+          },
+          "provider": "Quicksilver"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "quicksilver",
+            "base_denom": "uqregen",
+            "channel_id": "channel-2"
+          },
+          "chain": {
+            "channel_id": "channel-522",
+            "path": "transfer/channel-522/uqregen"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qregen.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qregen.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076:948"
+      ]
+    },
+    {
+      "description": "Inspired by Bonk. A community project to celebrate the settlers of JunoNetwork.",
+      "denom_units": [
+        {
+          "denom": "ibc/4F24D904BAB5FFBD3524F2DE3EC3C7A9E687A2408D9A985E57B356D9FA9201C6",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1u8cr3hcjvfkzxcaacv9q75uw9hwjmn8pucc93pmy6yvkzz79kh3qncca8x"
+          ]
+        },
+        {
+          "denom": "fox",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1u8cr3hcjvfkzxcaacv9q75uw9hwjmn8pucc93pmy6yvkzz79kh3qncca8x",
+      "base": "ibc/4F24D904BAB5FFBD3524F2DE3EC3C7A9E687A2408D9A985E57B356D9FA9201C6",
+      "name": "Juno Fox",
+      "display": "fox",
+      "symbol": "FOX",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1u8cr3hcjvfkzxcaacv9q75uw9hwjmn8pucc93pmy6yvkzz79kh3qncca8x",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1u8cr3hcjvfkzxcaacv9q75uw9hwjmn8pucc93pmy6yvkzz79kh3qncca8x"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/fox.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:949"
+      ]
+    },
+    {
+      "description": "QCK - native token of Quicksilver",
+      "denom_units": [
+        {
+          "denom": "ibc/635CB83EF1DFE598B10A3E90485306FD0D47D34217A4BE5FD9977FA010A5367D",
+          "exponent": 0,
+          "aliases": [
+            "uqck"
+          ]
+        },
+        {
+          "denom": "qck",
+          "exponent": 6,
+          "aliases": []
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/635CB83EF1DFE598B10A3E90485306FD0D47D34217A4BE5FD9977FA010A5367D",
+      "name": "Quicksilver",
+      "display": "qck",
+      "symbol": "QCK",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "quicksilver",
+            "base_denom": "uqck",
+            "channel_id": "channel-2"
+          },
+          "chain": {
+            "channel_id": "channel-522",
+            "path": "transfer/channel-522/uqck"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qck.png"
+      },
+      "coingecko_id": "quicksilver",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:952"
+      ]
+    },
+    {
+      "description": "The native token of Arkhadian",
+      "denom_units": [
+        {
+          "denom": "ibc/0F91EE8B98AAE3CF393D94CD7F89A10F8D7758C5EC707E721899DFE65C164C28",
+          "exponent": 0,
+          "aliases": [
+            "arkh"
+          ]
+        },
+        {
+          "denom": "ARKH",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/0F91EE8B98AAE3CF393D94CD7F89A10F8D7758C5EC707E721899DFE65C164C28",
+      "name": "Arkh",
+      "display": "ARKH",
+      "symbol": "ARKH",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "arkh",
+            "base_denom": "arkh",
+            "channel_id": "channel-12"
+          },
+          "chain": {
+            "channel_id": "channel-648",
+            "path": "transfer/channel-648/arkh"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/arkh/images/arkh.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/arkh/images/arkh.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:954"
+      ]
+    },
+    {
+      "description": "Quicksilver Liquid Staked OSMO",
+      "denom_units": [
+        {
+          "denom": "ibc/42D24879D4569CE6477B7E88206ADBFE47C222C6CAD51A54083E4A72594269FC",
+          "exponent": 0,
+          "aliases": [
+            "uqosmo"
+          ]
+        },
+        {
+          "denom": "qosmo",
+          "exponent": 6,
+          "aliases": []
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/42D24879D4569CE6477B7E88206ADBFE47C222C6CAD51A54083E4A72594269FC",
+      "name": "Quicksilver Liquid Staked OSMO",
+      "display": "qosmo",
+      "symbol": "qOSMO",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "osmosis",
+            "base_denom": "uosmo"
+          },
+          "provider": "Quicksilver"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "quicksilver",
+            "base_denom": "uqosmo",
+            "channel_id": "channel-2"
+          },
+          "chain": {
+            "channel_id": "channel-522",
+            "path": "transfer/channel-522/uqosmo"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qosmo.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qosmo.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:956"
+      ]
+    },
+    {
+      "description": "Frienzies are an IBC token redeemable exclusively for a physical asset issued by the Noble entity.",
+      "denom_units": [
+        {
+          "denom": "ibc/7FA7EC64490E3BDE5A1A28CBE73CC0AD22522794957BC891C46321E3A6074DB9",
+          "exponent": 0,
+          "aliases": [
+            "microfrienzies",
+            "ufrienzies"
+          ]
+        },
+        {
+          "denom": "frienzies",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/7FA7EC64490E3BDE5A1A28CBE73CC0AD22522794957BC891C46321E3A6074DB9",
+      "name": "Frienzies",
+      "display": "frienzies",
+      "symbol": "FRNZ",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "noble",
+            "base_denom": "ufrienzies",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-750",
+            "path": "transfer/channel-750/ufrienzies"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/frnz.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/frnz.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:1012"
+      ]
+    },
+    {
+      "description": "The native token of Migaloo Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/EDD6F0D66BCD49C1084FB2C35353B4ACD7B9191117CE63671B61320548F7C89D",
+          "exponent": 0,
+          "aliases": [
+            "uwhale"
+          ]
+        },
+        {
+          "denom": "whale",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/EDD6F0D66BCD49C1084FB2C35353B4ACD7B9191117CE63671B61320548F7C89D",
+      "name": "Whale",
+      "display": "whale",
+      "symbol": "WHALE",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "migaloo",
+            "base_denom": "uwhale",
+            "channel_id": "channel-5"
+          },
+          "chain": {
+            "channel_id": "channel-642",
+            "path": "transfer/channel-642/uwhale"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg"
+      },
+      "coingecko_id": "white-whale",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:960"
+      ]
+    },
+    {
+      "description": "Evmos Guardians governance token.",
+      "denom_units": [
+        {
+          "denom": "ibc/BAC9C6998F1F5C316D3353622EAEDAF8BD00FAABEB374FECDF8C9BC475172CFA",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1xekkh27punj0uxruv3gvuydyt856fax0nu750xns99t2qcxp7xmsqwhfma"
+          ]
+        },
+        {
+          "denom": "grdn",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1xekkh27punj0uxruv3gvuydyt856fax0nu750xns99t2qcxp7xmsqwhfma",
+      "base": "ibc/BAC9C6998F1F5C316D3353622EAEDAF8BD00FAABEB374FECDF8C9BC475172CFA",
+      "name": "Guardian",
+      "display": "grdn",
+      "symbol": "GRDN",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1xekkh27punj0uxruv3gvuydyt856fax0nu750xns99t2qcxp7xmsqwhfma",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1xekkh27punj0uxruv3gvuydyt856fax0nu750xns99t2qcxp7xmsqwhfma"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/guardian.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858:966"
+      ]
+    },
+    {
+      "description": "Mini Punks Token",
+      "denom_units": [
+        {
+          "denom": "ibc/DC0D3303BBE739E073224D0314385B88B247F56D71D726A91414CCA244FFFE7E",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno166heaxlyntd33a5euh4rrz26svhean4klzw594esmd02l4atan6sazy2my"
+          ]
+        },
+        {
+          "denom": "mnpu",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno166heaxlyntd33a5euh4rrz26svhean4klzw594esmd02l4atan6sazy2my",
+      "base": "ibc/DC0D3303BBE739E073224D0314385B88B247F56D71D726A91414CCA244FFFE7E",
+      "name": "Mini Punks",
+      "display": "mnpu",
+      "symbol": "MNPU",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno166heaxlyntd33a5euh4rrz26svhean4klzw594esmd02l4atan6sazy2my",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno166heaxlyntd33a5euh4rrz26svhean4klzw594esmd02l4atan6sazy2my"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/mnpu.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/mnpu.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:961"
+      ]
+    },
+    {
+      "description": "Shiba Cosmos",
+      "denom_units": [
+        {
+          "denom": "ibc/447A0DCE83691056289503DDAB8EB08E52E167A73629F2ACC59F056B92F51CE8",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1x5qt47rw84c4k6xvvywtrd40p8gxjt8wnmlahlqg07qevah3f8lqwxfs7z"
+          ]
+        },
+        {
+          "denom": "shibac",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1x5qt47rw84c4k6xvvywtrd40p8gxjt8wnmlahlqg07qevah3f8lqwxfs7z",
+      "base": "ibc/447A0DCE83691056289503DDAB8EB08E52E167A73629F2ACC59F056B92F51CE8",
+      "name": "ShibaCosmos",
+      "display": "shibac",
+      "symbol": "SHIBAC",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1x5qt47rw84c4k6xvvywtrd40p8gxjt8wnmlahlqg07qevah3f8lqwxfs7z",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1x5qt47rw84c4k6xvvywtrd40p8gxjt8wnmlahlqg07qevah3f8lqwxfs7z"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/shibacosmos.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:962"
+      ]
+    },
+    {
+      "description": "Sikoba Governance Token",
+      "denom_units": [
+        {
+          "denom": "ibc/71066B030D8FC6479E638580E1BA9C44925E8C1F6E45036669D22017CFDC8C5E",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1qqwf3lkfjhp77yja7gmg3y95pda0e5xctqrdhf3wvwdd79flagvqfgrgxp"
+          ]
+        },
+        {
+          "denom": "sikoba",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1qqwf3lkfjhp77yja7gmg3y95pda0e5xctqrdhf3wvwdd79flagvqfgrgxp",
+      "base": "ibc/71066B030D8FC6479E638580E1BA9C44925E8C1F6E45036669D22017CFDC8C5E",
+      "name": "Sikoba Token",
+      "display": "sikoba",
+      "symbol": "SKOJ",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1qqwf3lkfjhp77yja7gmg3y95pda0e5xctqrdhf3wvwdd79flagvqfgrgxp",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1qqwf3lkfjhp77yja7gmg3y95pda0e5xctqrdhf3wvwdd79flagvqfgrgxp"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sikoba.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sikoba.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:964"
+      ]
+    },
+    {
+      "description": "Nature Carbon Ton (NCT) is a carbon token standard backed 1:1 by carbon credits issued by Verra, a global leader in the voluntary carbon market. NCT credits on Regen Network have been tokenized by Toucan.earth.",
+      "denom_units": [
+        {
+          "denom": "ibc/A76EB6ECF4E3E2D4A23C526FD1B48FDD42F171B206C9D2758EF778A7826ADD68",
+          "exponent": 0,
+          "aliases": [
+            "eco.uC.NCT"
+          ]
+        },
+        {
+          "denom": "nct",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/A76EB6ECF4E3E2D4A23C526FD1B48FDD42F171B206C9D2758EF778A7826ADD68",
+      "name": "Nature Carbon Ton",
+      "display": "nct",
+      "symbol": "NCT",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "regen",
+            "base_denom": "eco.uC.NCT",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-8",
+            "path": "transfer/channel-8/eco.uC.NCT"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/nct.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/nct.svg"
+      },
+      "coingecko_id": "toucan-protocol-nature-carbon-tonne",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076:972"
+      ]
+    },
+    {
+      "description": "Celestims",
+      "denom_units": [
+        {
+          "denom": "ibc/0E4FA664327BD40B32803EE84A77F145834C0281B7F82B65521333B3669FA0BA",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1ngww7zxak55fql42wmyqrr4rhzpne24hhs4p3w4cwhcdgqgr3hxsmzl9zg"
+          ]
+        },
+        {
+          "denom": "clst",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1ngww7zxak55fql42wmyqrr4rhzpne24hhs4p3w4cwhcdgqgr3hxsmzl9zg",
+      "base": "ibc/0E4FA664327BD40B32803EE84A77F145834C0281B7F82B65521333B3669FA0BA",
+      "name": "Celestims",
+      "display": "clst",
+      "symbol": "CLST",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1ngww7zxak55fql42wmyqrr4rhzpne24hhs4p3w4cwhcdgqgr3hxsmzl9zg",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1ngww7zxak55fql42wmyqrr4rhzpne24hhs4p3w4cwhcdgqgr3hxsmzl9zg"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/celestims.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:974"
+      ]
+    },
+    {
+      "description": "The First Doge on Osmosis",
+      "denom_units": [
+        {
+          "denom": "ibc/8AEEA9B9304392070F72611076C0E328CE3F2DECA1E18557E36F9DB4F09C0156",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1ytymtllllsp3hfmndvcp802p2xmy5s8m59ufel8xv9ahyxyfs4hs4kd4je"
+          ]
+        },
+        {
+          "denom": "osdoge",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1ytymtllllsp3hfmndvcp802p2xmy5s8m59ufel8xv9ahyxyfs4hs4kd4je",
+      "base": "ibc/8AEEA9B9304392070F72611076C0E328CE3F2DECA1E18557E36F9DB4F09C0156",
+      "name": "Osmosis Doge",
+      "display": "osdoge",
+      "symbol": "OSDOGE",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1ytymtllllsp3hfmndvcp802p2xmy5s8m59ufel8xv9ahyxyfs4hs4kd4je",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1ytymtllllsp3hfmndvcp802p2xmy5s8m59ufel8xv9ahyxyfs4hs4kd4je"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/osdoge.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:975"
+      ]
+    },
+    {
+      "description": "Apemos",
+      "denom_units": [
+        {
+          "denom": "ibc/1EB03F13F29FEA73444586FC4E88A8C14ACE9291501E9658E3BEF951EA4AC85D",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1jrr0tuuzxrrwcg6hgeqhw5wqpck2y55734e7zcrp745aardlp0qqg8jz06"
+          ]
+        },
+        {
+          "denom": "apemos",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1jrr0tuuzxrrwcg6hgeqhw5wqpck2y55734e7zcrp745aardlp0qqg8jz06",
+      "base": "ibc/1EB03F13F29FEA73444586FC4E88A8C14ACE9291501E9658E3BEF951EA4AC85D",
+      "name": "Apemos",
+      "display": "apemos",
+      "symbol": "APEMOS",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1jrr0tuuzxrrwcg6hgeqhw5wqpck2y55734e7zcrp745aardlp0qqg8jz06",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1jrr0tuuzxrrwcg6hgeqhw5wqpck2y55734e7zcrp745aardlp0qqg8jz06"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/apemos.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:977"
+      ]
+    },
+    {
+      "description": "Evmos Guardians' Invaders DAO token.",
+      "denom_units": [
+        {
+          "denom": "ibc/3DB1721541C94AD19D7735FECED74C227E13F925BDB814392980B40A19C1ED54",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1jwdy7v4egw36pd84aeks3ww6n8k7zhsumd4ac8q5lts83ppxueus4626e8"
+          ]
+        },
+        {
+          "denom": "invdrs",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1jwdy7v4egw36pd84aeks3ww6n8k7zhsumd4ac8q5lts83ppxueus4626e8",
+      "base": "ibc/3DB1721541C94AD19D7735FECED74C227E13F925BDB814392980B40A19C1ED54",
+      "name": "Invaders",
+      "display": "invdrs",
+      "symbol": "INVDRS",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1jwdy7v4egw36pd84aeks3ww6n8k7zhsumd4ac8q5lts83ppxueus4626e8",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1jwdy7v4egw36pd84aeks3ww6n8k7zhsumd4ac8q5lts83ppxueus4626e8"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/invdrs.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:969"
+      ]
+    },
+    {
+      "description": "Doge Apr",
+      "denom_units": [
+        {
+          "denom": "ibc/04BE4E9C825ED781F9684A1226114BB49607500CAD855F1E3FEEC18532297250",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1k2ruzzvvwwtwny6gq6kcwyfhkzahaunp685wmz4hafplduekj98q9hgs6d"
+          ]
+        },
+        {
+          "denom": "doga",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1k2ruzzvvwwtwny6gq6kcwyfhkzahaunp685wmz4hafplduekj98q9hgs6d",
+      "base": "ibc/04BE4E9C825ED781F9684A1226114BB49607500CAD855F1E3FEEC18532297250",
+      "name": "Doge Apr",
+      "display": "doga",
+      "symbol": "DOGA",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1k2ruzzvvwwtwny6gq6kcwyfhkzahaunp685wmz4hafplduekj98q9hgs6d",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1k2ruzzvvwwtwny6gq6kcwyfhkzahaunp685wmz4hafplduekj98q9hgs6d"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/doga.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:978"
+      ]
+    },
+    {
+      "description": "Osmo Pepe",
+      "denom_units": [
+        {
+          "denom": "ibc/00BC6883C29D45EAA021A55CFDD5884CA8EFF9D39F698A9FEF79E13819FF94F8",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1zqrj3ta4u7ylv0wqzd8t8q3jrr9rdmn43zuzp9zemeunecnhy8fss778g7"
+          ]
+        },
+        {
+          "denom": "pepe",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1zqrj3ta4u7ylv0wqzd8t8q3jrr9rdmn43zuzp9zemeunecnhy8fss778g7",
+      "base": "ibc/00BC6883C29D45EAA021A55CFDD5884CA8EFF9D39F698A9FEF79E13819FF94F8",
+      "name": "Osmo Pepe",
+      "display": "pepe",
+      "symbol": "PEPE",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1zqrj3ta4u7ylv0wqzd8t8q3jrr9rdmn43zuzp9zemeunecnhy8fss778g7",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1zqrj3ta4u7ylv0wqzd8t8q3jrr9rdmn43zuzp9zemeunecnhy8fss778g7"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/pepe.png"
+      },
+      "keywords": [
+        "osmosis-price:uosmo:979"
+      ]
+    },
+    {
+      "description": "Catmos",
+      "denom_units": [
+        {
+          "denom": "ibc/F4A07138CAEF0BFB4889E03C44C57956A48631061F1C8AB80421C1F229C1B835",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1f5datjdse3mdgrapwuzs3prl7pvxxht48ns6calnn0t77v2s9l8s0qu488"
+          ]
+        },
+        {
+          "denom": "catmos",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1f5datjdse3mdgrapwuzs3prl7pvxxht48ns6calnn0t77v2s9l8s0qu488",
+      "base": "ibc/F4A07138CAEF0BFB4889E03C44C57956A48631061F1C8AB80421C1F229C1B835",
+      "name": "Catmos",
+      "display": "catmos",
+      "symbol": "CATMOS",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1f5datjdse3mdgrapwuzs3prl7pvxxht48ns6calnn0t77v2s9l8s0qu488",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1f5datjdse3mdgrapwuzs3prl7pvxxht48ns6calnn0t77v2s9l8s0qu488"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/catmos.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:981"
+      ]
+    },
+    {
+      "description": "Social Impact DAO providing showers, meals, and vehicles to the homeless",
+      "denom_units": [
+        {
+          "denom": "ibc/56B988C4D934FB7503F5EA9B440C75D489C8AD5D193715B477BEC4F84B8BBA2A",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1j4ux0f6gt7e82z7jdpm25v4g2gts880ap64rdwa49989wzhd0dfqed6vqm"
+          ]
+        },
+        {
+          "denom": "summit",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1j4ux0f6gt7e82z7jdpm25v4g2gts880ap64rdwa49989wzhd0dfqed6vqm",
+      "base": "ibc/56B988C4D934FB7503F5EA9B440C75D489C8AD5D193715B477BEC4F84B8BBA2A",
+      "name": "Summit",
+      "display": "summit",
+      "symbol": "SUMMIT",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1j4ux0f6gt7e82z7jdpm25v4g2gts880ap64rdwa49989wzhd0dfqed6vqm",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1j4ux0f6gt7e82z7jdpm25v4g2gts880ap64rdwa49989wzhd0dfqed6vqm"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/summit.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:982"
+      ]
+    },
+    {
+      "description": "Social Impact DAO providing showers, meals, and vehicles to the homeless",
+      "denom_units": [
+        {
+          "denom": "ibc/56B988C4D934FB7503F5EA9B440C75D489C8AD5D193715B477BEC4F84B8BBA2A",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1j4ux0f6gt7e82z7jdpm25v4g2gts880ap64rdwa49989wzhd0dfqed6vqm"
+          ]
+        },
+        {
+          "denom": "summit",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1j4ux0f6gt7e82z7jdpm25v4g2gts880ap64rdwa49989wzhd0dfqed6vqm",
+      "base": "ibc/56B988C4D934FB7503F5EA9B440C75D489C8AD5D193715B477BEC4F84B8BBA2A",
+      "name": "Summit",
+      "display": "summit",
+      "symbol": "SUMMIT",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1j4ux0f6gt7e82z7jdpm25v4g2gts880ap64rdwa49989wzhd0dfqed6vqm",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1j4ux0f6gt7e82z7jdpm25v4g2gts880ap64rdwa49989wzhd0dfqed6vqm"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/summit.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:982"
+      ]
+    },
+    {
+      "description": "The native staking token of OmniFlix Hub.",
+      "denom_units": [
+        {
+          "denom": "ibc/CEE970BB3D26F4B907097B6B660489F13F3B0DA765B83CC7D9A0BC0CE220FA6F",
+          "exponent": 0,
+          "aliases": [
+            "uflix"
+          ]
+        },
+        {
+          "denom": "flix",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/CEE970BB3D26F4B907097B6B660489F13F3B0DA765B83CC7D9A0BC0CE220FA6F",
+      "name": "Flix",
+      "display": "flix",
+      "symbol": "FLIX",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "omniflixhub",
+            "base_denom": "uflix",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-199",
+            "path": "transfer/channel-199/uflix"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/omniflixhub/images/flix.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/omniflixhub/images/flix.svg"
+      },
+      "coingecko_id": "omniflix-network",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:992"
+      ]
+    },
+    {
+      "description": "Spacer",
+      "denom_units": [
+        {
+          "denom": "ibc/7A496DB7C2277D4B74EC4428DDB5AC8A62816FBD0DEBE1CFE094935D746BE19C",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1dyyf7pxeassxvftf570krv7fdf5r8e4r04mp99h0mllsqzp3rs4q7y8yqg"
+          ]
+        },
+        {
+          "denom": "spacer",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1dyyf7pxeassxvftf570krv7fdf5r8e4r04mp99h0mllsqzp3rs4q7y8yqg",
+      "base": "ibc/7A496DB7C2277D4B74EC4428DDB5AC8A62816FBD0DEBE1CFE094935D746BE19C",
+      "name": "Spacer",
+      "display": "spacer",
+      "symbol": "SPACER",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1dyyf7pxeassxvftf570krv7fdf5r8e4r04mp99h0mllsqzp3rs4q7y8yqg",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1dyyf7pxeassxvftf570krv7fdf5r8e4r04mp99h0mllsqzp3rs4q7y8yqg"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/spacer.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:993"
+      ]
+    },
+    {
+      "description": "Light: LumenX community DAO treasury token",
+      "denom_units": [
+        {
+          "denom": "ibc/3DC08BDF2689978DBCEE28C7ADC2932AA658B2F64B372760FBC5A0058669AD29",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1dpany8c0lj526lsa02sldv7shzvnw5dt5ues72rk35hd69rrydxqeraz8l"
+          ]
+        },
+        {
+          "denom": "light",
+          "exponent": 9
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1dpany8c0lj526lsa02sldv7shzvnw5dt5ues72rk35hd69rrydxqeraz8l",
+      "base": "ibc/3DC08BDF2689978DBCEE28C7ADC2932AA658B2F64B372760FBC5A0058669AD29",
+      "name": "LIGHT",
+      "display": "light",
+      "symbol": "LIGHT",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1dpany8c0lj526lsa02sldv7shzvnw5dt5ues72rk35hd69rrydxqeraz8l",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1dpany8c0lj526lsa02sldv7shzvnw5dt5ues72rk35hd69rrydxqeraz8l"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/light.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:1009"
+      ]
+    },
+    {
+      "description": "The native token cw20 for Silk on Secret Network",
+      "denom_units": [
+        {
+          "denom": "ibc/8A025A1E70101E39DE0C0F153E582A30806D3DA16795F6D868A3AA247D2DEDF7",
+          "exponent": 0,
+          "aliases": [
+            "cw20:secret1fl449muk5yq8dlad7a22nje4p5d2pnsgymhjfd"
+          ]
+        },
+        {
+          "denom": "silk",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "secret1fl449muk5yq8dlad7a22nje4p5d2pnsgymhjfd",
+      "base": "ibc/8A025A1E70101E39DE0C0F153E582A30806D3DA16795F6D868A3AA247D2DEDF7",
+      "name": "Silk",
+      "display": "silk",
+      "symbol": "SILK",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "secretnetwork",
+            "base_denom": "cw20:secret1fl449muk5yq8dlad7a22nje4p5d2pnsgymhjfd",
+            "port": "wasm.secret1tqmms5awftpuhalcv5h5mg76fa0tkdz4jv9ex4",
+            "channel_id": "channel-44"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-476",
+            "path": "transfer/channel-476/cw20:secret1fl449muk5yq8dlad7a22nje4p5d2pnsgymhjfd"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/silk.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/silk.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:1005"
+      ]
+    },
+    {
+      "description": "Mille: the 1000th token on osmosis",
+      "denom_units": [
+        {
+          "denom": "ibc/912275A63A565BFD80734AEDFFB540132C51E446EAC41483B26EDE8A557C71CF",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1llg7q2d5dqlrqzh5dxv8c7kzzjszld34s5vktqmlmaaxqjssz43sxyhq0d"
+          ]
+        },
+        {
+          "denom": "mile",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1llg7q2d5dqlrqzh5dxv8c7kzzjszld34s5vktqmlmaaxqjssz43sxyhq0d",
+      "base": "ibc/912275A63A565BFD80734AEDFFB540132C51E446EAC41483B26EDE8A557C71CF",
+      "name": "Mille",
+      "display": "mile",
+      "symbol": "MILE",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1llg7q2d5dqlrqzh5dxv8c7kzzjszld34s5vktqmlmaaxqjssz43sxyhq0d",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1llg7q2d5dqlrqzh5dxv8c7kzzjszld34s5vktqmlmaaxqjssz43sxyhq0d"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/mille.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:1000"
+      ]
+    },
+    {
+      "description": "Social Impact DAO dedicated to combatting food insecurity and malnutrition",
+      "denom_units": [
+        {
+          "denom": "ibc/980A2748F37C938AD129B92A51E2ABA8CFFC6862ADD61EC1B291125535DBE30B",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno13ca2g36ng6etcfhr9qxx352uw2n5e92np54thfkm3w3nzlhsgvwsjaqlyq"
+          ]
+        },
+        {
+          "denom": "manna",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno13ca2g36ng6etcfhr9qxx352uw2n5e92np54thfkm3w3nzlhsgvwsjaqlyq",
+      "base": "ibc/980A2748F37C938AD129B92A51E2ABA8CFFC6862ADD61EC1B291125535DBE30B",
+      "name": "Manna",
+      "display": "manna",
+      "symbol": "MANNA",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno13ca2g36ng6etcfhr9qxx352uw2n5e92np54thfkm3w3nzlhsgvwsjaqlyq",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno13ca2g36ng6etcfhr9qxx352uw2n5e92np54thfkm3w3nzlhsgvwsjaqlyq"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/manna.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:997"
+      ]
+    },
+    {
+      "description": "Wrapped FIL on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/18FB5C09D9D2371F659D4846A956FA56225E377EE3C3652A2BF3542BF809159D",
+          "exponent": 0,
+          "aliases": [
+            "wfil-wei"
+          ]
+        },
+        {
+          "denom": "fil",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/18FB5C09D9D2371F659D4846A956FA56225E377EE3C3652A2BF3542BF809159D",
+      "name": "Wrapped FIL from Filecoin",
+      "display": "fil",
+      "symbol": "axlFIL",
+      "traces": [
+        {
+          "type": "wrapped",
+          "counterparty": {
+            "chain_name": "filecoin",
+            "base_denom": "attoFIL"
+          },
+          "provider": "Filecoin"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "filecoin",
+            "base_denom": "0x60E1773636CF5E4A227d9AC24F20fEca034ee25A"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "wfil-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/wfil-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/filecoin/images/wfil.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/filecoin/images/wfil.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-price:uosmo:1006"
+      ]
+    },
+    {
+      "description": "Void",
+      "denom_units": [
+        {
+          "denom": "ibc/593F820ECE676A3E0890C734EC4F3A8DE16EC10A54EEDFA8BDFEB40EEA903960",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1lpvx3mv2a6ddzfjc7zzz2v2cm5gqgqf0hx67hc5p5qwn7hz4cdjsnznhu8"
+          ]
+        },
+        {
+          "denom": "void",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1lpvx3mv2a6ddzfjc7zzz2v2cm5gqgqf0hx67hc5p5qwn7hz4cdjsnznhu8",
+      "base": "ibc/593F820ECE676A3E0890C734EC4F3A8DE16EC10A54EEDFA8BDFEB40EEA903960",
+      "name": "Void",
+      "display": "void",
+      "symbol": "VOID",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1lpvx3mv2a6ddzfjc7zzz2v2cm5gqgqf0hx67hc5p5qwn7hz4cdjsnznhu8",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1lpvx3mv2a6ddzfjc7zzz2v2cm5gqgqf0hx67hc5p5qwn7hz4cdjsnznhu8"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/void.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:1003"
+      ]
+    },
+    {
+      "description": "The native token cw20 for Shade on Secret Network",
+      "denom_units": [
+        {
+          "denom": "ibc/0B3D528E74E3DEAADF8A68F393887AC7E06028904D02173561B0D27F6E751D0A",
+          "exponent": 0,
+          "aliases": [
+            "cw20:secret153wu605vvp934xhd4k9dtd640zsep5jkesstdm"
+          ]
+        },
+        {
+          "denom": "shd",
+          "exponent": 8
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "secret153wu605vvp934xhd4k9dtd640zsep5jkesstdm",
+      "base": "ibc/0B3D528E74E3DEAADF8A68F393887AC7E06028904D02173561B0D27F6E751D0A",
+      "name": "Shade",
+      "display": "shd",
+      "symbol": "SHD",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "secretnetwork",
+            "base_denom": "cw20:secret153wu605vvp934xhd4k9dtd640zsep5jkesstdm",
+            "port": "wasm.secret1tqmms5awftpuhalcv5h5mg76fa0tkdz4jv9ex4",
+            "channel_id": "channel-44"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-476",
+            "path": "transfer/channel-476/cw20:secret153wu605vvp934xhd4k9dtd640zsep5jkesstdm"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/shd.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/shd.svg"
+      },
+      "coingecko_id": "shade-protocol",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:1004"
+      ]
+    },
+    {
+      "description": "The native token of Bluzelle",
+      "denom_units": [
+        {
+          "denom": "ibc/63CDD51098FD99E04E5F5610A3882CBE7614C441607BA6FCD7F3A3C1CD5325F8",
+          "exponent": 0,
+          "aliases": [
+            "ubnt"
+          ]
+        },
+        {
+          "denom": "bnt",
+          "exponent": 6,
+          "aliases": [
+            "blz"
+          ]
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/63CDD51098FD99E04E5F5610A3882CBE7614C441607BA6FCD7F3A3C1CD5325F8",
+      "name": "Bluzelle",
+      "display": "bnt",
+      "symbol": "BLZ",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "bluzelle",
+            "base_denom": "ubnt",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-763",
+            "path": "transfer/channel-763/ubnt"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bluzelle/images/bluzelle.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bluzelle/images/bluzelle.svg"
+      },
+      "coingecko_id": "bluzelle",
+      "keywords": [
+        "bluzelle",
+        "game",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858:1007"
+      ]
+    },
+    {
+      "description": "Arbitrum on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/10E5E5B06D78FFBB61FD9F89209DEE5FD4446ED0550CBB8E3747DA79E10D9DC6",
+          "exponent": 0,
+          "aliases": [
+            "arb-wei"
+          ]
+        },
+        {
+          "denom": "arb",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/10E5E5B06D78FFBB61FD9F89209DEE5FD4446ED0550CBB8E3747DA79E10D9DC6",
+      "name": "Arbitrum",
+      "display": "arb",
+      "symbol": "ARB",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "arbitrum",
+            "base_denom": "0x912CE59144191C1204E64559FE8253a0e49E6548"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "arb-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/arb-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/arbitrum/images/arb.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/arbitrum/images/arb.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:1011"
+      ]
+    },
+    {
+      "description": "Silica",
+      "denom_units": [
+        {
+          "denom": "ibc/5164ECF584AD7DC27DA9E6A89E75DAB0F7C4FCB0A624B69215B8BC6A2C40CD07",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno10vgf2u03ufcf25tspgn05l7j3tfg0j63ljgpffy98t697m5r5hmqaw95ux"
+          ]
+        },
+        {
+          "denom": "silica",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno10vgf2u03ufcf25tspgn05l7j3tfg0j63ljgpffy98t697m5r5hmqaw95ux",
+      "base": "ibc/5164ECF584AD7DC27DA9E6A89E75DAB0F7C4FCB0A624B69215B8BC6A2C40CD07",
+      "name": "Silica",
+      "display": "silica",
+      "symbol": "SLCA",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno10vgf2u03ufcf25tspgn05l7j3tfg0j63ljgpffy98t697m5r5hmqaw95ux",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno10vgf2u03ufcf25tspgn05l7j3tfg0j63ljgpffy98t697m5r5hmqaw95ux"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/silica.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F:1023"
+      ]
+    },
+    {
+      "description": "Pepec",
+      "denom_units": [
+        {
+          "denom": "ibc/C00B17F74C94449A62935B4C886E6F0F643249A270DEF269D53CE6741ECCDB93",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1epxnvge53c4hkcmqzlxryw5fp7eae2utyk6ehjcfpwajwp48km3sgxsh9k"
+          ]
+        },
+        {
+          "denom": "pepec",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1epxnvge53c4hkcmqzlxryw5fp7eae2utyk6ehjcfpwajwp48km3sgxsh9k",
+      "base": "ibc/C00B17F74C94449A62935B4C886E6F0F643249A270DEF269D53CE6741ECCDB93",
+      "name": "Pepec",
+      "display": "pepec",
+      "symbol": "PEPEC",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1epxnvge53c4hkcmqzlxryw5fp7eae2utyk6ehjcfpwajwp48km3sgxsh9k",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1epxnvge53c4hkcmqzlxryw5fp7eae2utyk6ehjcfpwajwp48km3sgxsh9k"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/pepec.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:1016"
+      ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "ibc/E47F4E97C534C95B942729E1B25DBDE111EA791411CFF100515050BEA0AC0C6B",
+          "exponent": 0,
+          "aliases": [
+            "0x6982508145454Ce325dDbE47a25d4ec3d2311933",
+            "pepe-wei"
+          ]
+        },
+        {
+          "denom": "pepe",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/E47F4E97C534C95B942729E1B25DBDE111EA791411CFF100515050BEA0AC0C6B",
+      "name": "Pepe",
+      "display": "pepe",
+      "symbol": "PEPE",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x6982508145454Ce325dDbE47a25d4ec3d2311933"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "pepe-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/pepe-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/pepe.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/pepe.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-price:uosmo:1018"
+      ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "factory/osmo14klwqgkmackvx2tqa0trtg69dmy0nrg4ntq4gjgw2za4734r5seqjqm4gm/uibcx",
+          "exponent": 0
+        },
+        {
+          "denom": "ibcx",
+          "exponent": 6
+        }
+      ],
+      "address": "osmo14klwqgkmackvx2tqa0trtg69dmy0nrg4ntq4gjgw2za4734r5seqjqm4gm",
+      "base": "factory/osmo14klwqgkmackvx2tqa0trtg69dmy0nrg4ntq4gjgw2za4734r5seqjqm4gm/uibcx",
+      "name": "IBCX Core <Product of ION DAO>",
+      "display": "ibcx",
+      "symbol": "IBCX",
+      "traces": [],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ibcx.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/D3B574938631B0A1BA704879020C696E514CFADAA7643CDE4BD5EB010BDE327B:1042"
+      ]
+    },
+    {
+      "description": "Coinbase Wrapped Staked ETH (“cbETH”) is a utility token and liquid representation of ETH staked through Coinbase. cbETH gives customers the option to sell, transfer, or otherwise use their staked ETH in dapps while it remains locked by the Ethereum protocol.",
+      "denom_units": [
+        {
+          "denom": "ibc/4D7A6F2A7744B1534C984A21F9EDFFF8809FC71A9E9243FFB702073E7FCA513A",
+          "exponent": 0,
+          "aliases": [
+            "0xbe9895146f7af43049ca1c1ae358b0541ea49704",
+            "cbeth-wei"
+          ]
+        },
+        {
+          "denom": "cbeth",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/4D7A6F2A7744B1534C984A21F9EDFFF8809FC71A9E9243FFB702073E7FCA513A",
+      "name": "Coinbase Wrapped Staked ETH",
+      "display": "cbeth",
+      "symbol": "cbETH",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "wei"
+          },
+          "provider": "Coinbase"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xbe9895146f7af43049ca1c1ae358b0541ea49704"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "cbeth-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/cbeth-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/cbeth.png"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-price:ibc/B2BD584CD2A0A9CE53D4449667E26160C7D44A9C41AF50F602C201E5B3CCA46C:1030"
+      ]
+    },
+    {
+      "description": "Rocket Pool is a decentralised Ethereum Proof of Stake pool.",
+      "denom_units": [
+        {
+          "denom": "ibc/E610B83FD5544E00A8A1967A2EB3BEF25F1A8CFE8650FE247A8BD4ECA9DC9222",
+          "exponent": 0,
+          "aliases": [
+            "0xae78736cd615f374d3085123a210448e74fc6393",
+            "reth-wei"
+          ]
+        },
+        {
+          "denom": "reth",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/E610B83FD5544E00A8A1967A2EB3BEF25F1A8CFE8650FE247A8BD4ECA9DC9222",
+      "name": "Rocket Pool Ether",
+      "display": "reth",
+      "symbol": "rETH",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "wei"
+          },
+          "provider": "Rocket Pool"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xae78736cd615f374d3085123a210448e74fc6393"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "reth-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/reth-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/reth.png"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-price:ibc/B2BD584CD2A0A9CE53D4449667E26160C7D44A9C41AF50F602C201E5B3CCA46C:1030"
+      ]
+    },
+    {
+      "description": "sfrxETH is the version of frxETH which accrues staking yield. All profit generated from Frax Ether validators is distributed to sfrxETH holders. By exchanging frxETH for sfrxETH, one become's eligible for staking yield, which is redeemed upon converting sfrxETH back to frxETH.",
+      "denom_units": [
+        {
+          "denom": "ibc/81F578C39006EB4B27FFFA9460954527910D73390991B379C03B18934D272F46",
+          "exponent": 0,
+          "aliases": [
+            "0xac3e018457b222d93114458476f3e3416abbe38f",
+            "sfrxeth-wei"
+          ]
+        },
+        {
+          "denom": "sfrxeth",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/81F578C39006EB4B27FFFA9460954527910D73390991B379C03B18934D272F46",
+      "name": "Staked Frax Ether",
+      "display": "sfrxeth",
+      "symbol": "sfrxETH",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "wei"
+          },
+          "provider": "Frax"
+        },
+        {
+          "type": "wrapped",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x5e8422345238f34275888049021821e8e08caa1f"
+          },
+          "provider": "Frax"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xac3e018457b222d93114458476f3e3416abbe38f"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "sfrxeth-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/sfrxeth-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/sfrxeth.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-price:ibc/B2BD584CD2A0A9CE53D4449667E26160C7D44A9C41AF50F602C201E5B3CCA46C:1030"
+      ]
+    },
+    {
+      "description": "wstETH is a wrapped version of stETH. As some DeFi protocols require a constant balance mechanism for tokens, wstETH keeps your balance of stETH fixed and uses an underlying share system to reflect your earned staking rewards.",
+      "denom_units": [
+        {
+          "denom": "ibc/B2BD584CD2A0A9CE53D4449667E26160C7D44A9C41AF50F602C201E5B3CCA46C",
+          "exponent": 0,
+          "aliases": [
+            "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+            "wsteth-wei"
+          ]
+        },
+        {
+          "denom": "wsteth",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/B2BD584CD2A0A9CE53D4449667E26160C7D44A9C41AF50F602C201E5B3CCA46C",
+      "name": "Wrapped Lido Staked Ether",
+      "display": "wsteth",
+      "symbol": "wstETH",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "wei"
+          },
+          "provider": "Lido"
+        },
+        {
+          "type": "wrapped",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84"
+          },
+          "provider": "Lido"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar",
+            "base_denom": "wsteth-wei",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-208",
+            "path": "transfer/channel-208/wsteth-wei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wsteth.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-price:ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5:1024"
+      ]
+    },
+    {
+      "description": "The native token of Gitopia",
+      "denom_units": [
+        {
+          "denom": "ibc/B1C1806A540B3E165A2D42222C59946FB85BA325596FC85662D7047649F419F3",
+          "exponent": 0,
+          "aliases": [
+            "ulore"
+          ]
+        },
+        {
+          "denom": "LORE",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/B1C1806A540B3E165A2D42222C59946FB85BA325596FC85662D7047649F419F3",
+      "name": "LORE",
+      "display": "LORE",
+      "symbol": "LORE",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gitopia",
+            "base_denom": "ulore",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-781",
+            "path": "transfer/channel-781/ulore"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gitopia/images/lore.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gitopia/images/lore.svg"
+      },
+      "coingecko_id": "gitopia",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:1036"
+      ]
+    },
+    {
+      "description": "Lion DAO is a community DAO that lives on the Terra blockchain with the mission to reactivate the LUNAtic community and showcase Terra protocols & tooling",
+      "denom_units": [
+        {
+          "denom": "ibc/98BCD43F190C6960D0005BC46BB765C827403A361C9C03C2FF694150A30284B0",
+          "exponent": 0,
+          "aliases": [
+            "cw20:terra1lxx40s29qvkrcj8fsa3yzyehy7w50umdvvnls2r830rys6lu2zns63eelv"
+          ]
+        },
+        {
+          "denom": "roar",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "terra1lxx40s29qvkrcj8fsa3yzyehy7w50umdvvnls2r830rys6lu2zns63eelv",
+      "base": "ibc/98BCD43F190C6960D0005BC46BB765C827403A361C9C03C2FF694150A30284B0",
+      "name": "Lion DAO",
+      "display": "roar",
+      "symbol": "ROAR",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "terra2",
+            "base_denom": "cw20:terra1lxx40s29qvkrcj8fsa3yzyehy7w50umdvvnls2r830rys6lu2zns63eelv",
+            "port": "wasm.terra1e0mrzy8077druuu42vs0hu7ugguade0cj65dgtauyaw4gsl4kv0qtdf2au",
+            "channel_id": "channel-26"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-341",
+            "path": "transfer/channel-341/cw20:terra1lxx40s29qvkrcj8fsa3yzyehy7w50umdvvnls2r830rys6lu2zns63eelv"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/roar.png"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:1043"
+      ]
+    },
+    {
+      "description": "The native token of Umee",
+      "denom_units": [
+        {
+          "denom": "ibc/02F196DA6FD0917DD5FEA249EE61880F4D941EE9059E7964C5C9B50AF103800F",
+          "exponent": 0,
+          "aliases": [
+            "stuumee"
+          ]
+        },
+        {
+          "denom": "stumee",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/02F196DA6FD0917DD5FEA249EE61880F4D941EE9059E7964C5C9B50AF103800F",
+      "name": "stUMEE",
+      "display": "stumee",
+      "symbol": "stUMEE",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "umee",
+            "base_denom": "uumee"
+          },
+          "provider": "Stride"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "stride",
+            "base_denom": "stuumee",
+            "channel_id": "channel-5"
+          },
+          "chain": {
+            "channel_id": "channel-326",
+            "path": "transfer/channel-326/stuumee"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stumee.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stumee.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C:1035"
+      ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "factory/osmo1xqw2sl9zk8a6pch0csaw78n4swg5ws8t62wc5qta4gnjxfqg6v2qcs243k/stuibcx",
+          "exponent": 0
+        },
+        {
+          "denom": "stibcx",
+          "exponent": 6
+        }
+      ],
+      "address": "osmo1xqw2sl9zk8a6pch0csaw78n4swg5ws8t62wc5qta4gnjxfqg6v2qcs243k",
+      "base": "factory/osmo1xqw2sl9zk8a6pch0csaw78n4swg5ws8t62wc5qta4gnjxfqg6v2qcs243k/stuibcx",
+      "name": "stIBCX Core <Product of ION DAO>",
+      "display": "stibcx",
+      "symbol": "stIBCX",
+      "traces": [],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/stibcx.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/stibcx.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:1039"
+      ]
+    },
+    {
+      "description": "The native token of Nolus chain",
+      "denom_units": [
+        {
+          "denom": "ibc/D9AFCECDD361D38302AA66EB3BAC23B95234832C51D12489DC451FA2B7C72782",
+          "exponent": 0,
+          "aliases": [
+            "unls"
+          ]
+        },
+        {
+          "denom": "nls",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/D9AFCECDD361D38302AA66EB3BAC23B95234832C51D12489DC451FA2B7C72782",
+      "name": "Nolus",
+      "display": "nls",
+      "symbol": "NLS",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "nolus",
+            "base_denom": "unls",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-783",
+            "path": "transfer/channel-783/unls"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nolus/images/nolus.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nolus/images/nolus.svg"
+      },
+      "coingecko_id": "nolus",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858:1041"
+      ]
+    },
+    {
+      "description": "Lion Cub DAO is a useless meme community DAO on Terra",
+      "denom_units": [
+        {
+          "denom": "ibc/6F18EFEBF1688AA77F7EAC17065609494DC1BA12AFC78E9AEC832AF70A11BEF3",
+          "exponent": 0,
+          "aliases": [
+            "cw20:terra1lalvk0r6nhruel7fvzdppk3tup3mh5j4d4eadrqzfhle4zrf52as58hh9t"
+          ]
+        },
+        {
+          "denom": "cub",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "terra1lalvk0r6nhruel7fvzdppk3tup3mh5j4d4eadrqzfhle4zrf52as58hh9t",
+      "base": "ibc/6F18EFEBF1688AA77F7EAC17065609494DC1BA12AFC78E9AEC832AF70A11BEF3",
+      "name": "Lion Cub DAO",
+      "display": "cub",
+      "symbol": "CUB",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "terra2",
+            "base_denom": "cw20:terra1lalvk0r6nhruel7fvzdppk3tup3mh5j4d4eadrqzfhle4zrf52as58hh9t",
+            "port": "wasm.terra1e0mrzy8077druuu42vs0hu7ugguade0cj65dgtauyaw4gsl4kv0qtdf2au",
+            "channel_id": "channel-26"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-341",
+            "path": "transfer/channel-341/cw20:terra1lalvk0r6nhruel7fvzdppk3tup3mh5j4d4eadrqzfhle4zrf52as58hh9t"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/cub.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9:1072"
+      ]
+    },
+    {
+      "description": "BLUE CUB DAO is a community DAO on Terra",
+      "denom_units": [
+        {
+          "denom": "ibc/DA961FE314B009C38595FFE3AF41225D8894D663B8C3F6650DCB5B6F8435592E",
+          "exponent": 0,
+          "aliases": [
+            "cw20:terra1gwrz9xzhqsygyr5asrgyq3pu0ewpn00mv2zenu86yvx2nlwpe8lqppv584"
+          ]
+        },
+        {
+          "denom": "blue",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "terra1gwrz9xzhqsygyr5asrgyq3pu0ewpn00mv2zenu86yvx2nlwpe8lqppv584",
+      "base": "ibc/DA961FE314B009C38595FFE3AF41225D8894D663B8C3F6650DCB5B6F8435592E",
+      "name": "BLUE CUB DAO",
+      "display": "blue",
+      "symbol": "BLUE",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "terra2",
+            "base_denom": "cw20:terra1gwrz9xzhqsygyr5asrgyq3pu0ewpn00mv2zenu86yvx2nlwpe8lqppv584",
+            "port": "wasm.terra1e0mrzy8077druuu42vs0hu7ugguade0cj65dgtauyaw4gsl4kv0qtdf2au",
+            "channel_id": "channel-26"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-341",
+            "path": "transfer/channel-341/cw20:terra1gwrz9xzhqsygyr5asrgyq3pu0ewpn00mv2zenu86yvx2nlwpe8lqppv584"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/blue.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9:1073"
+      ]
+    },
+    {
+      "description": "The native token of Neutron chain.",
+      "denom_units": [
+        {
+          "denom": "ibc/126DA09104B71B164883842B769C0E9EC1486C0887D27A9999E395C2C8FB5682",
+          "exponent": 0,
+          "aliases": [
+            "untrn"
+          ]
+        },
+        {
+          "denom": "ntrn",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/126DA09104B71B164883842B769C0E9EC1486C0887D27A9999E395C2C8FB5682",
+      "name": "Neutron",
+      "display": "ntrn",
+      "symbol": "NTRN",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "neutron",
+            "base_denom": "untrn",
+            "channel_id": "channel-10"
+          },
+          "chain": {
+            "channel_id": "channel-874",
+            "path": "transfer/channel-874/untrn"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/ntrn.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/ntrn.svg"
+      },
+      "coingecko_id": "neutron",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:1046"
+      ]
+    },
+    {
+      "description": "An innovative DAO dedicated to housing the most vulnerable",
+      "denom_units": [
+        {
+          "denom": "ibc/2F5C084037D951B24D100F15CC013A131DF786DCE1B1DBDC48F018A9B9A138DE",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1ju8k8sqwsqu5k6umrypmtyqu2wqcpnrkf4w4mntvl0javt4nma7s8lzgss"
+          ]
+        },
+        {
+          "denom": "casa",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1ju8k8sqwsqu5k6umrypmtyqu2wqcpnrkf4w4mntvl0javt4nma7s8lzgss",
+      "base": "ibc/2F5C084037D951B24D100F15CC013A131DF786DCE1B1DBDC48F018A9B9A138DE",
+      "name": "Casa",
+      "display": "casa",
+      "symbol": "CASA",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1ju8k8sqwsqu5k6umrypmtyqu2wqcpnrkf4w4mntvl0javt4nma7s8lzgss",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1ju8k8sqwsqu5k6umrypmtyqu2wqcpnrkf4w4mntvl0javt4nma7s8lzgss"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/casa.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:1028"
+      ]
+    },
+    {
+      "description": "The native staking and governance token of Composable.",
+      "denom_units": [
+        {
+          "denom": "ibc/56D7C03B8F6A07AD322EEE1BEF3AE996E09D1C1E34C27CF37E0D4A0AC5972516",
+          "exponent": 0,
+          "aliases": [
+            "ppica"
+          ]
+        },
+        {
+          "denom": "pica",
+          "exponent": 12
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/56D7C03B8F6A07AD322EEE1BEF3AE996E09D1C1E34C27CF37E0D4A0AC5972516",
+      "name": "Pica",
+      "display": "pica",
+      "symbol": "PICA",
+      "traces": [
+        {
+          "type": "additional-mintage",
+          "counterparty": {
+            "chain_name": "picasso",
+            "base_denom": "ppica"
+          },
+          "provider": "Composable Finance"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "composable",
+            "base_denom": "ppica",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-1279",
+            "path": "transfer/channel-1279/ppica"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/composable/images/pica.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:1057"
+      ]
+    },
+    {
+      "description": "The native staking and governance token of Kusama Relay Chain.",
+      "denom_units": [
+        {
+          "denom": "ibc/6727B2F071643B3841BD535ECDD4ED9CAE52ABDD0DCD07C3630811A7A37B215C",
+          "exponent": 0,
+          "aliases": [
+            "4",
+            "ibc/EE9046745AEC0E8302CB7ED9D5AD67F528FB3B7AE044B247FB0FB293DBDA35E9"
+          ]
+        },
+        {
+          "denom": "ksm",
+          "exponent": 12
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/6727B2F071643B3841BD535ECDD4ED9CAE52ABDD0DCD07C3630811A7A37B215C",
+      "name": "KSM",
+      "display": "ksm",
+      "symbol": "KSM",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "kusama",
+            "base_denom": "Planck"
+          },
+          "provider": "Kusama Parachain"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "picasso",
+            "base_denom": "4",
+            "channel_id": "channel-17"
+          },
+          "chain": {
+            "channel_id": "channel-2",
+            "path": "transfer/channel-2/4"
+          }
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "composable",
+            "base_denom": "ibc/EE9046745AEC0E8302CB7ED9D5AD67F528FB3B7AE044B247FB0FB293DBDA35E9",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-1279",
+            "path": "transfer/channel-1279/transfer/channel-2/4"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/kusama/images/ksm.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:1058"
+      ]
+    },
+    {
+      "description": "The native staking and governance token of Polkadot Relay Chain.",
+      "denom_units": [
+        {
+          "denom": "ibc/6B2B19D874851F631FF0AF82C38A20D4B82F438C7A22F41EDA33568345397244",
+          "exponent": 0,
+          "aliases": [
+            "79228162514264337593543950342",
+            "ibc/3CC19CEC7E5A3E90E78A5A9ECC5A0E2F8F826A375CF1E096F4515CF09DA3E366"
+          ]
+        },
+        {
+          "denom": "dot",
+          "exponent": 10
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/6B2B19D874851F631FF0AF82C38A20D4B82F438C7A22F41EDA33568345397244",
+      "name": "DOT",
+      "display": "dot",
+      "symbol": "DOT",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "polkadot",
+            "base_denom": "Planck"
+          },
+          "provider": "Polkadot Relay"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "composablepolkadot",
+            "base_denom": "79228162514264337593543950342",
+            "channel_id": "channel-15"
+          },
+          "chain": {
+            "channel_id": "channel-15",
+            "path": "transfer/channel-15/79228162514264337593543950342"
+          }
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "picasso",
+            "base_denom": "79228162514264337593543950342",
+            "channel_id": "channel-17"
+          },
+          "chain": {
+            "channel_id": "channel-2",
+            "path": "transfer/channel-2/transfer/channel-15/79228162514264337593543950342"
+          }
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "composable",
+            "base_denom": "ibc/3CC19CEC7E5A3E90E78A5A9ECC5A0E2F8F826A375CF1E096F4515CF09DA3E366",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-1279",
+            "path": "transfer/channel-1279/transfer/channel-2/transfer/channel-15/79228162514264337593543950342"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.svg"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:1069"
+      ]
+    },
+    {
+      "description": "The native currency of the Realio Network.",
+      "denom_units": [
+        {
+          "denom": "ibc/1CDF9C7D073DD59ED06F15DB08CC0901F2A24759BE70463570E8896F9A444ADF",
+          "exponent": 0,
+          "aliases": [
+            "ario"
+          ]
+        },
+        {
+          "denom": "rio",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/1CDF9C7D073DD59ED06F15DB08CC0901F2A24759BE70463570E8896F9A444ADF",
+      "name": "Realio Network",
+      "display": "rio",
+      "symbol": "RIO",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "realio",
+            "base_denom": "ario",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-1424",
+            "path": "transfer/channel-1424/ario"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/realio/images/rio.png"
+      },
+      "coingecko_id": "realio-network",
+      "keywords": [
+        "osmosis-info",
+        "osmosis-price:ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:1084"
+      ]
+    },
+    {
+      "description": "The native token of Quasar",
+      "denom_units": [
+        {
+          "denom": "ibc/1B708808D372E959CD4839C594960309283424C775F4A038AAEBE7F83A988477",
+          "exponent": 0,
+          "aliases": [
+            "uqsr"
+          ]
+        },
+        {
+          "denom": "qsr",
+          "exponent": 6,
+          "aliases": []
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/1B708808D372E959CD4839C594960309283424C775F4A038AAEBE7F83A988477",
+      "name": "Quasar",
+      "display": "qsr",
+      "symbol": "QSR",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "quasar",
+            "base_denom": "uqsr",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-688",
+            "path": "transfer/channel-688/uqsr"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quasar/images/quasar.png"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:1060"
+      ]
+    },
+    {
+      "description": "The native token of Archway network",
+      "denom_units": [
+        {
+          "denom": "ibc/23AB778D694C1ECFC59B91D8C399C115CC53B0BD1C61020D8E19519F002BDD85",
+          "exponent": 0,
+          "aliases": [
+            "aarch"
+          ]
+        },
+        {
+          "denom": "uarch",
+          "exponent": 12
+        },
+        {
+          "denom": "arch",
+          "exponent": 18
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/23AB778D694C1ECFC59B91D8C399C115CC53B0BD1C61020D8E19519F002BDD85",
+      "name": "Archway",
+      "display": "arch",
+      "symbol": "ARCH",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "archway",
+            "base_denom": "aarch",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-1429",
+            "path": "transfer/channel-1429/aarch"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/archway.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/archway.svg"
+      },
+      "coingecko_id": "archway",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:1061"
+      ]
+    },
+    {
+      "description": "The native staking and governance token of Empower.",
+      "denom_units": [
+        {
+          "denom": "ibc/DD3938D8131F41994C1F01F4EB5233DEE9A0A5B787545B9A07A321925655BF38",
+          "exponent": 0,
+          "aliases": [
+            "umpwr"
+          ]
+        },
+        {
+          "denom": "mpwr",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/DD3938D8131F41994C1F01F4EB5233DEE9A0A5B787545B9A07A321925655BF38",
+      "name": "MPWR",
+      "display": "mpwr",
+      "symbol": "MPWR",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "empowerchain",
+            "base_denom": "umpwr",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-1411",
+            "path": "transfer/channel-1411/umpwr"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/empowerchain/images/mpwr.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:1065"
+      ]
+    },
+    {
+      "description": "A revolutionary DAO created to bring clean drinking water to men, women, and children worldwide. We hope you join us on our journey!",
+      "denom_units": [
+        {
+          "denom": "ibc/AABCB14ACAFD53A5C455BAC01EA0CA5AE18714895846681A52BFF1E3B960B44E",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1m4h8q4p305wgy7vkux0w6e5ylhqll3s6pmadhxkhqtuwd5wlxhxs8xklsw"
+          ]
+        },
+        {
+          "denom": "watr",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1m4h8q4p305wgy7vkux0w6e5ylhqll3s6pmadhxkhqtuwd5wlxhxs8xklsw",
+      "base": "ibc/AABCB14ACAFD53A5C455BAC01EA0CA5AE18714895846681A52BFF1E3B960B44E",
+      "name": "WATR",
+      "display": "watr",
+      "symbol": "WATR",
+      "traces": [
+        {
+          "type": "ibc-cw20",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "cw20:juno1m4h8q4p305wgy7vkux0w6e5ylhqll3s6pmadhxkhqtuwd5wlxhxs8xklsw",
+            "port": "wasm.juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+            "channel_id": "channel-47"
+          },
+          "chain": {
+            "port": "transfer",
+            "channel_id": "channel-169",
+            "path": "transfer/channel-169/cw20:juno1m4h8q4p305wgy7vkux0w6e5ylhqll3s6pmadhxkhqtuwd5wlxhxs8xklsw"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/watr.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:1071"
+      ]
+    },
+    {
+      "description": "The native utility token of the KYVE network.",
+      "denom_units": [
+        {
+          "denom": "ibc/613BF0BF2F2146AE9941E923725745E931676B2C14E9768CD609FA0849B2AE13",
+          "exponent": 0,
+          "aliases": [
+            "ukyve"
+          ]
+        },
+        {
+          "denom": "kyve",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/613BF0BF2F2146AE9941E923725745E931676B2C14E9768CD609FA0849B2AE13",
+      "name": "KYVE",
+      "display": "kyve",
+      "symbol": "KYVE",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "kyve",
+            "base_denom": "ukyve",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-767",
+            "path": "transfer/channel-767/ukyve"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kyve/images/kyve-token.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kyve/images/kyve-token.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:uosmo:1075"
+      ]
+    },
+    {
+      "description": "Tether gives you the joint benefits of open blockchain technology and traditional currency by converting your cash into a stable digital currency equivalent.",
+      "denom_units": [
+        {
+          "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
+          "exponent": 0,
+          "aliases": [
+            "erc20/tether/usdt"
+          ]
+        },
+        {
+          "denom": "usdt",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
+      "name": "Tether USD",
+      "display": "usdt",
+      "symbol": "USDT",
+      "traces": [
+        {
+          "type": "synthetic",
+          "counterparty": {
+            "chain_name": "forex",
+            "base_denom": "USD"
+          },
+          "provider": "Tether"
+        },
+        {
+          "type": "additional-mintage",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+          },
+          "provider": "Tether"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "kava",
+            "base_denom": "erc20/tether/usdt",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-143",
+            "path": "transfer/channel-143/erc20/tether/usdt"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier"
+      ]
+    },
+    {
+      "description": "ERIS liquid staked OSMO",
+      "denom_units": [
+        {
+          "denom": "factory/osmo1dv8wz09tckslr2wy5z86r46dxvegylhpt97r9yd6qc3kyc6tv42qa89dr9/ampOSMO",
+          "exponent": 0
+        },
+        {
+          "denom": "ampOSMO",
+          "exponent": 6
+        }
+      ],
+      "address": "osmo1dv8wz09tckslr2wy5z86r46dxvegylhpt97r9yd6qc3kyc6tv42qa89dr9",
+      "base": "factory/osmo1dv8wz09tckslr2wy5z86r46dxvegylhpt97r9yd6qc3kyc6tv42qa89dr9/ampOSMO",
+      "name": "ERIS Amplified OSMO",
+      "display": "ampOSMO",
+      "symbol": "ampOSMO",
+      "traces": [],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/amp.osmo.png"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-price:uosmo:1067"
+      ]
+    },
+    {
+      "description": "The native staking token of Sei.",
+      "denom_units": [
+        {
+          "denom": "ibc/71F11BC0AF8E526B80E44172EBA9D3F0A8E03950BB882325435691EBC9450B1D",
+          "exponent": 0,
+          "aliases": [
+            "usei"
+          ]
+        },
+        {
+          "denom": "sei",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/71F11BC0AF8E526B80E44172EBA9D3F0A8E03950BB882325435691EBC9450B1D",
+      "name": "Sei",
+      "display": "sei",
+      "symbol": "SEI",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "sei",
+            "base_denom": "usei",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-782",
+            "path": "transfer/channel-782/usei"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sei/images/sei.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sei/images/sei.svg"
+      },
+      "coingecko_id": "sei-network",
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-price:uosmo:1086"
+      ]
+    },
+    {
+      "description": "Quicksilver Liquid Staked SOMM",
+      "denom_units": [
+        {
+          "denom": "ibc/EAF76AD1EEF7B16D167D87711FB26ABE881AC7D9F7E6D0CF313D5FA530417208",
+          "exponent": 0,
+          "aliases": [
+            "uqsomm"
+          ]
+        },
+        {
+          "denom": "qsomm",
+          "exponent": 6,
+          "aliases": []
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/EAF76AD1EEF7B16D167D87711FB26ABE881AC7D9F7E6D0CF313D5FA530417208",
+      "name": "Quicksilver Liquid Staked SOMM",
+      "display": "qsomm",
+      "symbol": "qSOMM",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "sommelier",
+            "base_denom": "usomm"
+          },
+          "provider": "Quicksilver"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "quicksilver",
+            "base_denom": "uqsomm",
+            "channel_id": "channel-2"
+          },
+          "chain": {
+            "channel_id": "channel-522",
+            "path": "transfer/channel-522/uqsomm"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qsomm.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qsomm.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E:1087"
+      ]
+    },
+    {
+      "description": "The native staking and governance token of the Passage chain.",
+      "denom_units": [
+        {
+          "denom": "ibc/208B2F137CDE510B44C41947C045CFDC27F996A9D990EA64460BDD5B3DBEB2ED",
+          "exponent": 0,
+          "aliases": [
+            "upasg"
+          ]
+        },
+        {
+          "denom": "pasg",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/208B2F137CDE510B44C41947C045CFDC27F996A9D990EA64460BDD5B3DBEB2ED",
+      "name": "Passage",
+      "display": "pasg",
+      "symbol": "PASG",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "passage",
+            "base_denom": "upasg",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-2494",
+            "path": "transfer/channel-2494/upasg"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/passage/images/pasg.png"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858:1137"
+      ]
+    },
+    {
+      "description": "Somm Token (SOMM) is the native staking token of the Sommelier Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/5A0060579D24FBE5268BEA74C3281E7FE533D361C41A99307B4998FEC611E46B",
+          "exponent": 0,
+          "aliases": [
+            "stusomm"
+          ]
+        },
+        {
+          "denom": "stsomm",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/5A0060579D24FBE5268BEA74C3281E7FE533D361C41A99307B4998FEC611E46B",
+      "name": "stSOMM",
+      "display": "stsomm",
+      "symbol": "stSOMM",
+      "traces": [
+        {
+          "type": "liquid-stake",
+          "counterparty": {
+            "chain_name": "sommelier",
+            "base_denom": "usomm"
+          },
+          "provider": "Stride"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "stride",
+            "base_denom": "stusomm",
+            "channel_id": "channel-5"
+          },
+          "chain": {
+            "channel_id": "channel-326",
+            "path": "transfer/channel-326/stusomm"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stsomm.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stsomm.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier",
+        "osmosis-info",
+        "osmosis-price:ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E:1120"
+      ]
+    },
+    {
+      "description": "Wrapped SOL (Wormhole), SOL, factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/8sYgCzLRJC3J7qPn2bNbx6PiGcarhyx8rBhVaNnfvHCA",
+      "denom_units": [
+        {
+          "denom": "ibc/C058818AD1980A9C77F26D1BEF9E3ADF674C9659EB88563FD46950A9BC4164A6",
+          "exponent": 0,
+          "aliases": [
+            "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/8sYgCzLRJC3J7qPn2bNbx6PiGcarhyx8rBhVaNnfvHCA"
+          ]
+        },
+        {
+          "denom": "wormhole/8sYgCzLRJC3J7qPn2bNbx6PiGcarhyx8rBhVaNnfvHCA/8",
+          "exponent": 8,
+          "aliases": []
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "wormhole1wn625s4jcmvk0szpl85rj5azkfc6suyvf75q6vrddscjdphtve8sca0pvl",
+      "base": "ibc/C058818AD1980A9C77F26D1BEF9E3ADF674C9659EB88563FD46950A9BC4164A6",
+      "name": "Wrapped SOL (Wormhole)",
+      "display": "wormhole/8sYgCzLRJC3J7qPn2bNbx6PiGcarhyx8rBhVaNnfvHCA/8",
+      "symbol": "SOL",
+      "traces": [
+        {
+          "type": "wrapped",
+          "counterparty": {
+            "chain_name": "solana",
+            "base_denom": "Lamport"
+          },
+          "provider": "Solana"
+        },
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "solana",
+            "base_denom": "So11111111111111111111111111111111111111112"
+          },
+          "provider": "Wormhole"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gateway",
+            "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/8sYgCzLRJC3J7qPn2bNbx6PiGcarhyx8rBhVaNnfvHCA",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-2186",
+            "path": "transfer/channel-2186/factory:wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx:8sYgCzLRJC3J7qPn2bNbx6PiGcarhyx8rBhVaNnfvHCA"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/sol.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier"
+      ]
+    },
+    {
+      "description": "Bonk (Wormhole), Bonk, factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/95mnwzvJZJ3fKz77xfGN2nR5to9pZmH8YNvaxgLgw5AR",
+      "denom_units": [
+        {
+          "denom": "ibc/620CD4A652485ECC8BEE7716D5D64BEA1B165612FCCD9706D63A4248CB685E7C",
+          "exponent": 0,
+          "aliases": [
+            "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/95mnwzvJZJ3fKz77xfGN2nR5to9pZmH8YNvaxgLgw5AR"
+          ]
+        },
+        {
+          "denom": "wormhole/95mnwzvJZJ3fKz77xfGN2nR5to9pZmH8YNvaxgLgw5AR/5",
+          "exponent": 5,
+          "aliases": []
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "wormhole10qt8wg0n7z740ssvf3urmvgtjhxpyp74hxqvqt7z226gykuus7eq9mpu8u",
+      "base": "ibc/620CD4A652485ECC8BEE7716D5D64BEA1B165612FCCD9706D63A4248CB685E7C",
+      "name": "Bonk (Wormhole)",
+      "display": "wormhole/95mnwzvJZJ3fKz77xfGN2nR5to9pZmH8YNvaxgLgw5AR/5",
+      "symbol": "Bonk",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "solana",
+            "base_denom": "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263"
+          },
+          "provider": "Wormhole"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gateway",
+            "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/95mnwzvJZJ3fKz77xfGN2nR5to9pZmH8YNvaxgLgw5AR",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-2186",
+            "path": "transfer/channel-2186/factory:wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx:95mnwzvJZJ3fKz77xfGN2nR5to9pZmH8YNvaxgLgw5AR"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/bonk.png"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier"
+      ]
+    },
+    {
+      "description": "Tether USD (Wormhole), USDT, factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/8iuAc6DSeLvi2JDUtwJxLytsZT8R19itXebZsNReLLNi",
+      "denom_units": [
+        {
+          "denom": "ibc/4EDA0CAEE870C8FCA5DDCD390F11B89BA850654D81FEAEF9DBBA17D722239D70",
+          "exponent": 0,
+          "aliases": [
+            "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/8iuAc6DSeLvi2JDUtwJxLytsZT8R19itXebZsNReLLNi"
+          ]
+        },
+        {
+          "denom": "wormhole/8iuAc6DSeLvi2JDUtwJxLytsZT8R19itXebZsNReLLNi/6",
+          "exponent": 6,
+          "aliases": []
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "wormhole1w27ekqvvtzfanfxnkw4jx2f8gdfeqwd3drkee3e64xat6phwjg0savgmhw",
+      "base": "ibc/4EDA0CAEE870C8FCA5DDCD390F11B89BA850654D81FEAEF9DBBA17D722239D70",
+      "name": "Tether USD (Wormhole)",
+      "display": "wormhole/8iuAc6DSeLvi2JDUtwJxLytsZT8R19itXebZsNReLLNi/6",
+      "symbol": "USDT.wh",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+          },
+          "provider": "Wormhole"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gateway",
+            "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/8iuAc6DSeLvi2JDUtwJxLytsZT8R19itXebZsNReLLNi",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-2186",
+            "path": "transfer/channel-2186/factory:wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx:8iuAc6DSeLvi2JDUtwJxLytsZT8R19itXebZsNReLLNi"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdt.hole.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier"
+      ]
+    },
+    {
+      "description": "Sui (Wormhole), SUI, factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/46YEtoSN1AcwgGSRoWruoS6bnVh8XpMp5aQTpKohCJYh",
+      "denom_units": [
+        {
+          "denom": "ibc/034873957DC93F6650D50760F2C289C5AA0AFEB307D8A8AE7E167F40023341D5",
+          "exponent": 0,
+          "aliases": [
+            "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/46YEtoSN1AcwgGSRoWruoS6bnVh8XpMp5aQTpKohCJYh"
+          ]
+        },
+        {
+          "denom": "wormhole/46YEtoSN1AcwgGSRoWruoS6bnVh8XpMp5aQTpKohCJYh/8",
+          "exponent": 8,
+          "aliases": []
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "wormhole19hlynxzedrlqv99v6qscww7d3crhl86qtd0vprpltg5g9xx6jk9q6ya33y",
+      "base": "ibc/034873957DC93F6650D50760F2C289C5AA0AFEB307D8A8AE7E167F40023341D5",
+      "name": "Sui (Wormhole)",
+      "display": "wormhole/46YEtoSN1AcwgGSRoWruoS6bnVh8XpMp5aQTpKohCJYh/8",
+      "symbol": "SUI",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "sui",
+            "base_denom": "0x2::sui::SUI"
+          },
+          "provider": "Wormhole"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gateway",
+            "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/46YEtoSN1AcwgGSRoWruoS6bnVh8XpMp5aQTpKohCJYh",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-2186",
+            "path": "transfer/channel-2186/factory:wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx:46YEtoSN1AcwgGSRoWruoS6bnVh8XpMp5aQTpKohCJYh"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/sui/images/sui.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier"
+      ]
+    },
+    {
+      "description": "Aptos Coin (Wormhole), APT, factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5wS2fGojbL9RhGEAeQBdkHPUAciYDxjDTMYvdf9aDn2r",
+      "denom_units": [
+        {
+          "denom": "ibc/F5493DA7706B00E955ADBC6DDDA24789D4644A81C5E96277A54A0B9C5FD63543",
+          "exponent": 0,
+          "aliases": [
+            "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5wS2fGojbL9RhGEAeQBdkHPUAciYDxjDTMYvdf9aDn2r"
+          ]
+        },
+        {
+          "denom": "wormhole/5wS2fGojbL9RhGEAeQBdkHPUAciYDxjDTMYvdf9aDn2r/8",
+          "exponent": 8,
+          "aliases": []
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "wormhole1f9sxjn0qu8xylcpzlvnhrefnatndqxnrajfrnr5h97hegnmsdqhsh6juc0",
+      "base": "ibc/F5493DA7706B00E955ADBC6DDDA24789D4644A81C5E96277A54A0B9C5FD63543",
+      "name": "Aptos Coin (Wormhole)",
+      "display": "wormhole/5wS2fGojbL9RhGEAeQBdkHPUAciYDxjDTMYvdf9aDn2r/8",
+      "symbol": "APT",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "aptos",
+            "base_denom": "0x1::aptos_coin::AptosCoin"
+          },
+          "provider": "Wormhole"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gateway",
+            "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5wS2fGojbL9RhGEAeQBdkHPUAciYDxjDTMYvdf9aDn2r",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-2186",
+            "path": "transfer/channel-2186/factory:wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx:5wS2fGojbL9RhGEAeQBdkHPUAciYDxjDTMYvdf9aDn2r"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/aptos/images/aptos.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier"
+      ]
+    },
+    {
+      "description": "MantaDAO Governance Token",
+      "denom_units": [
+        {
+          "denom": "ibc/51D893F870B7675E507E91DA8DB0B22EA66333207E4F5C0708757F08EE059B0B",
+          "exponent": 0,
+          "aliases": [
+            "factory/kujira1643jxg8wasy5cfcn7xm8rd742yeazcksqlg4d7/umnta"
+          ]
+        },
+        {
+          "denom": "mnta",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/51D893F870B7675E507E91DA8DB0B22EA66333207E4F5C0708757F08EE059B0B",
+      "name": "MNTA",
+      "display": "MNTA",
+      "symbol": "MNTA",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "kujira",
+            "base_denom": "factory/kujira1643jxg8wasy5cfcn7xm8rd742yeazcksqlg4d7/umnta",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-259",
+            "path": "transfer/channel-259/factory:kujira1643jxg8wasy5cfcn7xm8rd742yeazcksqlg4d7:umnta"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/mnta.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/mnta.svg"
+      },
+      "coingecko_id": "mantadao",
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-price:uosmo:1139"
+      ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "ibc/DB421D24F8571EDBA4816557B8D459B444ADD795E499289841228AD3EFB2B791",
+          "exponent": 0,
+          "aliases": [
+            "factory/juno1u805lv20qc6jy7c3ttre7nct6uyl20pfky5r7e/DGL"
+          ]
+        },
+        {
+          "denom": "dgl",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "juno1u805lv20qc6jy7c3ttre7nct6uyl20pfky5r7e",
+      "base": "ibc/DB421D24F8571EDBA4816557B8D459B444ADD795E499289841228AD3EFB2B791",
+      "name": "Licorice",
+      "display": "dgl",
+      "symbol": "DGL",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "juno",
+            "base_denom": "factory/juno1u805lv20qc6jy7c3ttre7nct6uyl20pfky5r7e/DGL",
+            "channel_id": "channel-0"
+          },
+          "chain": {
+            "channel_id": "channel-42",
+            "path": "transfer/channel-42/factory:juno1u805lv20qc6jy7c3ttre7nct6uyl20pfky5r7e:DGL"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/dgl.png"
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
+    },
+    {
+      "description": "USD Coin (Wormhole), USDC, factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/GGh9Ufn1SeDGrhzEkMyRKt5568VbbxZK2yvWNsd6PbXt",
+      "denom_units": [
+        {
+          "denom": "ibc/9FB3464A62D6E1D712E3036E11757FF88626F41CCA87F061AB0EF469CF4D19FC",
+          "exponent": 0,
+          "aliases": [
+            "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/GGh9Ufn1SeDGrhzEkMyRKt5568VbbxZK2yvWNsd6PbXt"
+          ]
+        },
+        {
+          "denom": "wormhole/GGh9Ufn1SeDGrhzEkMyRKt5568VbbxZK2yvWNsd6PbXt/6",
+          "exponent": 6,
+          "aliases": []
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "wormhole1utjx3594tlvfw4375esgu72wa4sdgf0q7x4ye27husf5kvuzp5rsr72gdq",
+      "base": "ibc/9FB3464A62D6E1D712E3036E11757FF88626F41CCA87F061AB0EF469CF4D19FC",
+      "name": "USD Coin (Wormhole)",
+      "display": "wormhole/GGh9Ufn1SeDGrhzEkMyRKt5568VbbxZK2yvWNsd6PbXt/6",
+      "symbol": "USDC.wh",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+          },
+          "provider": "Wormhole"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gateway",
+            "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/GGh9Ufn1SeDGrhzEkMyRKt5568VbbxZK2yvWNsd6PbXt",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-2186",
+            "path": "transfer/channel-2186/factory:wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx:GGh9Ufn1SeDGrhzEkMyRKt5568VbbxZK2yvWNsd6PbXt"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.hole.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier"
+      ]
+    },
+    {
+      "description": "Wrapped Ether (Wormhole), WETH, factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5BWqpR48Lubd55szM5i62zK7TFkddckhbT48yy6mNbDp",
+      "denom_units": [
+        {
+          "denom": "ibc/580F8A1EF2A4281116B8F331973CC87E579811593859AC11B4E46BF6EA73EBFE",
+          "exponent": 0,
+          "aliases": [
+            "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5BWqpR48Lubd55szM5i62zK7TFkddckhbT48yy6mNbDp"
+          ]
+        },
+        {
+          "denom": "wormhole/5BWqpR48Lubd55szM5i62zK7TFkddckhbT48yy6mNbDp/8",
+          "exponent": 8,
+          "aliases": []
+        }
+      ],
+      "type_asset": "ics20",
+      "address": "wormhole18csycs4vm6varkp00apuqlsm7v4twg8jsljk8wfdd7cghr7g4rtslwqndm",
+      "base": "ibc/580F8A1EF2A4281116B8F331973CC87E579811593859AC11B4E46BF6EA73EBFE",
+      "name": "Wrapped Ether (Wormhole)",
+      "display": "wormhole/5BWqpR48Lubd55szM5i62zK7TFkddckhbT48yy6mNbDp/8",
+      "symbol": "wETH.wh",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereum",
+            "base_denom": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+          },
+          "provider": "Wormhole"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "gateway",
+            "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5BWqpR48Lubd55szM5i62zK7TFkddckhbT48yy6mNbDp",
+            "channel_id": "channel-3"
+          },
+          "chain": {
+            "channel_id": "channel-2186",
+            "path": "transfer/channel-2186/factory:wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx:5BWqpR48Lubd55szM5i62zK7TFkddckhbT48yy6mNbDp"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/weth.hole.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier"
+      ]
+    },
+    {
+      "description": "USD Coin",
+      "denom_units": [
+        {
+          "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+          "exponent": 0,
+          "aliases": [
+            "microusdc",
+            "uusdc"
+          ]
+        },
+        {
+          "denom": "usdc",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+      "name": "USD Coin",
+      "display": "usdc",
+      "symbol": "noble.USDC",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "noble",
+            "base_denom": "uusdc",
+            "channel_id": "channel-1"
+          },
+          "chain": {
+            "channel_id": "channel-750",
+            "path": "transfer/channel-750/uusdc"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/noble.usdc.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-frontier"
+      ]
+    }
+  ]
+}

--- a/src/templates/osmosis.yml
+++ b/src/templates/osmosis.yml
@@ -1,0 +1,21 @@
+networks:
+  mainnet:
+    rpcURL: https://rpc.osmosis.zone/   # AKA nodeurl sometimes - see xdc ## ALSO CAN USE https://rpc.cosmos.directory/osmosis
+    nodeURL: https://rpc.osmosis.zone/   # AKA nodeurl sometimes - see xdc ## ALSO CAN USE https://rpc.cosmos.directory/osmosis
+    tokenListType: URL
+    tokenListSource: https://raw.githubusercontent.com/osmosis-labs/assetlists/main/osmosis-1/osmosis-1.assetlist.json
+    chainId: osmosis-1
+  testnet:
+    rpcURL: https://rpc.testnet.osmosis.zone/
+    nodeURL: https://rpc.testnet.osmosis.zone/
+    tokenListType: URL
+    tokenListSource: https://raw.githubusercontent.com/osmosis-labs/osmosis/c387e00c6338fa113ccb3abcb129f633670445f6/cmd/osmosisd/cmd/osmo-test-5-assetlist.json
+    chainId: osmo-test-5
+network: mainnet
+nativeCurrencySymbol: OSMO
+
+feeTier: medium
+gasAdjustment: 1.3
+gasLimitTransaction: 2000000
+manualGasPrice: 0.025uosmo
+allowedSlippage: 2%

--- a/src/templates/root.yml
+++ b/src/templates/root.yml
@@ -72,6 +72,10 @@ configurations:
     configurationPath: cosmos.yml
     schemaPath: cosmos-schema.json
 
+  $namespace osmosis:
+    configurationPath: osmosis.yml
+    schemaPath: osmosis-schema.json
+
   $namespace cronos:
     configurationPath: cronos.yml
     schemaPath: ethereum-schema.json

--- a/test/chains/osmosis/osmosis.test.ts
+++ b/test/chains/osmosis/osmosis.test.ts
@@ -1,0 +1,421 @@
+import { patch, unpatch } from '../../services/patch';
+import { Osmosis } from '../../../src/chains/osmosis/osmosis';
+import { ConfigManagerCertPassphrase } from '../../../src/services/config-manager-cert-passphrase';
+import { addWallet, getWallets } from '../../../src/services/wallet/wallet.controllers';
+import Decimal from 'decimal.js-light';
+import { CosmosAsset } from '../../../src/chains/cosmos/cosmos-base';
+import { Side } from '../../../src/amm/amm.requests';
+
+const osmosisAddress = 'osmo1gxfandcf6x6y0lv3afv0p4w4akv809ycrly4cs';
+const osmosisPrivateKey = '2e8be986f72f76dba7f8448b2e2342d3297cd628cf08aad9b90098102824f9d5'; // real 
+// const zer3oAddress = '0000000000000000000000000000000000000000000000000000000000000000'; // noqa: mock
+const liveAddressNik = 'osmo1mvsg3en5ulpnpd3dset2m86zjpnzp4v4epmjh7'
+
+jest.setTimeout(300000); // run for 5 mins
+
+let osmosis: Osmosis;
+
+beforeAll(async () => {
+  patch(ConfigManagerCertPassphrase, 'readPassphrase', () => 'macymo');
+  osmosis = Osmosis.getInstance('testnet');
+
+  await osmosis.init();
+});
+
+beforeEach(() => {
+});
+
+afterEach(() => {
+});
+
+afterAll(async () => {
+  unpatch();
+  await osmosis.close();
+});
+
+describe('wallets', () => {
+  it('add an Osmosmis wallet', async () => {
+    await addWallet({
+      privateKey: osmosisPrivateKey,
+      chain: 'osmosis',
+      network: 'testnet',
+    });
+
+    const wallets = await getWallets();
+
+    const addresses: string[][] = wallets
+      .filter((wallet) => wallet.chain === 'osmosis')
+      .map((wallet) => wallet.walletAddresses);
+
+    expect(addresses[0]).toContain(osmosisAddress);
+  });
+});
+
+describe('chain.routes', () => {
+
+  it('getTokens', async () => {
+    var getTokens = await osmosis.controller.getTokens(osmosis, {tokenSymbols:['OSMO']});
+    //console.debug(getTokens);
+    expect(getTokens.tokens[0].symbol).toEqual('OSMO');
+  });
+
+  it('getTokens All', async () => {
+    var getTokens = await osmosis.controller.getTokens(osmosis, {});
+    //console.debug(getTokens);
+    expect(getTokens.tokens.length).toEqual(12);
+  });
+
+  it('balances OSMO', async () => {
+    const balances = await osmosis.controller.balances(osmosis, {address:osmosisAddress, tokenSymbols:['OSMO']});
+    //console.debug(balances);
+    expect(Number(balances.balances['OSMO'])).toBeGreaterThan(0);
+  });
+
+  it('balances All', async () => {
+    const balances = await osmosis.controller.balances(osmosis, {address:osmosisAddress, tokenSymbols:['OSMO']});
+    //console.debug(balances);
+    expect(Number(balances.balances['OSMO'])).toBeGreaterThan(0);
+  });
+
+  it('getWalletFromPrivateKey', async () => {
+    const walleto = await osmosis.getWalletFromPrivateKey(
+      osmosisPrivateKey,
+      'osmo'
+    );
+    //console.debug(walleto);
+    expect(walleto.prefix).toEqual('osmo');
+
+    const balanceo = await osmosis.getBalances(walleto)
+    expect(Number(balanceo['OSMO'].value)).toBeGreaterThan(0);
+  });
+
+  it('balances All', async () => {
+    const block = await osmosis.getCurrentBlockNumber();
+    //console.debug(block);
+    expect(block).toBeGreaterThan(0);
+  });
+
+  it('getTokenBySymbol', async () => {
+    var token = osmosis.getTokenBySymbol('ATOM');
+    var token2 = osmosis.getTokenForSymbol('OSMO');
+    //console.debug(token);
+    //console.debug(token2);
+    expect(token.decimals).toEqual(6);
+    expect(token2.symbol).toEqual('OSMO');
+  });
+
+  it('transfer', async () => {
+    var transfer = await osmosis.controller.transfer(osmosis, {'from':osmosisAddress, 'to':liveAddressNik, 'token':'OSMO', amount:'0.000001', 'chain':'osmosis', 'network':'testnet'});
+    //console.debug(transfer);
+    expect(transfer).toContain('Transfer success');
+  });
+
+});
+
+
+describe('chain.routes - DISABLED', () => {
+
+  it('allowances', async () => {
+    var allowances = await osmosis.controller.allowances(osmosis, {'address':osmosisAddress, 'spender':liveAddressNik, 'tokenSymbols':[], 'chain':'osmosis', 'network':'testnet'});
+    //console.debug(allowances);
+    expect(allowances.spender).toBeUndefined()
+  });
+
+  it('approve', async () => {
+    var approve = await osmosis.controller.approve(osmosis, {'address':osmosisAddress, 'spender':liveAddressNik, token:'OSMO', 'chain':'osmosis', 'network':'testnet'});
+    //console.debug(approve);
+    expect(approve.spender).toBeUndefined()
+  });
+
+  it('cancel', async () => {
+    var cancel = await osmosis.controller.cancel(osmosis, {'address':osmosisAddress, 'nonce':0, 'chain':'osmosis', 'network':'testnet'});
+    //console.debug(cancel);
+    expect(cancel.txHash).toBeUndefined()
+  });
+
+  it('nextNonce', async () => {
+    var nextNonce = await osmosis.controller.nextNonce(osmosis, {'address':osmosisAddress, 'chain':'osmosis', 'network':'testnet'});
+    //console.debug(nextNonce);
+    expect(nextNonce.nonce).toEqual(0)
+  });
+
+  it('nonce', async () => {
+    var nonce = await osmosis.controller.nonce(osmosis, {'address':osmosisAddress, 'chain':'osmosis', 'network':'testnet'});
+    //console.debug(nonce);
+    expect(nonce.nonce).toEqual(0)
+  });
+
+});
+
+
+
+describe('controllers - price + trade', () => {
+
+  it('estimateGas', async () => {
+    var estimateGas = await osmosis.controller.estimateGas(osmosis);
+    //console.debug(estimateGas);
+    expect(estimateGas.gasPriceToken).toEqual('uosmo');
+  });
+
+  it('getTradeInfo', async () => {
+    const tradeInfo = await osmosis.controller.getTradeInfo(osmosis, "OSMO", "ION", new Decimal(1.0), "BUY")
+    //console.debug(tradeInfo);
+    expect((tradeInfo.baseToken as CosmosAsset).base).toEqual('uosmo');
+    expect(tradeInfo.requestAmount.toNumber()).toEqual(1);
+    expect(tradeInfo.expectedTrade.routes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('price', async () => {
+    // slippage must be high on testnet due to price mismatch with pool ratios
+    const priceRequest1 = {'quote':'ION', 'base':'OSMO', 'amount':'1', 'side':'BUY' as Side, 'allowedSlippage':'100%', 'chain':'osmosis', 'network':'testnet'};
+    const priceResponse1 = await osmosis.controller.price(osmosis, priceRequest1)
+    //console.debug(priceResponse1)
+    expect(priceResponse1.base).toEqual('OSMO')
+  });
+
+  it('trade', async () => {
+    const tradeRequest = {'quote':'ION', 'base':'OSMO', 'amount':'0.01', 'side':'BUY' as Side, 'allowedSlippage':'100%', 'chain':'osmosis', 'network':'testnet', 'address':osmosisAddress, };
+    const tradeResponse = await osmosis.controller.trade(osmosis, tradeRequest)
+    //console.debug(tradeResponse);
+    expect(tradeResponse.base).toEqual('uosmo')
+  });
+
+  it('trade back', async () => {
+    const tradeRequest = {'quote':'OSMO', 'base':'ION', 'amount':'0.0001', 'side':'BUY' as Side, 'allowedSlippage':'100%', 'chain':'osmosis', 'network':'testnet', 'address':osmosisAddress, };
+    const tradeResponse = await osmosis.controller.trade(osmosis, tradeRequest)
+    //console.debug(tradeResponse);
+    expect(tradeResponse.base).toEqual('uion')
+  });
+
+
+  // try {
+  //   //console.debug('priceResponse2');
+  //   const priceRequest2 = {'quote':'OSMO', 'base':'ION', 'amount':'1', 'side':'BUY' as Side, 'allowedSlippage':'100%', 'chain':'osmosis', 'network':'testnet'};
+  //   const priceResponse2 = await osmosis.controller.price(osmosis, priceRequest2)
+  //   //console.debug(priceResponse2)
+  // } catch (err) {
+  //   //console.debug(err);
+  // }
+
+  // try {
+  //   //console.debug('priceResponse3');
+  //   const priceRequest3 = {'quote':'ATOM', 'base':'OSMO', 'amount':'0.01', 'side':'BUY' as Side, 'allowedSlippage':'100%', 'chain':'osmosis', 'network':'testnet'};
+  //   const priceResponse3 = await osmosis.controller.price(osmosis, priceRequest3)
+  //   //console.debug(priceResponse3)
+  // } catch (err) {
+  //   //console.debug(err);
+  // }
+
+  // fail no ATOM in wallet
+  // try {
+  //   //console.debug('tradeResponse2');
+  //   const tradeRequest2 = {'quote':'OSMO', 'base':'ATOM', 'amount':'0.01', 'side':'BUY' as Side, 'allowedSlippage':'100%', 'chain':'osmosis', 'network':'testnet', 'address':osmosisAddress, };
+  //   const tradeResponse2 = await osmosis.controller.trade(osmosis, tradeRequest2)
+  //   //console.debug(tradeResponse2)
+  // } catch (err) {
+  //   //console.debug(err);
+  // }
+
+  // try {
+  //   //console.debug('tradeResponse2');
+  //   const tradeRequest2 = {'quote':'ATOM', 'base':'OSMO', 'amount':'0.01', 'side':'BUY' as Side, 'allowedSlippage':'20%', 'chain':'osmosis', 'network':'testnet', 'address':osmosisAddress, };
+  //   const tradeResponse2 = await osmosis.controller.trade(osmosis, tradeRequest2)
+  //   //console.debug(tradeResponse2)
+  // } catch (err) {
+  //   //console.debug(err);
+  // }
+
+  // try {
+  //   //console.debug('tradeResponse2');
+  //   const tradeRequest2 = {'quote':'ION', 'base':'OSMO', 'amount':'0.01', 'side':'BUY' as Side, 'allowedSlippage':'100%', 'chain':'osmosis', 'network':'testnet', 'address':osmosisAddress, };
+  //   const tradeResponse2 = await osmosis.controller.trade(osmosis, tradeRequest2)
+  //   //console.debug(tradeResponse2)
+  // } catch (err) {
+  //   //console.debug(err);
+  // }
+
+
+});
+
+
+describe('controllers - CL Pools + Liquidity', () => {
+
+  // best to join pools using one amount == 0 (so input 1 token type at a time)
+  //  adds tend to fail unless amounts input are similar in relative $ value
+  it('addLiquidity', async () => {
+    const addLiquidityRequestFunction = {'poolId':'62', 'fee': 'high', 'token0':'ION', 'token1':'OSMO', 'amount0':'0.0005', 'amount1':'0', 'chain':'osmosis', 'network':'testnet', 'address':osmosisAddress, };
+    var addLiquidityResponse = await osmosis.controller.addLiquidity(osmosis, addLiquidityRequestFunction)
+    //console.debug(addLiquidityResponse);
+    expect(addLiquidityResponse.poolId).toEqual('62')
+  });
+
+  it('positionsRequest', async () => {
+    const positionsRequest1 = {
+      chain:'osmosis', 
+      network:'testnet',
+      address: osmosisAddress,
+    }
+    var positionsResponse1 = await osmosis.controller.poolPositions(osmosis, positionsRequest1)
+    //console.debug(positionsResponse1);
+    expect(positionsResponse1.pools.length).toBeGreaterThan(0)
+  });
+
+  it('removeLiquidity', async () => {
+    const removeLiquidityRequest = {'decreasePercent':100, 'poolId':'62', 'chain':'osmosis', 'network':'testnet', 'address':osmosisAddress, 'allowedSlippage':'100%'};
+    var removeLiquidityResponse = await osmosis.controller.removeLiquidity(osmosis, removeLiquidityRequest)
+    //console.debug(removeLiquidityResponse);
+    expect(removeLiquidityResponse.txHash).toBeDefined();
+  });
+
+  it('poolPrice', async () => {
+    const poolPriceRequest = {
+      chain:'osmosis', 
+      network:'testnet',
+      address: osmosisAddress,
+      token0: 'OSMO',
+      token1: 'ATOM',
+    }
+    var poolPriceResponse = await osmosis.controller.poolPrice(osmosis, poolPriceRequest)
+    //console.debug(poolPriceResponse);
+    expect(poolPriceResponse.token0).toEqual('OSMO')
+  });
+
+});
+
+  
+
+// describe('chain.routes via endpoints', () => {
+//   it('/status', async () => {
+//     var res1 = await request(gatewayApp)
+//     //console.debug(res1)
+//     var res = await request(gatewayApp)
+//       .get(`/status`)
+//       .send({
+//         chain: 'osmosis',
+//         network: 'testnet',
+//       })
+//       .set('Accept', 'application/json')
+//       .expect('Content-Type', /json/)
+//       .expect(200)
+//       //console.debug(res)
+//   });
+
+//   it('/balances', async () => {
+//     var res = await request(gatewayApp)
+//       .post(`/balances`)
+//       .send({
+//         chain: 'osmosis',
+//         network: 'testnet',
+//         address: osmosisAddress,
+//         // tokenSymbols: ['OSMO'],
+//       })
+//       .set('Accept', 'application/json')
+//       .expect('Content-Type', /json/)
+//       .expect(200)
+//       // .expect((res) => expect(res.body.approvals.WETH).toEqual('0.001'))
+//       //console.debug(res)
+//   });
+
+//   it('/tokens', async () => {
+//     var res = await request(gatewayApp)
+//       .get(`/chain/tokens?chain=osmosis&network=testnet`)
+//       .send({
+//       })
+//       .set('Accept', 'application/json')
+//       .expect('Content-Type', /json/)
+//       .expect(200)
+//       // .expect((res) => expect(res.body.approvals.WETH).toEqual('0.001'))
+//       //console.debug(res)
+//   });
+
+//   it('/poll', async () => {
+//     var res = await request(gatewayApp)
+//       .get(`/poll`)
+//       .send({
+//       })
+//       .set('Accept', 'application/json')
+//       .expect('Content-Type', /json/)
+//       .expect(200)
+//       .expect((res) => expect(res.body.currentBlock).toBeDefined())
+//       //console.debug(res)
+//   });
+
+//   it('/transfer', async () => {
+//     var res = await request(gatewayApp)
+//       .post(`/transfer`)
+//       .send({
+//         chain: 'osmosis',
+//         network: 'testnet',
+//         to: liveAddressNik,
+//         from: osmosisAddress,
+//         amount: 0.0001,
+//         token: 'OSMO'
+//       })
+//       .set('Accept', 'application/json')
+//       .expect('Content-Type', /json/)
+//       .expect(200)
+//       .expect((res) => expect(res.body).toContain('Transfer success'))
+//       //console.debug(res)
+//   });
+
+// });
+
+// describe('chain.routes - DISABLED via endpoints', () => {
+
+//   it('/allowances', async () => {
+//     var res = await request(gatewayApp)
+//       .post(`/allowances`)
+//       .send({
+//       })
+//       .set('Accept', 'application/json')
+//       .expect('Content-Type', /json/)
+//       .expect(200)
+//       .expect((res) => expect(res.body.spender).toBeUndefined())
+//       //console.debug(res)
+//   });
+
+//   it('/approve', async () => {
+//     var res = await request(gatewayApp)
+//       .post(`/approve`)
+//       .send({
+//       })
+//       .set('Accept', 'application/json')
+//       .expect('Content-Type', /json/)
+//       .expect(200)
+//       .expect((res) => expect(res.body.spender).toBeUndefined())
+//       //console.debug(res)
+//   });
+    
+//   it('/cancel', async () => {
+//     var res = await request(gatewayApp)
+//       .post(`/cancel`)
+//       .send({
+//       })
+//       .set('Accept', 'application/json')
+//       .expect('Content-Type', /json/)
+//       .expect(200)
+//       .expect((res) => expect(res.body.txHash).toBeUndefined())
+//       //console.debug(res)
+//   });
+    
+//   it('/nextNonce', async () => {
+//     var res = await request(gatewayApp)
+//       .post(`/nextNonce`)
+//       .send({
+//       })
+//       .set('Accept', 'application/json')
+//       .expect('Content-Type', /json/)
+//       .expect(200)
+//       .expect((res) => expect(res.body.nextNonce).toEqual(0))
+//       //console.debug(res)
+//   });
+
+// });
+
+
+
+describe('balances', () => {
+  it('fail if wallet not found', async () => {
+
+  });
+});

--- a/test/chains/osmosis/osmosis.testnojest.ts
+++ b/test/chains/osmosis/osmosis.testnojest.ts
@@ -1,0 +1,453 @@
+
+// @ts-nocheck
+
+import fs = require('fs');
+import path = require('path');
+import https = require('https');
+import axios from 'axios';
+
+type method = 'GET' | 'POST';
+
+const certPath = '/home/vboxuser/hbot/gateway/certs';
+
+const httpsAgent = axios.create({
+  httpsAgent: new https.Agent({
+    ca: fs.readFileSync(certPath.concat('/ca_cert.pem'), {
+      encoding: 'utf-8',
+    }),
+    cert: fs.readFileSync(certPath.concat('/client_cert.pem'), {
+      encoding: 'utf-8',
+    }),
+    key: fs.readFileSync(certPath.concat('/client_key.pem'), {
+      encoding: 'utf-8',
+    }),
+    host: '127.0.0.1',
+    port: 15888,
+    requestCert: true,
+    rejectUnauthorized: false,
+  }),
+});
+const request = async (
+  method: method,
+  path: string,
+  params: Record<string, any>
+) => {
+  try {
+    let response;
+    const gatewayAddress = 'https://127.0.0.1:15888';
+    if (method === 'GET') {
+      response = await httpsAgent.get(gatewayAddress + path);
+    } else {
+      response = await httpsAgent.post(gatewayAddress + path, params);
+    }
+    return response.data;
+  } catch (err) {
+    console.log(`${method} ${path} - ${err}`);
+  }
+};
+
+import { Osmosis } from '../../../src/chains/osmosis/osmosis';
+// import { osmosis } from '../../../src/chains/osmosis/osmosis';
+// import { Side } from '../../../src/amm/liquidity/amm.requests';
+import { addWallet, getWallets } from '../../../src/services/wallet/wallet.controllers';
+import Decimal from 'decimal.js-light';
+// import { price, trade, addLiquidity, removeLiquidity, poolPrice, poolPositions, transfer, getTokens, } from '../../../src/chains/osmosis/osmosis.controllers'; //getTradeInfo, price
+
+const osmosisAddress = 'osmo1gxfandcf6x6y0lv3afv0p4w4akv809ycrly4cs';
+const osmosisPrivateKey = '2e8be986f72f76dba7f8448b2e2342d3297cd628cf08aad9b90098102824f9d5'; // real testnet
+
+const liveAddressNik = 'osmo1mvsg3en5ulpnpd3dset2m86zjpnzp4v4epmjh7'
+
+async function test() {
+  let osmosis: Osmosis;
+  
+  osmosis = Osmosis.getInstance('testnet');
+  await osmosis.init();
+
+
+  // DISABLED ENDPOINTS
+  // try {
+  //   console.debug('allowances');
+  //   var allowances = await osmosis.controller.allowances(osmosis, {'address':osmosisAddress, 'spender':liveAddressNik, 'tokenSymbols':[], 'chain':'osmosis', 'network':'testnet'});
+  //   console.debug(allowances);
+  //   console.debug(allowances);
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+  // try {
+  //   console.debug('cancel');
+  //   var cancel = await osmosis.controller.cancel(osmosis, {'address':osmosisAddress, 'nonce':0, 'chain':'osmosis', 'network':'testnet'});
+  //   console.debug(cancel);
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+  // try {
+  //   console.debug('approve');
+  //   var approve = await osmosis.controller.approve(osmosis, {'address':osmosisAddress, 'spender':liveAddressNik, token:'OSMO', 'chain':'osmosis', 'network':'testnet'});
+  //   console.debug(approve);
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+  // try {
+  //   console.debug('transfer');
+  //   var transfer = await osmosis.controller.transfer(osmosis, {'from':osmosisAddress, 'to':liveAddressNik, 'token':'OSMO', amount:'0.1', 'chain':'osmosis', 'network':'testnet'});
+  //   console.debug(transfer);
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+  // try {
+  //   console.debug('getTokens OSMO');
+  //   var getTokens = await osmosis.controller.getTokens(osmosis, {tokenSymbols:['OSMO']});
+  //   console.debug(getTokens);
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+  // try {
+  //   console.debug('getTokens All');
+  //   var getTokens = await osmosis.controller.getTokens(osmosis, {});
+  //   console.debug(getTokens);
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+  // try {
+  //   console.debug('estimateGas');
+  //   var estimateGas = await osmosis.controller.estimateGas(osmosis);
+  //   console.debug(estimateGas);
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+  // try {
+  //   console.debug('block');
+  //   const block = await osmosis.getCurrentBlockNumber();
+  //   console.debug(block);
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+  // try {
+  //   console.debug('balances OSMO');
+  //   const balances = await osmosis.controller.balances(osmosis, {address:osmosisAddress, tokenSymbols:['OSMO']});
+  //   console.debug(balances);
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+  try {
+    console.debug('balances All');
+    const balances = await osmosis.controller.balances(osmosis, {address:osmosisAddress, tokenSymbols:[]});
+    console.debug(balances);
+  } catch (err) {
+    console.debug(err);
+  }
+
+
+
+  // try {
+  //   await osmosis.clientTests(wallet, osmosisAddress);
+  //   console.debug(wallet);
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+  
+
+  // try {
+  //   console.debug('wallet balances All');
+  //   const walleto = await osmosis.getWalletFromPrivateKey(
+  //     osmosisPrivateKey,
+  //     'osmo'
+  //   );
+  //   const balanceo = await osmosis.getBalances(walleto)
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+
+  // try {
+  //   console.debug('get token');
+  //   var token = osmosis.getTokenBySymbol('ATOM');
+  //   var token2 = osmosis.getTokenForSymbol('OSMO');
+  //   console.debug(token);
+  //   console.debug(token2);
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+
+
+
+  // try {
+  //   console.debug('priceResponse1');
+  //   const priceRequest1 = {'quote':'ION', 'base':'OSMO', 'amount':'1', 'side':'BUY' as Side, 'allowedSlippage':'1%', 'chain':'osmosis', 'network':'testnet'};
+  //   const priceResponse1 = await osmosis.controller.price(osmosis, priceRequest1)
+  //   console.debug(priceResponse1)
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+
+
+  // try {
+  //   console.debug('priceResponse2');
+  //   const priceRequest2 = {'quote':'OSMO', 'base':'ION', 'amount':'1', 'side':'BUY' as Side, 'allowedSlippage':'1%', 'chain':'osmosis', 'network':'testnet'};
+  //   const priceResponse2 = await osmosis.controller.price(osmosis, priceRequest2)
+  //   console.debug(priceResponse2)
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+
+
+  try {
+    console.debug('tradeResponse');
+    const tradeRequest = {'quote':'ION', 'base':'OSMO', 'amount':'0.01', 'side':'BUY' as Side, 'allowedSlippage':'100%', 'chain':'osmosis', 'network':'testnet', 'address':osmosisAddress, };
+    const tradeResponse = await osmosis.controller.trade(osmosis, tradeRequest)
+    console.debug(tradeResponse);
+  } catch (err) {
+    console.debug(err);
+  }
+
+  try {
+    console.debug('tradeResponse');
+    const tradeRequest = {'quote':'OSMO', 'base':'ION', 'amount':'0.0001', 'side':'BUY' as Side, 'allowedSlippage':'100%', 'chain':'osmosis', 'network':'testnet', 'address':osmosisAddress, };
+    const tradeResponse = await osmosis.controller.trade(osmosis, tradeRequest)
+    console.debug(tradeResponse);
+  } catch (err) {
+    console.debug(err);
+  }
+
+
+  // try {
+  //   console.debug('priceResponse3');
+  //   const priceRequest3 = {'quote':'ATOM', 'base':'OSMO', 'amount':'0.01', 'side':'BUY' as Side, 'allowedSlippage':'1%', 'chain':'osmosis', 'network':'testnet'};
+  //   const priceResponse3 = await osmosis.controller.price(osmosis, priceRequest3)
+  //   console.debug(priceResponse3)
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+  // fail no ATOM in wallet
+  // try {
+  //   console.debug('tradeResponse2');
+  //   const tradeRequest2 = {'quote':'OSMO', 'base':'ATOM', 'amount':'0.01', 'side':'BUY' as Side, 'allowedSlippage':'1%', 'chain':'osmosis', 'network':'testnet', 'address':osmosisAddress, };
+  //   const tradeResponse2 = await osmosis.controller.trade(osmosis, tradeRequest2)
+  //   console.debug(tradeResponse2)
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+  // try {
+  //   console.debug('tradeResponse2');
+  //   const tradeRequest2 = {'quote':'ATOM', 'base':'OSMO', 'amount':'0.01', 'side':'BUY' as Side, 'allowedSlippage':'20%', 'chain':'osmosis', 'network':'testnet', 'address':osmosisAddress, };
+  //   const tradeResponse2 = await osmosis.controller.trade(osmosis, tradeRequest2)
+  //   console.debug(tradeResponse2)
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+  // try {
+  //   console.debug('tradeResponse2');
+  //   const tradeRequest2 = {'quote':'ION', 'base':'OSMO', 'amount':'0.01', 'side':'BUY' as Side, 'allowedSlippage':'1%', 'chain':'osmosis', 'network':'testnet', 'address':osmosisAddress, };
+  //   const tradeResponse2 = await osmosis.controller.trade(osmosis, tradeRequest2)
+  //   console.debug(tradeResponse2)
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+  // try {
+  //   const tradeInfo = await osmosis.controller.getTradeInfo(osmosis, "OSMO", "ION", new Decimal(1.0), "BUY")
+  //   console.debug(tradeInfo);
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+  // try {
+  //   console.debug('addLiquidityResponse');
+  //   const addLiquidityRequestFunction = {'poolId':'62', 'fee': 'high', 'token0':'ION', 'token1':'OSMO', 'amount0':'0.0005', 'amount1':'0', 'chain':'osmosis', 'network':'testnet', 'address':osmosisAddress, };
+  //   var addLiquidityResponse = await osmosis.controller.addLiquidity(osmosis, addLiquidityRequestFunction)
+  //   console.debug(addLiquidityResponse);
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+
+
+  // try {
+  //   console.debug('removeLiquidityResponse');
+  //   const removeLiquidityRequest = {'decreasePercent':100, 'poolId':'62', 'chain':'osmosis', 'network':'testnet', 'address':osmosisAddress, 'allowedSlippage':'100%'};
+  //   var removeLiquidityResponse = await osmosis.controller.removeLiquidity(osmosis, removeLiquidityRequest)
+  //   console.debug(removeLiquidityResponse);
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+
+
+  // try {
+  //   console.debug('poolPriceResponse');
+  //   const poolPriceRequest = {
+  //     chain:'osmosis', 
+  //     network:'testnet',
+  //     address: osmosisAddress,
+  //     token0: 'OSMO',
+  //     token1: 'ATOM',
+  //   }
+  //   var poolPriceResponse = await osmosis.controller.poolPrice(osmosis, poolPriceRequest)
+  //   console.debug(poolPriceResponse);
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+  
+
+  // try {
+  //   console.debug('positionsResponse1');
+  //   const positionsRequest1 = {
+  //     chain:'osmosis', 
+  //     network:'testnet',
+  //     address: osmosisAddress,
+  //   }
+  //   var positionsResponse1 = await osmosis.controller.poolPositions(osmosis, positionsRequest1)
+  //   console.debug(positionsResponse1);
+  // } catch (err) {
+  //   console.debug(err);
+  // }
+
+  
+  // await osmosis.close();
+
+}
+
+  // BELOW NEEDS TO HAVE GATEWAY RUNNIN SEPARATELY
+async function testViaEndpoints() {
+  let osmosis: Osmosis;
+  
+  osmosis = Osmosis.getInstance('testnet');
+  await osmosis.init();
+
+  console.debug('starting');
+  console.debug('starting');
+  console.debug('starting');
+  console.debug('starting');
+
+  const status = await request('GET', '/chain/status', {
+    privateKey: osmosisPrivateKey,
+    chain: 'osmosis',
+    network: 'testnet',
+  });
+  console.debug('status');
+  console.debug(status);
+
+  const balances = await request('POST', '/chain/balances', {
+    privateKey: osmosisPrivateKey,
+    address: osmosisAddress,
+    chain: 'osmosis',
+    network: 'testnet',
+    tokenSymbols: ['OSMO','ATOM','ION'],
+  });
+  console.debug('balances');
+  console.debug(balances);
+
+  const tokensList = await osmosis.controller.getTokens(osmosis,{})
+
+  const tokens = await request('GET', '/chain/tokens?chain=osmosis&network=testnet', {
+    privateKey: osmosisPrivateKey,
+    chain: 'osmosis',
+    network: 'testnet',
+    query: {chain: 'osmosis', network: 'testnet'},
+  });
+  console.debug('tokens');
+  console.debug(tokens);
+
+  await osmosis.close();
+
+}
+
+async function testViaEndpoints2() {
+
+  const priceRequest = await request('POST', '/amm/price_osmosis', {
+    privateKey: osmosisPrivateKey,
+    chain: 'osmosis',
+    network: 'testnet',
+    address: osmosisAddress,
+    connector: 'osmosis',
+    quote: 'ION',
+    base: 'OSMO',
+    amount: '0.001',
+    side: 'BUY',
+    allowedSlippage: '1%',
+  });
+  console.debug(priceRequest);
+
+  // can specify poolId
+  const addLiquidityRequest = await request('POST', '/amm/liquidity/add_osmosis', {
+    privateKey: osmosisPrivateKey,
+    chain: 'osmosis',
+    network: 'testnet',
+    address: osmosisAddress,
+    connector: 'osmosis',
+    token0: 'ION',
+    token1: 'OSMO',
+    amount0: '0.001',
+    amount1: '0.1',
+    // poolId: 'testnet',
+  });
+  console.debug(addLiquidityRequest);
+
+  const removeLiquidityRequest = await request('POST', '/amm/liquidity/remove_osmosis', {
+    privateKey: osmosisPrivateKey,
+    chain: 'osmosis',
+    network: 'testnet',
+    address: osmosisAddress,
+    connector: 'osmosis',
+    decreasePercent: 10,
+    poolId: '62',
+  });
+  console.debug(removeLiquidityRequest);
+
+  const poolPriceRequest = await request('POST', '/amm/liquidity/price_osmosis', {
+    privateKey: osmosisPrivateKey,
+    chain: 'osmosis',
+    network: 'testnet',
+    address: osmosisAddress,
+    connector: 'osmosis',
+    token0: 'ION',
+    token1: 'OSMO',
+  });
+  console.debug(poolPriceRequest);
+
+    
+  const poolPriceRequestTest = await request('POST', '/amm/liquidity/price_osmosis', {
+    privateKey: osmosisPrivateKey,
+    chain: 'osmosis',
+    network: 'testnet',
+    address: osmosisAddress,
+    connector: 'osmosis',
+    token0: 'ATOM',
+    token1: 'OSMO',
+  });
+  console.debug(poolPriceRequestTest);
+
+  // can specify poolId
+  const positionsRequest = await request('POST', '/amm/liquidity/positions_osmosis', {
+    privateKey: osmosisPrivateKey,
+    chain: 'osmosis',
+    network: 'testnet',
+    address: osmosisAddress,
+    connector: 'osmosis',
+    // poolId: 'testnet',
+  });
+  console.debug(positionsRequest);
+
+  
+
+
+};
+
+
+// testViaEndpoints();
+// testViaEndpoints2();
+test();

--- a/test/services/wallet/wallet.controllers.test.ts
+++ b/test/services/wallet/wallet.controllers.test.ts
@@ -20,7 +20,7 @@ import { ConfigManagerCertPassphrase } from '../../../src/services/config-manage
 import { BinanceSmartChain } from '../../../src/chains/binance-smart-chain/binance-smart-chain';
 import { Cronos } from '../../../src/chains/cronos/cronos';
 import { Near } from '../../../src/chains/near/near';
-// import { Cosmos } from '../../../src/chains/cosmos/cosmos';
+import { Cosmos } from '../../../src/chains/cosmos/cosmos';
 
 let avalanche: Avalanche;
 let cronos: Cronos;
@@ -28,7 +28,7 @@ let eth: Ethereum;
 let harmony: Harmony;
 let bsc: BinanceSmartChain;
 let near: Near;
-// let cosmos: Cosmos;
+let cosmos: Cosmos;
 
 beforeAll(async () => {
   patch(ConfigManagerCertPassphrase, 'readPassphrase', () => 'a');
@@ -39,7 +39,7 @@ beforeAll(async () => {
   bsc = BinanceSmartChain.getInstance('testnet');
   cronos = Cronos.getInstance('testnet');
   near = Near.getInstance('testnet');
-  // cosmos = Cosmos.getInstance('testnet');
+  cosmos = Cosmos.getInstance('testnet');
 });
 
 beforeEach(() =>
@@ -53,7 +53,7 @@ afterAll(async () => {
   await bsc.close();
   await cronos.close();
   await near.close();
-  // await cosmos.close();
+  await cosmos.close();
 });
 
 afterEach(() => unpatch());
@@ -85,10 +85,25 @@ const encodedPrivateKey = {
   },
 };
 
-// const cosmosAddress = 'cosmos18nadm9qd4pz8pgffhvehc0dthuhpgevp4l3nar';
-// const cosmosPrivateKey =
-//   '218507defde7d91a9eba858437115b8aea68e3cbc7a4b68b3edac53d5ec89516'; // noqa: mock
-// const encodedCosmosPrivateKey = {
+const cosmosAddress = 'cosmos18nadm9qd4pz8pgffhvehc0dthuhpgevp4l3nar';
+const cosmosPrivateKey =
+  '218507defde7d91a9eba858437115b8aea68e3cbc7a4b68b3edac53d5ec89516'; // noqa: mock
+const encodedCosmosPrivateKey = {
+  keyAlgorithm: {
+    name: 'PBKDF2',
+    salt: 'PkkhCEpSae+dYup0Q2ZKpA==',
+    iterations: 500000,
+    hash: 'SHA-256',
+  },
+  cipherAlgorithm: { name: 'AES-GCM', iv: '1mBtuYgYHJ/xkkA7xdU1QQ==' },
+  ciphertext:
+    'F7M1ic/dSNHbD1MrU3gQlv9RCiHaSeyk1Rb63NkKSuOuIE1WeCvVLGha5LujsAJAkQ++Mts+h2Ub2OGCdoFkHRO1BMYF0djNDFmwJlKzd68=',
+};
+
+// const osmosisAddress = 'osmo1gxfandcf6x6y0lv3afv0p4w4akv809ycrly4cs';
+// const osmosisPrivateKey =
+//   '2e8be986f72f76dba7f8448b2e2342d3297cd628cf08aad9b90098102824f9d5'; // real 
+// const encodedOsmosisPrivateKey = {
 //   keyAlgorithm: {
 //     name: 'PBKDF2',
 //     salt: 'PkkhCEpSae+dYup0Q2ZKpA==',
@@ -231,32 +246,32 @@ describe('addWallet and getWallets', () => {
     expect(addresses[0]).toContain(oneAddress);
   });
 
-  // it('add a Cosmos wallet', async () => {
-  //   patch(cosmos, 'getWallet', () => {
-  //     return {
-  //       address: cosmosAddress,
-  //       prefix: 'cosmos',
-  //     };
-  //   });
+  it('add a Cosmos wallet', async () => {
+    patch(cosmos, 'getWallet', () => {
+      return {
+        address: cosmosAddress,
+        prefix: 'cosmos',
+      };
+    });
 
-  //   patch(cosmos, 'encrypt', () => {
-  //     return JSON.stringify(encodedCosmosPrivateKey);
-  //   });
+    patch(cosmos, 'encrypt', () => {
+      return JSON.stringify(encodedCosmosPrivateKey);
+    });
 
-  //   await addWallet({
-  //     privateKey: cosmosPrivateKey,
-  //     chain: 'cosmos',
-  //     network: 'testnet',
-  //   });
+    await addWallet({
+      privateKey: cosmosPrivateKey,
+      chain: 'cosmos',
+      network: 'testnet',
+    });
 
-  //   const wallets = await getWallets();
+    const wallets = await getWallets();
 
-  //   const addresses: string[][] = wallets
-  //     .filter((wallet) => wallet.chain === 'cosmos')
-  //     .map((wallet) => wallet.walletAddresses);
+    const addresses: string[][] = wallets
+      .filter((wallet) => wallet.chain === 'cosmos')
+      .map((wallet) => wallet.walletAddresses);
 
-  //   expect(addresses[0]).toContain(cosmosAddress);
-  // });
+    expect(addresses[0]).toContain(cosmosAddress);
+  });
 
   it('fail to add a wallet to unknown chain', async () => {
     await expect(
@@ -354,32 +369,33 @@ describe('addWallet and removeWallets', () => {
     expect(addresses[0]).not.toContain(oneAddress);
   });
 
-  // it('remove a Cosmos wallet', async () => {
-  //   patch(cosmos, 'getWallet', () => {
-  //     return {
-  //       address: cosmosAddress,
-  //       prefix: 'cosmos',
-  //     };
-  //   });
+  
+  it('remove a Cosmos wallet', async () => {
+    patch(cosmos, 'getWallet', () => {
+      return {
+        address: cosmosAddress,
+        prefix: 'cosmos',
+      };
+    });
 
-  //   patch(cosmos, 'encrypt', () => {
-  //     return JSON.stringify(encodedCosmosPrivateKey);
-  //   });
+    patch(cosmos, 'encrypt', () => {
+      return JSON.stringify(encodedCosmosPrivateKey);
+    });
 
-  //   await addWallet({
-  //     privateKey: cosmosPrivateKey,
-  //     chain: 'cosmos',
-  //     network: 'testnet',
-  //   });
+    await addWallet({
+      privateKey: cosmosPrivateKey,
+      chain: 'cosmos',
+      network: 'testnet',
+    });
 
-  //   await removeWallet({ chain: 'cosmos', address: cosmosAddress });
+    await removeWallet({ chain: 'cosmos', address: cosmosAddress });
 
-  //   const wallets = await getWallets();
+    const wallets = await getWallets();
 
-  //   const addresses: string[][] = wallets
-  //     .filter((wallet) => wallet.chain === 'cosmos')
-  //     .map((wallet) => wallet.walletAddresses);
+    const addresses: string[][] = wallets
+      .filter((wallet) => wallet.chain === 'cosmos')
+      .map((wallet) => wallet.walletAddresses);
 
-  //   expect(addresses[0]).not.toContain(cosmosAddress);
-  // });
+    expect(addresses[0]).not.toContain(cosmosAddress);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -542,12 +542,22 @@
     eventemitter3 "^4.0.7"
     uuid "^8.3.2"
 
-"@chain-registry/types@^0.16.0":
+"@chain-registry/types@0.16.0", "@chain-registry/types@^0.16.0":
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/@chain-registry/types/-/types-0.16.0.tgz#f76409186899a976d33693d7f458c33d71a66730"
   integrity sha512-4j6vq2Vqn/nF+UBjvRPUVs6eM3+5rJ+dPmEWpd/OoNH3wTy1k6aoilcSTZRR//vGcI5EOVGsxhhJxUzo2qqweA==
   dependencies:
     "@babel/runtime" "^7.21.0"
+
+"@chain-registry/utils@1.13.1":
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/@chain-registry/utils/-/utils-1.13.1.tgz#bee23868e0bdee0533e26fb99276c190916332fd"
+  integrity sha512-BV8XoZGGlfeF3d5p06y4w2uDggAxtWa5g5zEDRgcyi6V+iJUSlPwu5PL7IKB5qJvAq7J1Vgw8x+Jqj1TVxjpvA==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
+    "@chain-registry/types" "^0.16.0"
+    bignumber.js "9.1.1"
+    sha.js "^2.4.11"
 
 "@chainsafe/as-sha256@^0.3.1":
   version "0.3.1"
@@ -590,6 +600,18 @@
   dependencies:
     "@chainsafe/as-sha256" "^0.4.1"
     "@chainsafe/persistent-merkle-tree" "^0.6.1"
+
+"@chasevoorhees/osmonauts-math-decimal@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@chasevoorhees/osmonauts-math-decimal/-/osmonauts-math-decimal-1.7.1.tgz#c5157b76c3ae0514b51c39dfb78ca3f1b551f14f"
+  integrity sha512-cAOG4r+Fk++81ixgH/c6SZTog51lrkJwBnGNhj1IhHhMyJjC6fflYEIKelJfrh8OyIObQjMIwDs+ayixUAWBPA==
+  dependencies:
+    "@chain-registry/types" "0.16.0"
+    "@chain-registry/utils" "1.13.1"
+    bignumber.js "9.1.1"
+    decimal.js "10.4.3"
+    long "5.2.3"
+    osmojs "^16.5.1"
 
 "@colors/colors@1.5.0":
   version "1.5.0"
@@ -651,6 +673,26 @@
     "@cosmjs/math" "0.27.1"
     "@cosmjs/utils" "0.27.1"
 
+"@cosmjs/amino@0.29.3":
+  version "0.29.3"
+  resolved "https://registry.yarnpkg.com/@cosmjs/amino/-/amino-0.29.3.tgz#5aa338a301ea970a93e15522706615efea507c10"
+  integrity sha512-BFz1++ERerIggiFc7iGHhGe1CeV3rCv8BvkoBQTBN/ZwzHOaKvqQj8smDlRGlQxX3HWlTwgiLN2A+OB5yX4ZRw==
+  dependencies:
+    "@cosmjs/crypto" "^0.29.3"
+    "@cosmjs/encoding" "^0.29.3"
+    "@cosmjs/math" "^0.29.3"
+    "@cosmjs/utils" "^0.29.3"
+
+"@cosmjs/amino@^0.29.3", "@cosmjs/amino@^0.29.5":
+  version "0.29.5"
+  resolved "https://registry.yarnpkg.com/@cosmjs/amino/-/amino-0.29.5.tgz#053b4739a90b15b9e2b781ccd484faf64bd49aec"
+  integrity sha512-Qo8jpC0BiziTSUqpkNatBcwtKNhCovUnFul9SlT/74JUCdLYaeG5hxr3q1cssQt++l4LvlcpF+OUXL48XjNjLw==
+  dependencies:
+    "@cosmjs/crypto" "^0.29.5"
+    "@cosmjs/encoding" "^0.29.5"
+    "@cosmjs/math" "^0.29.5"
+    "@cosmjs/utils" "^0.29.5"
+
 "@cosmjs/amino@^0.30.1":
   version "0.30.1"
   resolved "https://registry.yarnpkg.com/@cosmjs/amino/-/amino-0.30.1.tgz#7c18c14627361ba6c88e3495700ceea1f76baace"
@@ -694,6 +736,19 @@
     ripemd160 "^2.0.2"
     sha.js "^2.4.11"
 
+"@cosmjs/crypto@^0.29.3", "@cosmjs/crypto@^0.29.5":
+  version "0.29.5"
+  resolved "https://registry.yarnpkg.com/@cosmjs/crypto/-/crypto-0.29.5.tgz#ab99fc382b93d8a8db075780cf07487a0f9519fd"
+  integrity sha512-2bKkaLGictaNL0UipQCL6C1afaisv6k8Wr/GCLx9FqiyFkh9ZgRHDyetD64ZsjnWV/N/D44s/esI+k6oPREaiQ==
+  dependencies:
+    "@cosmjs/encoding" "^0.29.5"
+    "@cosmjs/math" "^0.29.5"
+    "@cosmjs/utils" "^0.29.5"
+    "@noble/hashes" "^1"
+    bn.js "^5.2.0"
+    elliptic "^6.5.4"
+    libsodium-wrappers "^0.7.6"
+
 "@cosmjs/crypto@^0.30.1":
   version "0.30.1"
   resolved "https://registry.yarnpkg.com/@cosmjs/crypto/-/crypto-0.30.1.tgz#21e94d5ca8f8ded16eee1389d2639cb5c43c3eb5"
@@ -716,6 +771,15 @@
     bech32 "^1.1.4"
     readonly-date "^1.0.0"
 
+"@cosmjs/encoding@^0.29.3", "@cosmjs/encoding@^0.29.5":
+  version "0.29.5"
+  resolved "https://registry.yarnpkg.com/@cosmjs/encoding/-/encoding-0.29.5.tgz#009a4b1c596cdfd326f30ccfa79f5e56daa264f2"
+  integrity sha512-G4rGl/Jg4dMCw5u6PEZHZcoHnUBlukZODHbm/wcL4Uu91fkn5jVo5cXXZcvs4VCkArVGrEj/52eUgTZCmOBGWQ==
+  dependencies:
+    base64-js "^1.3.0"
+    bech32 "^1.1.4"
+    readonly-date "^1.0.0"
+
 "@cosmjs/encoding@^0.30.1":
   version "0.30.1"
   resolved "https://registry.yarnpkg.com/@cosmjs/encoding/-/encoding-0.30.1.tgz#b5c4e0ef7ceb1f2753688eb96400ed70f35c6058"
@@ -724,6 +788,14 @@
     base64-js "^1.3.0"
     bech32 "^1.1.4"
     readonly-date "^1.0.0"
+
+"@cosmjs/json-rpc@^0.29.5":
+  version "0.29.5"
+  resolved "https://registry.yarnpkg.com/@cosmjs/json-rpc/-/json-rpc-0.29.5.tgz#5e483a9bd98a6270f935adf0dfd8a1e7eb777fe4"
+  integrity sha512-C78+X06l+r9xwdM1yFWIpGl03LhB9NdM1xvZpQHwgCOl0Ir/WV8pw48y3Ez2awAoUBRfTeejPe4KvrE6NoIi/w==
+  dependencies:
+    "@cosmjs/stream" "^0.29.5"
+    xstream "^11.14.0"
 
 "@cosmjs/json-rpc@^0.30.1":
   version "0.30.1"
@@ -753,12 +825,32 @@
   dependencies:
     bn.js "^5.2.0"
 
+"@cosmjs/math@^0.29.3", "@cosmjs/math@^0.29.5":
+  version "0.29.5"
+  resolved "https://registry.yarnpkg.com/@cosmjs/math/-/math-0.29.5.tgz#722c96e080d6c2b62215ce9f4c70da7625b241b6"
+  integrity sha512-2GjKcv+A9f86MAWYLUkjhw1/WpRl2R1BTb3m9qPG7lzMA7ioYff9jY5SPCfafKdxM4TIQGxXQlYGewQL16O68Q==
+  dependencies:
+    bn.js "^5.2.0"
+
 "@cosmjs/math@^0.30.1":
   version "0.30.1"
   resolved "https://registry.yarnpkg.com/@cosmjs/math/-/math-0.30.1.tgz#8b816ef4de5d3afa66cb9fdfb5df2357a7845b8a"
   integrity sha512-yaoeI23pin9ZiPHIisa6qqLngfnBR/25tSaWpkTm8Cy10MX70UF5oN4+/t1heLaM6SSmRrhk3psRkV4+7mH51Q==
   dependencies:
     bn.js "^5.2.0"
+
+"@cosmjs/proto-signing@0.29.3":
+  version "0.29.3"
+  resolved "https://registry.yarnpkg.com/@cosmjs/proto-signing/-/proto-signing-0.29.3.tgz#fa5ed609ed2a0007d8d5eacbeb1f5a89ba1b77ff"
+  integrity sha512-Ai3l9THjMOrLJ4Ebn1Dgptwg6W5ZIRJqtnJjijHhGwTVC1WT0WdYU3aMZ7+PwubcA/cA1rH4ZTK7jrfYbra63g==
+  dependencies:
+    "@cosmjs/amino" "^0.29.3"
+    "@cosmjs/crypto" "^0.29.3"
+    "@cosmjs/encoding" "^0.29.3"
+    "@cosmjs/math" "^0.29.3"
+    "@cosmjs/utils" "^0.29.3"
+    cosmjs-types "^0.5.2"
+    long "^4.0.0"
 
 "@cosmjs/proto-signing@0.30.1", "@cosmjs/proto-signing@^0.30.1":
   version "0.30.1"
@@ -773,6 +865,29 @@
     cosmjs-types "^0.7.1"
     long "^4.0.0"
 
+"@cosmjs/proto-signing@^0.29.3":
+  version "0.29.5"
+  resolved "https://registry.yarnpkg.com/@cosmjs/proto-signing/-/proto-signing-0.29.5.tgz#af3b62a46c2c2f1d2327d678b13b7262db1fe87c"
+  integrity sha512-QRrS7CiKaoETdgIqvi/7JC2qCwCR7lnWaUsTzh/XfRy3McLkEd+cXbKAW3cygykv7IN0VAEIhZd2lyIfT8KwNA==
+  dependencies:
+    "@cosmjs/amino" "^0.29.5"
+    "@cosmjs/crypto" "^0.29.5"
+    "@cosmjs/encoding" "^0.29.5"
+    "@cosmjs/math" "^0.29.5"
+    "@cosmjs/utils" "^0.29.5"
+    cosmjs-types "^0.5.2"
+    long "^4.0.0"
+
+"@cosmjs/socket@^0.29.5":
+  version "0.29.5"
+  resolved "https://registry.yarnpkg.com/@cosmjs/socket/-/socket-0.29.5.tgz#a48df6b4c45dc6a6ef8e47232725dd4aa556ac2d"
+  integrity sha512-5VYDupIWbIXq3ftPV1LkS5Ya/T7Ol/AzWVhNxZ79hPe/mBfv1bGau/LqIYOm2zxGlgm9hBHOTmWGqNYDwr9LNQ==
+  dependencies:
+    "@cosmjs/stream" "^0.29.5"
+    isomorphic-ws "^4.0.1"
+    ws "^7"
+    xstream "^11.14.0"
+
 "@cosmjs/socket@^0.30.1":
   version "0.30.1"
   resolved "https://registry.yarnpkg.com/@cosmjs/socket/-/socket-0.30.1.tgz#00b22f4b5e2ab01f4d82ccdb7b2e59536bfe5ce0"
@@ -781,6 +896,24 @@
     "@cosmjs/stream" "^0.30.1"
     isomorphic-ws "^4.0.1"
     ws "^7"
+    xstream "^11.14.0"
+
+"@cosmjs/stargate@0.29.3":
+  version "0.29.3"
+  resolved "https://registry.yarnpkg.com/@cosmjs/stargate/-/stargate-0.29.3.tgz#9bd303bfd32a7399a233e662864e7cc32e2607af"
+  integrity sha512-455TgXStCi6E8KDjnhDAM8wt6aLSjobH4Dixvd7Up1DfCH6UB9NkC/G0fMJANNcNXMaM4wSX14niTXwD1d31BA==
+  dependencies:
+    "@confio/ics23" "^0.6.8"
+    "@cosmjs/amino" "^0.29.3"
+    "@cosmjs/encoding" "^0.29.3"
+    "@cosmjs/math" "^0.29.3"
+    "@cosmjs/proto-signing" "^0.29.3"
+    "@cosmjs/stream" "^0.29.3"
+    "@cosmjs/tendermint-rpc" "^0.29.3"
+    "@cosmjs/utils" "^0.29.3"
+    cosmjs-types "^0.5.2"
+    long "^4.0.0"
+    protobufjs "~6.11.3"
     xstream "^11.14.0"
 
 "@cosmjs/stargate@^0.30.1":
@@ -801,11 +934,34 @@
     protobufjs "~6.11.3"
     xstream "^11.14.0"
 
+"@cosmjs/stream@^0.29.3", "@cosmjs/stream@^0.29.5":
+  version "0.29.5"
+  resolved "https://registry.yarnpkg.com/@cosmjs/stream/-/stream-0.29.5.tgz#350981cac496d04939b92ee793b9b19f44bc1d4e"
+  integrity sha512-TToTDWyH1p05GBtF0Y8jFw2C+4783ueDCmDyxOMM6EU82IqpmIbfwcdMOCAm0JhnyMh+ocdebbFvnX/sGKzRAA==
+  dependencies:
+    xstream "^11.14.0"
+
 "@cosmjs/stream@^0.30.1":
   version "0.30.1"
   resolved "https://registry.yarnpkg.com/@cosmjs/stream/-/stream-0.30.1.tgz#ba038a2aaf41343696b1e6e759d8e03a9516ec1a"
   integrity sha512-Fg0pWz1zXQdoxQZpdHRMGvUH5RqS6tPv+j9Eh7Q953UjMlrwZVo0YFLC8OTf/HKVf10E4i0u6aM8D69Q6cNkgQ==
   dependencies:
+    xstream "^11.14.0"
+
+"@cosmjs/tendermint-rpc@^0.29.3":
+  version "0.29.5"
+  resolved "https://registry.yarnpkg.com/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.29.5.tgz#f205c10464212bdf843f91bb2e4a093b618cb5c2"
+  integrity sha512-ar80twieuAxsy0x2za/aO3kBr2DFPAXDmk2ikDbmkda+qqfXgl35l9CVAAjKRqd9d+cRvbQyb5M4wy6XQpEV6w==
+  dependencies:
+    "@cosmjs/crypto" "^0.29.5"
+    "@cosmjs/encoding" "^0.29.5"
+    "@cosmjs/json-rpc" "^0.29.5"
+    "@cosmjs/math" "^0.29.5"
+    "@cosmjs/socket" "^0.29.5"
+    "@cosmjs/stream" "^0.29.5"
+    "@cosmjs/utils" "^0.29.5"
+    axios "^0.21.2"
+    readonly-date "^1.0.0"
     xstream "^11.14.0"
 
 "@cosmjs/tendermint-rpc@^0.30.1":
@@ -829,10 +985,23 @@
   resolved "https://registry.yarnpkg.com/@cosmjs/utils/-/utils-0.27.1.tgz#1c8efde17256346ef142a3bd15158ee4055470e2"
   integrity sha512-VG7QPDiMUzVPxRdJahDV8PXxVdnuAHiIuG56hldV4yPnOz/si/DLNd7VAUUA5923b6jS1Hhev0Hr6AhEkcxBMg==
 
+"@cosmjs/utils@^0.29.3", "@cosmjs/utils@^0.29.5":
+  version "0.29.5"
+  resolved "https://registry.yarnpkg.com/@cosmjs/utils/-/utils-0.29.5.tgz#3fed1b3528ae8c5f1eb5d29b68755bebfd3294ee"
+  integrity sha512-m7h+RXDUxOzEOGt4P+3OVPX7PuakZT3GBmaM/Y2u+abN3xZkziykD/NvedYFvvCCdQo714XcGl33bwifS9FZPQ==
+
 "@cosmjs/utils@^0.30.1":
   version "0.30.1"
   resolved "https://registry.yarnpkg.com/@cosmjs/utils/-/utils-0.30.1.tgz#6d92582341be3c2ec8d82090253cfa4b7f959edb"
   integrity sha512-KvvX58MGMWh7xA+N+deCfunkA/ZNDvFLw4YbOmX3f/XBIkqrVY7qlotfy2aNb1kgp6h4B6Yc8YawJPDTfvWX7g==
+
+"@cosmology/lcd@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@cosmology/lcd/-/lcd-0.12.0.tgz#a6594fc00a8c84c7341e90840627e62a7e63fd1b"
+  integrity sha512-f2mcySYO1xdislAhuWtNFmg4q/bzY3Aem2UkDzYzI0ZELVev5i2Pi0bQrYUNTeNg1isAo0Kyrdqj/4YPqEwjGA==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
+    axios "0.27.2"
 
 "@cosmostation/extension-client@^0.1.15":
   version "0.1.15"
@@ -967,137 +1136,137 @@
 "@ethersproject-xdc/abi@file:vendor/@ethersproject-xdc/abi":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/address" "file:vendor/@ethersproject-xdc/address"
-    "@ethersproject-xdc/bignumber" "file:vendor/@ethersproject-xdc/bignumber"
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/constants" "file:vendor/@ethersproject-xdc/constants"
-    "@ethersproject-xdc/hash" "file:vendor/@ethersproject-xdc/hash"
-    "@ethersproject-xdc/keccak256" "file:vendor/@ethersproject-xdc/keccak256"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
-    "@ethersproject-xdc/properties" "file:vendor/@ethersproject-xdc/properties"
-    "@ethersproject-xdc/strings" "file:vendor/@ethersproject-xdc/strings"
+    "@ethersproject-xdc/address" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abi-5.7.0-71b37d49-d2ce-4b9d-a5b5-239f5ad137a6-1700272091153/node_modules/@ethersproject-xdc/address"
+    "@ethersproject-xdc/bignumber" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abi-5.7.0-71b37d49-d2ce-4b9d-a5b5-239f5ad137a6-1700272091153/node_modules/@ethersproject-xdc/bignumber"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abi-5.7.0-71b37d49-d2ce-4b9d-a5b5-239f5ad137a6-1700272091153/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/constants" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abi-5.7.0-71b37d49-d2ce-4b9d-a5b5-239f5ad137a6-1700272091153/node_modules/@ethersproject-xdc/constants"
+    "@ethersproject-xdc/hash" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abi-5.7.0-71b37d49-d2ce-4b9d-a5b5-239f5ad137a6-1700272091153/node_modules/@ethersproject-xdc/hash"
+    "@ethersproject-xdc/keccak256" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abi-5.7.0-71b37d49-d2ce-4b9d-a5b5-239f5ad137a6-1700272091153/node_modules/@ethersproject-xdc/keccak256"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abi-5.7.0-71b37d49-d2ce-4b9d-a5b5-239f5ad137a6-1700272091153/node_modules/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/properties" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abi-5.7.0-71b37d49-d2ce-4b9d-a5b5-239f5ad137a6-1700272091153/node_modules/@ethersproject-xdc/properties"
+    "@ethersproject-xdc/strings" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abi-5.7.0-71b37d49-d2ce-4b9d-a5b5-239f5ad137a6-1700272091153/node_modules/@ethersproject-xdc/strings"
 
 "@ethersproject-xdc/abstract-provider@file:vendor/@ethersproject-xdc/abstract-provider":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/bignumber" "file:vendor/@ethersproject-xdc/bignumber"
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
-    "@ethersproject-xdc/networks" "file:vendor/@ethersproject-xdc/networks"
-    "@ethersproject-xdc/properties" "file:vendor/@ethersproject-xdc/properties"
-    "@ethersproject-xdc/transactions" "file:vendor/@ethersproject-xdc/transactions"
-    "@ethersproject-xdc/web" "file:vendor/@ethersproject-xdc/web"
+    "@ethersproject-xdc/bignumber" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abstract-provider-5.7.0-9762a3e0-bdb7-4e87-a7a2-92fe6ec8e571-1700272091151/node_modules/@ethersproject-xdc/bignumber"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abstract-provider-5.7.0-9762a3e0-bdb7-4e87-a7a2-92fe6ec8e571-1700272091151/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abstract-provider-5.7.0-9762a3e0-bdb7-4e87-a7a2-92fe6ec8e571-1700272091151/node_modules/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/networks" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abstract-provider-5.7.0-9762a3e0-bdb7-4e87-a7a2-92fe6ec8e571-1700272091151/node_modules/@ethersproject-xdc/networks"
+    "@ethersproject-xdc/properties" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abstract-provider-5.7.0-9762a3e0-bdb7-4e87-a7a2-92fe6ec8e571-1700272091151/node_modules/@ethersproject-xdc/properties"
+    "@ethersproject-xdc/transactions" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abstract-provider-5.7.0-9762a3e0-bdb7-4e87-a7a2-92fe6ec8e571-1700272091151/node_modules/@ethersproject-xdc/transactions"
+    "@ethersproject-xdc/web" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abstract-provider-5.7.0-9762a3e0-bdb7-4e87-a7a2-92fe6ec8e571-1700272091151/node_modules/@ethersproject-xdc/web"
 
 "@ethersproject-xdc/abstract-signer@file:vendor/@ethersproject-xdc/abstract-signer":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/abstract-provider" "file:vendor/@ethersproject-xdc/abstract-provider"
-    "@ethersproject-xdc/bignumber" "file:vendor/@ethersproject-xdc/bignumber"
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
-    "@ethersproject-xdc/properties" "file:vendor/@ethersproject-xdc/properties"
+    "@ethersproject-xdc/abstract-provider" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abstract-signer-5.7.0-e30af242-35dc-4f3b-b873-850d9111c65f-1700272091155/node_modules/@ethersproject-xdc/abstract-provider"
+    "@ethersproject-xdc/bignumber" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abstract-signer-5.7.0-e30af242-35dc-4f3b-b873-850d9111c65f-1700272091155/node_modules/@ethersproject-xdc/bignumber"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abstract-signer-5.7.0-e30af242-35dc-4f3b-b873-850d9111c65f-1700272091155/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abstract-signer-5.7.0-e30af242-35dc-4f3b-b873-850d9111c65f-1700272091155/node_modules/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/properties" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-abstract-signer-5.7.0-e30af242-35dc-4f3b-b873-850d9111c65f-1700272091155/node_modules/@ethersproject-xdc/properties"
 
 "@ethersproject-xdc/address@file:vendor/@ethersproject-xdc/address":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/bignumber" "file:vendor/@ethersproject-xdc/bignumber"
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/keccak256" "file:vendor/@ethersproject-xdc/keccak256"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
-    "@ethersproject-xdc/rlp" "file:vendor/@ethersproject-xdc/rlp"
+    "@ethersproject-xdc/bignumber" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-address-5.7.0-2fb0d2fa-f9c4-4823-8179-7a7d6a08d3e4-1700272091166/node_modules/@ethersproject-xdc/bignumber"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-address-5.7.0-2fb0d2fa-f9c4-4823-8179-7a7d6a08d3e4-1700272091166/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/keccak256" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-address-5.7.0-2fb0d2fa-f9c4-4823-8179-7a7d6a08d3e4-1700272091166/node_modules/@ethersproject-xdc/keccak256"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-address-5.7.0-2fb0d2fa-f9c4-4823-8179-7a7d6a08d3e4-1700272091166/node_modules/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/rlp" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-address-5.7.0-2fb0d2fa-f9c4-4823-8179-7a7d6a08d3e4-1700272091166/node_modules/@ethersproject-xdc/rlp"
 
 "@ethersproject-xdc/base64@file:vendor/@ethersproject-xdc/base64":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-base64-5.7.0-51e2e958-2326-48c8-9aea-8276f457cbb8-1700272091168/node_modules/@ethersproject-xdc/bytes"
 
 "@ethersproject-xdc/basex@file:vendor/@ethersproject-xdc/basex":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/properties" "file:vendor/@ethersproject-xdc/properties"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-basex-5.7.0-15484a19-09d3-4d58-b0f2-535a95cc0519-1700272091152/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/properties" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-basex-5.7.0-15484a19-09d3-4d58-b0f2-535a95cc0519-1700272091152/node_modules/@ethersproject-xdc/properties"
 
 "@ethersproject-xdc/bignumber@file:vendor/@ethersproject-xdc/bignumber":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-bignumber-5.7.0-5529a83a-2b63-4019-9ea6-7d47c996ce22-1700272091153/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-bignumber-5.7.0-5529a83a-2b63-4019-9ea6-7d47c996ce22-1700272091153/node_modules/@ethersproject-xdc/logger"
     bn.js "^5.2.1"
 
 "@ethersproject-xdc/bytes@file:vendor/@ethersproject-xdc/bytes":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-bytes-5.7.0-70cc4ab5-ff68-448d-b2ab-a83d309dc309-1700272091167/node_modules/@ethersproject-xdc/logger"
 
 "@ethersproject-xdc/constants@file:vendor/@ethersproject-xdc/constants":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/bignumber" "file:vendor/@ethersproject-xdc/bignumber"
+    "@ethersproject-xdc/bignumber" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-constants-5.7.0-77844e99-9f2a-4ac0-bace-f9f5c11e1f5b-1700272091155/node_modules/@ethersproject-xdc/bignumber"
 
 "@ethersproject-xdc/contracts@file:vendor/@ethersproject-xdc/contracts":
   version "5.6.0"
   dependencies:
-    "@ethersproject-xdc/abi" "file:vendor/@ethersproject-xdc/abi"
-    "@ethersproject-xdc/abstract-provider" "file:vendor/@ethersproject-xdc/abstract-provider"
-    "@ethersproject-xdc/abstract-signer" "file:vendor/@ethersproject-xdc/abstract-signer"
-    "@ethersproject-xdc/address" "file:vendor/@ethersproject-xdc/address"
-    "@ethersproject-xdc/bignumber" "file:vendor/@ethersproject-xdc/bignumber"
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/constants" "file:vendor/@ethersproject-xdc/constants"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
-    "@ethersproject-xdc/properties" "file:vendor/@ethersproject-xdc/properties"
-    "@ethersproject-xdc/transactions" "file:vendor/@ethersproject-xdc/transactions"
+    "@ethersproject-xdc/abi" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-contracts-5.6.0-1b638f82-0800-4f3c-8137-c88c4016af48-1700272091154/node_modules/@ethersproject-xdc/abi"
+    "@ethersproject-xdc/abstract-provider" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-contracts-5.6.0-1b638f82-0800-4f3c-8137-c88c4016af48-1700272091154/node_modules/@ethersproject-xdc/abstract-provider"
+    "@ethersproject-xdc/abstract-signer" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-contracts-5.6.0-1b638f82-0800-4f3c-8137-c88c4016af48-1700272091154/node_modules/@ethersproject-xdc/abstract-signer"
+    "@ethersproject-xdc/address" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-contracts-5.6.0-1b638f82-0800-4f3c-8137-c88c4016af48-1700272091154/node_modules/@ethersproject-xdc/address"
+    "@ethersproject-xdc/bignumber" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-contracts-5.6.0-1b638f82-0800-4f3c-8137-c88c4016af48-1700272091154/node_modules/@ethersproject-xdc/bignumber"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-contracts-5.6.0-1b638f82-0800-4f3c-8137-c88c4016af48-1700272091154/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/constants" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-contracts-5.6.0-1b638f82-0800-4f3c-8137-c88c4016af48-1700272091154/node_modules/@ethersproject-xdc/constants"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-contracts-5.6.0-1b638f82-0800-4f3c-8137-c88c4016af48-1700272091154/node_modules/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/properties" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-contracts-5.6.0-1b638f82-0800-4f3c-8137-c88c4016af48-1700272091154/node_modules/@ethersproject-xdc/properties"
+    "@ethersproject-xdc/transactions" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-contracts-5.6.0-1b638f82-0800-4f3c-8137-c88c4016af48-1700272091154/node_modules/@ethersproject-xdc/transactions"
 
 "@ethersproject-xdc/hash@file:vendor/@ethersproject-xdc/hash":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/abstract-signer" "file:vendor/@ethersproject-xdc/abstract-signer"
-    "@ethersproject-xdc/address" "file:vendor/@ethersproject-xdc/address"
-    "@ethersproject-xdc/base64" "file:vendor/@ethersproject-xdc/base64"
-    "@ethersproject-xdc/bignumber" "file:vendor/@ethersproject-xdc/bignumber"
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/keccak256" "file:vendor/@ethersproject-xdc/keccak256"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
-    "@ethersproject-xdc/properties" "file:vendor/@ethersproject-xdc/properties"
-    "@ethersproject-xdc/strings" "file:vendor/@ethersproject-xdc/strings"
+    "@ethersproject-xdc/abstract-signer" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hash-5.7.0-22604872-40a8-491e-ad87-e3df3bdba8ff-1700272091167/node_modules/@ethersproject-xdc/abstract-signer"
+    "@ethersproject-xdc/address" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hash-5.7.0-22604872-40a8-491e-ad87-e3df3bdba8ff-1700272091167/node_modules/@ethersproject-xdc/address"
+    "@ethersproject-xdc/base64" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hash-5.7.0-22604872-40a8-491e-ad87-e3df3bdba8ff-1700272091167/node_modules/@ethersproject-xdc/base64"
+    "@ethersproject-xdc/bignumber" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hash-5.7.0-22604872-40a8-491e-ad87-e3df3bdba8ff-1700272091167/node_modules/@ethersproject-xdc/bignumber"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hash-5.7.0-22604872-40a8-491e-ad87-e3df3bdba8ff-1700272091167/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/keccak256" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hash-5.7.0-22604872-40a8-491e-ad87-e3df3bdba8ff-1700272091167/node_modules/@ethersproject-xdc/keccak256"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hash-5.7.0-22604872-40a8-491e-ad87-e3df3bdba8ff-1700272091167/node_modules/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/properties" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hash-5.7.0-22604872-40a8-491e-ad87-e3df3bdba8ff-1700272091167/node_modules/@ethersproject-xdc/properties"
+    "@ethersproject-xdc/strings" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hash-5.7.0-22604872-40a8-491e-ad87-e3df3bdba8ff-1700272091167/node_modules/@ethersproject-xdc/strings"
 
 "@ethersproject-xdc/hdnode@file:vendor/@ethersproject-xdc/hdnode":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/abstract-signer" "file:vendor/@ethersproject-xdc/abstract-signer"
-    "@ethersproject-xdc/basex" "file:vendor/@ethersproject-xdc/basex"
-    "@ethersproject-xdc/bignumber" "file:vendor/@ethersproject-xdc/bignumber"
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
-    "@ethersproject-xdc/pbkdf2" "file:vendor/@ethersproject-xdc/pbkdf2"
-    "@ethersproject-xdc/properties" "file:vendor/@ethersproject-xdc/properties"
-    "@ethersproject-xdc/sha2" "file:vendor/@ethersproject-xdc/sha2"
-    "@ethersproject-xdc/signing-key" "file:vendor/@ethersproject-xdc/signing-key"
-    "@ethersproject-xdc/strings" "file:vendor/@ethersproject-xdc/strings"
-    "@ethersproject-xdc/transactions" "file:vendor/@ethersproject-xdc/transactions"
-    "@ethersproject-xdc/wordlists" "file:vendor/@ethersproject-xdc/wordlists"
+    "@ethersproject-xdc/abstract-signer" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hdnode-5.7.0-2601fe6b-1a67-4cef-b944-58ed31152cd3-1700272091165/node_modules/@ethersproject-xdc/abstract-signer"
+    "@ethersproject-xdc/basex" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hdnode-5.7.0-2601fe6b-1a67-4cef-b944-58ed31152cd3-1700272091165/node_modules/@ethersproject-xdc/basex"
+    "@ethersproject-xdc/bignumber" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hdnode-5.7.0-2601fe6b-1a67-4cef-b944-58ed31152cd3-1700272091165/node_modules/@ethersproject-xdc/bignumber"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hdnode-5.7.0-2601fe6b-1a67-4cef-b944-58ed31152cd3-1700272091165/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hdnode-5.7.0-2601fe6b-1a67-4cef-b944-58ed31152cd3-1700272091165/node_modules/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/pbkdf2" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hdnode-5.7.0-2601fe6b-1a67-4cef-b944-58ed31152cd3-1700272091165/node_modules/@ethersproject-xdc/pbkdf2"
+    "@ethersproject-xdc/properties" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hdnode-5.7.0-2601fe6b-1a67-4cef-b944-58ed31152cd3-1700272091165/node_modules/@ethersproject-xdc/properties"
+    "@ethersproject-xdc/sha2" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hdnode-5.7.0-2601fe6b-1a67-4cef-b944-58ed31152cd3-1700272091165/node_modules/@ethersproject-xdc/sha2"
+    "@ethersproject-xdc/signing-key" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hdnode-5.7.0-2601fe6b-1a67-4cef-b944-58ed31152cd3-1700272091165/node_modules/@ethersproject-xdc/signing-key"
+    "@ethersproject-xdc/strings" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hdnode-5.7.0-2601fe6b-1a67-4cef-b944-58ed31152cd3-1700272091165/node_modules/@ethersproject-xdc/strings"
+    "@ethersproject-xdc/transactions" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hdnode-5.7.0-2601fe6b-1a67-4cef-b944-58ed31152cd3-1700272091165/node_modules/@ethersproject-xdc/transactions"
+    "@ethersproject-xdc/wordlists" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-hdnode-5.7.0-2601fe6b-1a67-4cef-b944-58ed31152cd3-1700272091165/node_modules/@ethersproject-xdc/wordlists"
 
 "@ethersproject-xdc/json-wallets@file:vendor/@ethersproject-xdc/json-wallets":
   version "5.6.0"
   dependencies:
-    "@ethersproject-xdc/abstract-signer" "file:vendor/@ethersproject-xdc/abstract-signer"
-    "@ethersproject-xdc/address" "file:vendor/@ethersproject-xdc/address"
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/hdnode" "file:vendor/@ethersproject-xdc/hdnode"
-    "@ethersproject-xdc/keccak256" "file:vendor/@ethersproject-xdc/keccak256"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
-    "@ethersproject-xdc/pbkdf2" "file:vendor/@ethersproject-xdc/pbkdf2"
-    "@ethersproject-xdc/properties" "file:vendor/@ethersproject-xdc/properties"
-    "@ethersproject-xdc/random" "file:vendor/@ethersproject-xdc/random"
-    "@ethersproject-xdc/strings" "file:vendor/@ethersproject-xdc/strings"
-    "@ethersproject-xdc/transactions" "file:vendor/@ethersproject-xdc/transactions"
+    "@ethersproject-xdc/abstract-signer" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-json-wallets-5.6.0-1b8d5f44-c156-400a-9b12-d36422cdedb9-1700272091164/node_modules/@ethersproject-xdc/abstract-signer"
+    "@ethersproject-xdc/address" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-json-wallets-5.6.0-1b8d5f44-c156-400a-9b12-d36422cdedb9-1700272091164/node_modules/@ethersproject-xdc/address"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-json-wallets-5.6.0-1b8d5f44-c156-400a-9b12-d36422cdedb9-1700272091164/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/hdnode" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-json-wallets-5.6.0-1b8d5f44-c156-400a-9b12-d36422cdedb9-1700272091164/node_modules/@ethersproject-xdc/hdnode"
+    "@ethersproject-xdc/keccak256" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-json-wallets-5.6.0-1b8d5f44-c156-400a-9b12-d36422cdedb9-1700272091164/node_modules/@ethersproject-xdc/keccak256"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-json-wallets-5.6.0-1b8d5f44-c156-400a-9b12-d36422cdedb9-1700272091164/node_modules/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/pbkdf2" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-json-wallets-5.6.0-1b8d5f44-c156-400a-9b12-d36422cdedb9-1700272091164/node_modules/@ethersproject-xdc/pbkdf2"
+    "@ethersproject-xdc/properties" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-json-wallets-5.6.0-1b8d5f44-c156-400a-9b12-d36422cdedb9-1700272091164/node_modules/@ethersproject-xdc/properties"
+    "@ethersproject-xdc/random" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-json-wallets-5.6.0-1b8d5f44-c156-400a-9b12-d36422cdedb9-1700272091164/node_modules/@ethersproject-xdc/random"
+    "@ethersproject-xdc/strings" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-json-wallets-5.6.0-1b8d5f44-c156-400a-9b12-d36422cdedb9-1700272091164/node_modules/@ethersproject-xdc/strings"
+    "@ethersproject-xdc/transactions" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-json-wallets-5.6.0-1b8d5f44-c156-400a-9b12-d36422cdedb9-1700272091164/node_modules/@ethersproject-xdc/transactions"
     aes-js "3.0.0"
     scrypt-js "3.0.1"
 
 "@ethersproject-xdc/keccak256@file:vendor/@ethersproject-xdc/keccak256":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-keccak256-5.7.0-1f4022cd-9e8a-4447-996d-7f3b0beffac8-1700272091168/node_modules/@ethersproject-xdc/bytes"
     js-sha3 "0.8.0"
 
 "@ethersproject-xdc/logger@file:vendor/@ethersproject-xdc/logger":
@@ -1106,67 +1275,67 @@
 "@ethersproject-xdc/networks@file:vendor/@ethersproject-xdc/networks":
   version "5.7.1"
   dependencies:
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-networks-5.7.1-6633ee85-10a0-478d-870b-16158be8036b-1700272091168/node_modules/@ethersproject-xdc/logger"
 
 "@ethersproject-xdc/pbkdf2@file:vendor/@ethersproject-xdc/pbkdf2":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/sha2" "file:vendor/@ethersproject-xdc/sha2"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-pbkdf2-5.7.0-055044ca-7a75-4ebe-a8df-04d9f57d8d80-1700272091168/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/sha2" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-pbkdf2-5.7.0-055044ca-7a75-4ebe-a8df-04d9f57d8d80-1700272091168/node_modules/@ethersproject-xdc/sha2"
 
 "@ethersproject-xdc/properties@file:vendor/@ethersproject-xdc/properties":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-properties-5.7.0-16b164e8-5e68-4634-bb7c-215896a14cc8-1700272091169/node_modules/@ethersproject-xdc/logger"
 
 "@ethersproject-xdc/providers@file:vendor/@ethersproject-xdc/providers":
   version "5.6.2"
   dependencies:
-    "@ethersproject-xdc/abstract-provider" "file:vendor/@ethersproject-xdc/abstract-provider"
-    "@ethersproject-xdc/abstract-signer" "file:vendor/@ethersproject-xdc/abstract-signer"
-    "@ethersproject-xdc/address" "file:vendor/@ethersproject-xdc/address"
-    "@ethersproject-xdc/basex" "file:vendor/@ethersproject-xdc/basex"
-    "@ethersproject-xdc/bignumber" "file:vendor/@ethersproject-xdc/bignumber"
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/constants" "file:vendor/@ethersproject-xdc/constants"
-    "@ethersproject-xdc/hash" "file:vendor/@ethersproject-xdc/hash"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
-    "@ethersproject-xdc/networks" "file:vendor/@ethersproject-xdc/networks"
-    "@ethersproject-xdc/properties" "file:vendor/@ethersproject-xdc/properties"
-    "@ethersproject-xdc/random" "file:vendor/@ethersproject-xdc/random"
-    "@ethersproject-xdc/rlp" "file:vendor/@ethersproject-xdc/rlp"
-    "@ethersproject-xdc/sha2" "file:vendor/@ethersproject-xdc/sha2"
-    "@ethersproject-xdc/strings" "file:vendor/@ethersproject-xdc/strings"
-    "@ethersproject-xdc/transactions" "file:vendor/@ethersproject-xdc/transactions"
-    "@ethersproject-xdc/web" "file:vendor/@ethersproject-xdc/web"
+    "@ethersproject-xdc/abstract-provider" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-providers-5.6.2-cd4c1ded-8604-4fa9-9561-a7e7126238dc-1700272091169/node_modules/@ethersproject-xdc/abstract-provider"
+    "@ethersproject-xdc/abstract-signer" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-providers-5.6.2-cd4c1ded-8604-4fa9-9561-a7e7126238dc-1700272091169/node_modules/@ethersproject-xdc/abstract-signer"
+    "@ethersproject-xdc/address" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-providers-5.6.2-cd4c1ded-8604-4fa9-9561-a7e7126238dc-1700272091169/node_modules/@ethersproject-xdc/address"
+    "@ethersproject-xdc/basex" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-providers-5.6.2-cd4c1ded-8604-4fa9-9561-a7e7126238dc-1700272091169/node_modules/@ethersproject-xdc/basex"
+    "@ethersproject-xdc/bignumber" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-providers-5.6.2-cd4c1ded-8604-4fa9-9561-a7e7126238dc-1700272091169/node_modules/@ethersproject-xdc/bignumber"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-providers-5.6.2-cd4c1ded-8604-4fa9-9561-a7e7126238dc-1700272091169/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/constants" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-providers-5.6.2-cd4c1ded-8604-4fa9-9561-a7e7126238dc-1700272091169/node_modules/@ethersproject-xdc/constants"
+    "@ethersproject-xdc/hash" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-providers-5.6.2-cd4c1ded-8604-4fa9-9561-a7e7126238dc-1700272091169/node_modules/@ethersproject-xdc/hash"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-providers-5.6.2-cd4c1ded-8604-4fa9-9561-a7e7126238dc-1700272091169/node_modules/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/networks" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-providers-5.6.2-cd4c1ded-8604-4fa9-9561-a7e7126238dc-1700272091169/node_modules/@ethersproject-xdc/networks"
+    "@ethersproject-xdc/properties" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-providers-5.6.2-cd4c1ded-8604-4fa9-9561-a7e7126238dc-1700272091169/node_modules/@ethersproject-xdc/properties"
+    "@ethersproject-xdc/random" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-providers-5.6.2-cd4c1ded-8604-4fa9-9561-a7e7126238dc-1700272091169/node_modules/@ethersproject-xdc/random"
+    "@ethersproject-xdc/rlp" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-providers-5.6.2-cd4c1ded-8604-4fa9-9561-a7e7126238dc-1700272091169/node_modules/@ethersproject-xdc/rlp"
+    "@ethersproject-xdc/sha2" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-providers-5.6.2-cd4c1ded-8604-4fa9-9561-a7e7126238dc-1700272091169/node_modules/@ethersproject-xdc/sha2"
+    "@ethersproject-xdc/strings" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-providers-5.6.2-cd4c1ded-8604-4fa9-9561-a7e7126238dc-1700272091169/node_modules/@ethersproject-xdc/strings"
+    "@ethersproject-xdc/transactions" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-providers-5.6.2-cd4c1ded-8604-4fa9-9561-a7e7126238dc-1700272091169/node_modules/@ethersproject-xdc/transactions"
+    "@ethersproject-xdc/web" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-providers-5.6.2-cd4c1ded-8604-4fa9-9561-a7e7126238dc-1700272091169/node_modules/@ethersproject-xdc/web"
     bech32 "1.1.4"
     ws "7.4.6"
 
 "@ethersproject-xdc/random@file:vendor/@ethersproject-xdc/random":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-random-5.7.0-4f15f27a-e443-4188-8d42-ea339d25f826-1700272091170/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-random-5.7.0-4f15f27a-e443-4188-8d42-ea339d25f826-1700272091170/node_modules/@ethersproject-xdc/logger"
 
 "@ethersproject-xdc/rlp@file:vendor/@ethersproject-xdc/rlp":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-rlp-5.7.0-685c88ac-f471-4b93-beee-99380fd3d5a0-1700272091170/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-rlp-5.7.0-685c88ac-f471-4b93-beee-99380fd3d5a0-1700272091170/node_modules/@ethersproject-xdc/logger"
 
 "@ethersproject-xdc/sha2@file:vendor/@ethersproject-xdc/sha2":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-sha2-5.7.0-1d1d4a23-1b4f-435d-b0f5-af079326879d-1700272091170/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-sha2-5.7.0-1d1d4a23-1b4f-435d-b0f5-af079326879d-1700272091170/node_modules/@ethersproject-xdc/logger"
     hash.js "1.1.7"
 
 "@ethersproject-xdc/signing-key@file:vendor/@ethersproject-xdc/signing-key":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
-    "@ethersproject-xdc/properties" "file:vendor/@ethersproject-xdc/properties"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-signing-key-5.7.0-d6e3bdb2-f15f-438f-b518-04c911809b49-1700272091175/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-signing-key-5.7.0-d6e3bdb2-f15f-438f-b518-04c911809b49-1700272091175/node_modules/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/properties" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-signing-key-5.7.0-d6e3bdb2-f15f-438f-b518-04c911809b49-1700272091175/node_modules/@ethersproject-xdc/properties"
     bn.js "^5.2.1"
     elliptic "6.5.4"
     hash.js "1.1.7"
@@ -1174,76 +1343,76 @@
 "@ethersproject-xdc/solidity@file:vendor/@ethersproject-xdc/solidity":
   version "5.6.0"
   dependencies:
-    "@ethersproject-xdc/bignumber" "file:vendor/@ethersproject-xdc/bignumber"
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/keccak256" "file:vendor/@ethersproject-xdc/keccak256"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
-    "@ethersproject-xdc/sha2" "file:vendor/@ethersproject-xdc/sha2"
-    "@ethersproject-xdc/strings" "file:vendor/@ethersproject-xdc/strings"
+    "@ethersproject-xdc/bignumber" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-solidity-5.6.0-c75b3dda-516f-4b9b-a0d4-a10f5b358df1-1700272091170/node_modules/@ethersproject-xdc/bignumber"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-solidity-5.6.0-c75b3dda-516f-4b9b-a0d4-a10f5b358df1-1700272091170/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/keccak256" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-solidity-5.6.0-c75b3dda-516f-4b9b-a0d4-a10f5b358df1-1700272091170/node_modules/@ethersproject-xdc/keccak256"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-solidity-5.6.0-c75b3dda-516f-4b9b-a0d4-a10f5b358df1-1700272091170/node_modules/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/sha2" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-solidity-5.6.0-c75b3dda-516f-4b9b-a0d4-a10f5b358df1-1700272091170/node_modules/@ethersproject-xdc/sha2"
+    "@ethersproject-xdc/strings" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-solidity-5.6.0-c75b3dda-516f-4b9b-a0d4-a10f5b358df1-1700272091170/node_modules/@ethersproject-xdc/strings"
 
 "@ethersproject-xdc/strings@file:vendor/@ethersproject-xdc/strings":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/constants" "file:vendor/@ethersproject-xdc/constants"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-strings-5.7.0-df283afe-743c-43ad-a431-76ecd798a3e4-1700272091171/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/constants" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-strings-5.7.0-df283afe-743c-43ad-a431-76ecd798a3e4-1700272091171/node_modules/@ethersproject-xdc/constants"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-strings-5.7.0-df283afe-743c-43ad-a431-76ecd798a3e4-1700272091171/node_modules/@ethersproject-xdc/logger"
 
 "@ethersproject-xdc/transactions@file:vendor/@ethersproject-xdc/transactions":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/address" "file:vendor/@ethersproject-xdc/address"
-    "@ethersproject-xdc/bignumber" "file:vendor/@ethersproject-xdc/bignumber"
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/constants" "file:vendor/@ethersproject-xdc/constants"
-    "@ethersproject-xdc/keccak256" "file:vendor/@ethersproject-xdc/keccak256"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
-    "@ethersproject-xdc/properties" "file:vendor/@ethersproject-xdc/properties"
-    "@ethersproject-xdc/rlp" "file:vendor/@ethersproject-xdc/rlp"
-    "@ethersproject-xdc/signing-key" "file:vendor/@ethersproject-xdc/signing-key"
+    "@ethersproject-xdc/address" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-transactions-5.7.0-24370c1c-d9ff-4f98-91d7-3e0436e85a32-1700272091176/node_modules/@ethersproject-xdc/address"
+    "@ethersproject-xdc/bignumber" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-transactions-5.7.0-24370c1c-d9ff-4f98-91d7-3e0436e85a32-1700272091176/node_modules/@ethersproject-xdc/bignumber"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-transactions-5.7.0-24370c1c-d9ff-4f98-91d7-3e0436e85a32-1700272091176/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/constants" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-transactions-5.7.0-24370c1c-d9ff-4f98-91d7-3e0436e85a32-1700272091176/node_modules/@ethersproject-xdc/constants"
+    "@ethersproject-xdc/keccak256" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-transactions-5.7.0-24370c1c-d9ff-4f98-91d7-3e0436e85a32-1700272091176/node_modules/@ethersproject-xdc/keccak256"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-transactions-5.7.0-24370c1c-d9ff-4f98-91d7-3e0436e85a32-1700272091176/node_modules/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/properties" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-transactions-5.7.0-24370c1c-d9ff-4f98-91d7-3e0436e85a32-1700272091176/node_modules/@ethersproject-xdc/properties"
+    "@ethersproject-xdc/rlp" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-transactions-5.7.0-24370c1c-d9ff-4f98-91d7-3e0436e85a32-1700272091176/node_modules/@ethersproject-xdc/rlp"
+    "@ethersproject-xdc/signing-key" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-transactions-5.7.0-24370c1c-d9ff-4f98-91d7-3e0436e85a32-1700272091176/node_modules/@ethersproject-xdc/signing-key"
 
 "@ethersproject-xdc/units@file:vendor/@ethersproject-xdc/units":
   version "5.6.0"
   dependencies:
-    "@ethersproject-xdc/bignumber" "file:vendor/@ethersproject-xdc/bignumber"
-    "@ethersproject-xdc/constants" "file:vendor/@ethersproject-xdc/constants"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/bignumber" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-units-5.6.0-2b97ba73-6b49-47d2-b2c0-4f0a0f900a66-1700272091171/node_modules/@ethersproject-xdc/bignumber"
+    "@ethersproject-xdc/constants" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-units-5.6.0-2b97ba73-6b49-47d2-b2c0-4f0a0f900a66-1700272091171/node_modules/@ethersproject-xdc/constants"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-units-5.6.0-2b97ba73-6b49-47d2-b2c0-4f0a0f900a66-1700272091171/node_modules/@ethersproject-xdc/logger"
 
 "@ethersproject-xdc/wallet@file:vendor/@ethersproject-xdc/wallet":
   version "5.6.0"
   dependencies:
-    "@ethersproject-xdc/abstract-provider" "file:vendor/@ethersproject-xdc/abstract-provider"
-    "@ethersproject-xdc/abstract-signer" "file:vendor/@ethersproject-xdc/abstract-signer"
-    "@ethersproject-xdc/address" "file:vendor/@ethersproject-xdc/address"
-    "@ethersproject-xdc/bignumber" "file:vendor/@ethersproject-xdc/bignumber"
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/hash" "file:vendor/@ethersproject-xdc/hash"
-    "@ethersproject-xdc/hdnode" "file:vendor/@ethersproject-xdc/hdnode"
-    "@ethersproject-xdc/json-wallets" "file:vendor/@ethersproject-xdc/json-wallets"
-    "@ethersproject-xdc/keccak256" "file:vendor/@ethersproject-xdc/keccak256"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
-    "@ethersproject-xdc/properties" "file:vendor/@ethersproject-xdc/properties"
-    "@ethersproject-xdc/random" "file:vendor/@ethersproject-xdc/random"
-    "@ethersproject-xdc/signing-key" "file:vendor/@ethersproject-xdc/signing-key"
-    "@ethersproject-xdc/transactions" "file:vendor/@ethersproject-xdc/transactions"
-    "@ethersproject-xdc/wordlists" "file:vendor/@ethersproject-xdc/wordlists"
+    "@ethersproject-xdc/abstract-provider" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wallet-5.6.0-90789cf5-ad3b-41dd-992a-8e51d70def60-1700272091171/node_modules/@ethersproject-xdc/abstract-provider"
+    "@ethersproject-xdc/abstract-signer" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wallet-5.6.0-90789cf5-ad3b-41dd-992a-8e51d70def60-1700272091171/node_modules/@ethersproject-xdc/abstract-signer"
+    "@ethersproject-xdc/address" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wallet-5.6.0-90789cf5-ad3b-41dd-992a-8e51d70def60-1700272091171/node_modules/@ethersproject-xdc/address"
+    "@ethersproject-xdc/bignumber" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wallet-5.6.0-90789cf5-ad3b-41dd-992a-8e51d70def60-1700272091171/node_modules/@ethersproject-xdc/bignumber"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wallet-5.6.0-90789cf5-ad3b-41dd-992a-8e51d70def60-1700272091171/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/hash" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wallet-5.6.0-90789cf5-ad3b-41dd-992a-8e51d70def60-1700272091171/node_modules/@ethersproject-xdc/hash"
+    "@ethersproject-xdc/hdnode" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wallet-5.6.0-90789cf5-ad3b-41dd-992a-8e51d70def60-1700272091171/node_modules/@ethersproject-xdc/hdnode"
+    "@ethersproject-xdc/json-wallets" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wallet-5.6.0-90789cf5-ad3b-41dd-992a-8e51d70def60-1700272091171/node_modules/@ethersproject-xdc/json-wallets"
+    "@ethersproject-xdc/keccak256" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wallet-5.6.0-90789cf5-ad3b-41dd-992a-8e51d70def60-1700272091171/node_modules/@ethersproject-xdc/keccak256"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wallet-5.6.0-90789cf5-ad3b-41dd-992a-8e51d70def60-1700272091171/node_modules/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/properties" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wallet-5.6.0-90789cf5-ad3b-41dd-992a-8e51d70def60-1700272091171/node_modules/@ethersproject-xdc/properties"
+    "@ethersproject-xdc/random" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wallet-5.6.0-90789cf5-ad3b-41dd-992a-8e51d70def60-1700272091171/node_modules/@ethersproject-xdc/random"
+    "@ethersproject-xdc/signing-key" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wallet-5.6.0-90789cf5-ad3b-41dd-992a-8e51d70def60-1700272091171/node_modules/@ethersproject-xdc/signing-key"
+    "@ethersproject-xdc/transactions" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wallet-5.6.0-90789cf5-ad3b-41dd-992a-8e51d70def60-1700272091171/node_modules/@ethersproject-xdc/transactions"
+    "@ethersproject-xdc/wordlists" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wallet-5.6.0-90789cf5-ad3b-41dd-992a-8e51d70def60-1700272091171/node_modules/@ethersproject-xdc/wordlists"
 
 "@ethersproject-xdc/web@file:vendor/@ethersproject-xdc/web":
   version "5.7.1"
   dependencies:
-    "@ethersproject-xdc/base64" "file:vendor/@ethersproject-xdc/base64"
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
-    "@ethersproject-xdc/properties" "file:vendor/@ethersproject-xdc/properties"
-    "@ethersproject-xdc/strings" "file:vendor/@ethersproject-xdc/strings"
+    "@ethersproject-xdc/base64" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-web-5.7.1-19aba4e8-a576-47ed-9889-cd9e5ee0a253-1700272091174/node_modules/@ethersproject-xdc/base64"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-web-5.7.1-19aba4e8-a576-47ed-9889-cd9e5ee0a253-1700272091174/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-web-5.7.1-19aba4e8-a576-47ed-9889-cd9e5ee0a253-1700272091174/node_modules/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/properties" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-web-5.7.1-19aba4e8-a576-47ed-9889-cd9e5ee0a253-1700272091174/node_modules/@ethersproject-xdc/properties"
+    "@ethersproject-xdc/strings" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-web-5.7.1-19aba4e8-a576-47ed-9889-cd9e5ee0a253-1700272091174/node_modules/@ethersproject-xdc/strings"
 
 "@ethersproject-xdc/wordlists@file:vendor/@ethersproject-xdc/wordlists":
   version "5.7.0"
   dependencies:
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/hash" "file:vendor/@ethersproject-xdc/hash"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
-    "@ethersproject-xdc/properties" "file:vendor/@ethersproject-xdc/properties"
-    "@ethersproject-xdc/strings" "file:vendor/@ethersproject-xdc/strings"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wordlists-5.7.0-a14ff437-e716-4258-8257-801bd040870e-1700272091174/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/hash" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wordlists-5.7.0-a14ff437-e716-4258-8257-801bd040870e-1700272091174/node_modules/@ethersproject-xdc/hash"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wordlists-5.7.0-a14ff437-e716-4258-8257-801bd040870e-1700272091174/node_modules/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/properties" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wordlists-5.7.0-a14ff437-e716-4258-8257-801bd040870e-1700272091174/node_modules/@ethersproject-xdc/properties"
+    "@ethersproject-xdc/strings" "file:../../.cache/yarn/v6/npm-@ethersproject-xdc-wordlists-5.7.0-a14ff437-e716-4258-8257-801bd040870e-1700272091174/node_modules/@ethersproject-xdc/strings"
 
 "@ethersproject/abi@5.7.0", "@ethersproject/abi@^5.0.12", "@ethersproject/abi@^5.1.2", "@ethersproject/abi@^5.4.0", "@ethersproject/abi@^5.5.0", "@ethersproject/abi@^5.6.3", "@ethersproject/abi@^5.7.0":
   version "5.7.0"
@@ -6302,6 +6471,14 @@ axios@0.26.0:
   dependencies:
     follow-redirects "^1.14.8"
 
+axios@0.27.2, axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
+
 axios@1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.2.4.tgz#6555dd955d2efa9b8f4cb4cb0b3371b7b243537a"
@@ -6324,14 +6501,6 @@ axios@^0.26.1:
   integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
   dependencies:
     follow-redirects "^1.14.8"
-
-axios@^0.27.2:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
-  dependencies:
-    follow-redirects "^1.14.9"
-    form-data "^4.0.0"
 
 babel-jest@^27.5.1:
   version "27.5.1"
@@ -6517,7 +6686,7 @@ bigint-mod-arith@^3.1.0:
   resolved "https://registry.yarnpkg.com/bigint-mod-arith/-/bigint-mod-arith-3.1.2.tgz#658e416bc593a463d97b59766226d0a3021a76b1"
   integrity sha512-nx8J8bBeiRR+NlsROFH9jHswW5HO8mgfOSqW0AmjicMMvaONDa8AO+5ViKDUUNytBPWiwfvZP4/Bj4Y3lUfvgQ==
 
-bignumber.js@^9.0.0, bignumber.js@^9.0.1, bignumber.js@^9.1.0, bignumber.js@^9.1.1:
+bignumber.js@9.1.1, bignumber.js@^9.0.0, bignumber.js@^9.0.1, bignumber.js@^9.1.0, bignumber.js@^9.1.1:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.1.tgz#c4df7dc496bd849d4c9464344c1aa74228b4dac6"
   integrity sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==
@@ -7585,6 +7754,14 @@ cors@^2.8.1, cors@^2.8.5:
     object-assign "^4"
     vary "^1"
 
+cosmjs-types@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/cosmjs-types/-/cosmjs-types-0.5.2.tgz#2d42b354946f330dfb5c90a87fdc2a36f97b965d"
+  integrity sha512-zxCtIJj8v3Di7s39uN4LNcN3HIE1z0B9Z0SPE8ZNQR0oSzsuSe1ACgxoFkvhkS7WBasCAFcglS11G2hyfd5tPg==
+  dependencies:
+    long "^4.0.0"
+    protobufjs "~6.11.2"
+
 cosmjs-types@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/cosmjs-types/-/cosmjs-types-0.7.2.tgz#a757371abd340949c5bd5d49c6f8379ae1ffd7e2"
@@ -7804,7 +7981,7 @@ decimal.js-light@^2.5.0, decimal.js-light@^2.5.1:
   resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.5.1.tgz#134fd32508f19e208f4fb2f8dac0d2626a867934"
   integrity sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==
 
-decimal.js@^10.2.0, decimal.js@^10.2.1, decimal.js@^10.3.1, decimal.js@^10.4.3:
+decimal.js@10.4.3, decimal.js@^10.2.0, decimal.js@^10.2.1, decimal.js@^10.3.1, decimal.js@^10.4.3:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
   integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
@@ -8860,36 +9037,36 @@ ethereumjs-util@^6.0.0, ethereumjs-util@^6.2.1:
 "ethers-xdc@file:./vendor/ethers-xdc":
   version "5.7.2"
   dependencies:
-    "@ethersproject-xdc/abi" "file:vendor/@ethersproject-xdc/abi"
-    "@ethersproject-xdc/abstract-provider" "file:vendor/@ethersproject-xdc/abstract-provider"
-    "@ethersproject-xdc/abstract-signer" "file:vendor/@ethersproject-xdc/abstract-signer"
-    "@ethersproject-xdc/address" "file:vendor/@ethersproject-xdc/address"
-    "@ethersproject-xdc/base64" "file:vendor/@ethersproject-xdc/base64"
-    "@ethersproject-xdc/basex" "file:vendor/@ethersproject-xdc/basex"
-    "@ethersproject-xdc/bignumber" "file:vendor/@ethersproject-xdc/bignumber"
-    "@ethersproject-xdc/bytes" "file:vendor/@ethersproject-xdc/bytes"
-    "@ethersproject-xdc/constants" "file:vendor/@ethersproject-xdc/constants"
-    "@ethersproject-xdc/contracts" "file:vendor/@ethersproject-xdc/contracts"
-    "@ethersproject-xdc/hash" "file:vendor/@ethersproject-xdc/hash"
-    "@ethersproject-xdc/hdnode" "file:vendor/@ethersproject-xdc/hdnode"
-    "@ethersproject-xdc/json-wallets" "file:vendor/@ethersproject-xdc/json-wallets"
-    "@ethersproject-xdc/keccak256" "file:vendor/@ethersproject-xdc/keccak256"
-    "@ethersproject-xdc/logger" "file:vendor/@ethersproject-xdc/logger"
-    "@ethersproject-xdc/networks" "file:vendor/@ethersproject-xdc/networks"
-    "@ethersproject-xdc/pbkdf2" "file:vendor/@ethersproject-xdc/pbkdf2"
-    "@ethersproject-xdc/properties" "file:vendor/@ethersproject-xdc/properties"
-    "@ethersproject-xdc/providers" "file:vendor/@ethersproject-xdc/providers"
-    "@ethersproject-xdc/random" "file:vendor/@ethersproject-xdc/random"
-    "@ethersproject-xdc/rlp" "file:vendor/@ethersproject-xdc/rlp"
-    "@ethersproject-xdc/sha2" "file:vendor/@ethersproject-xdc/sha2"
-    "@ethersproject-xdc/signing-key" "file:vendor/@ethersproject-xdc/signing-key"
-    "@ethersproject-xdc/solidity" "file:vendor/@ethersproject-xdc/solidity"
-    "@ethersproject-xdc/strings" "file:vendor/@ethersproject-xdc/strings"
-    "@ethersproject-xdc/transactions" "file:vendor/@ethersproject-xdc/transactions"
-    "@ethersproject-xdc/units" "file:vendor/@ethersproject-xdc/units"
-    "@ethersproject-xdc/wallet" "file:vendor/@ethersproject-xdc/wallet"
-    "@ethersproject-xdc/web" "file:vendor/@ethersproject-xdc/web"
-    "@ethersproject-xdc/wordlists" "file:vendor/@ethersproject-xdc/wordlists"
+    "@ethersproject-xdc/abi" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/abi"
+    "@ethersproject-xdc/abstract-provider" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/abstract-provider"
+    "@ethersproject-xdc/abstract-signer" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/abstract-signer"
+    "@ethersproject-xdc/address" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/address"
+    "@ethersproject-xdc/base64" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/base64"
+    "@ethersproject-xdc/basex" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/basex"
+    "@ethersproject-xdc/bignumber" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/bignumber"
+    "@ethersproject-xdc/bytes" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/bytes"
+    "@ethersproject-xdc/constants" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/constants"
+    "@ethersproject-xdc/contracts" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/contracts"
+    "@ethersproject-xdc/hash" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/hash"
+    "@ethersproject-xdc/hdnode" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/hdnode"
+    "@ethersproject-xdc/json-wallets" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/json-wallets"
+    "@ethersproject-xdc/keccak256" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/keccak256"
+    "@ethersproject-xdc/logger" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/logger"
+    "@ethersproject-xdc/networks" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/networks"
+    "@ethersproject-xdc/pbkdf2" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/pbkdf2"
+    "@ethersproject-xdc/properties" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/properties"
+    "@ethersproject-xdc/providers" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/providers"
+    "@ethersproject-xdc/random" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/random"
+    "@ethersproject-xdc/rlp" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/rlp"
+    "@ethersproject-xdc/sha2" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/sha2"
+    "@ethersproject-xdc/signing-key" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/signing-key"
+    "@ethersproject-xdc/solidity" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/solidity"
+    "@ethersproject-xdc/strings" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/strings"
+    "@ethersproject-xdc/transactions" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/transactions"
+    "@ethersproject-xdc/units" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/units"
+    "@ethersproject-xdc/wallet" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/wallet"
+    "@ethersproject-xdc/web" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/web"
+    "@ethersproject-xdc/wordlists" "file:../../.cache/yarn/v6/npm-ethers-xdc-5.7.2-a7913beb-7447-433b-8fb9-3d03e085e867-1700272091135/node_modules/@ethersproject-xdc/wordlists"
 
 ethers@4.0.0-beta.3:
   version "4.0.0-beta.3"
@@ -12062,6 +12239,11 @@ loglevel@^1.6.8, loglevel@^1.8.1:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.1.tgz#5c621f83d5b48c54ae93b6156353f555963377b4"
   integrity sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==
 
+long@5.2.3, long@^5.2.1:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
+  integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
+
 long@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
@@ -12071,11 +12253,6 @@ long@^5.0.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/long/-/long-5.2.1.tgz#e27595d0083d103d2fa2c20c7699f8e0c92b897f"
   integrity sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==
-
-long@^5.2.1:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
-  integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
 
 long@~3:
   version "3.2.0"
@@ -13196,6 +13373,28 @@ os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
+
+osmo-query@^16.5.2:
+  version "16.5.2"
+  resolved "https://registry.yarnpkg.com/osmo-query/-/osmo-query-16.5.2.tgz#09e6d4bc5b47da5b6ea4fccb0bc3012c69e5eaa0"
+  integrity sha512-tO10iBjZ4voJ0G9qb1iYY8Mb/SAklqiVAWYfWdGA3PPtHiG48F326hCbUwFrF6tfQrFyBTnFuFZjXyyeZZrOzg==
+  dependencies:
+    "@cosmjs/amino" "0.29.3"
+    "@cosmjs/proto-signing" "0.29.3"
+    "@cosmjs/stargate" "0.29.3"
+    "@cosmjs/tendermint-rpc" "^0.29.3"
+    "@cosmology/lcd" "^0.12.0"
+
+osmojs@^16.5.1:
+  version "16.5.1"
+  resolved "https://registry.yarnpkg.com/osmojs/-/osmojs-16.5.1.tgz#38f2fe3cd65dbd4e4b415e9f22f387a24b634155"
+  integrity sha512-V2Q2yMt7Paax6i+S5Q1l29Km0As/waXKmSVRe8gtd9he42kcbkpwwk/QUCvgS98XsL7Qz+vas2Tca016uBQHTQ==
+  dependencies:
+    "@cosmjs/amino" "0.29.3"
+    "@cosmjs/proto-signing" "0.29.3"
+    "@cosmjs/stargate" "0.29.3"
+    "@cosmjs/tendermint-rpc" "^0.29.3"
+    "@cosmology/lcd" "^0.12.0"
 
 p-cancelable@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x ] Your code builds clean without any errors or warnings
- [x ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Adds Osmosis (with LP) support as a chain, plus some updates to Cosmos chain.

Cosmos amm.routes.ts models don't match up well with the rest due to inherent differences in their data. This has been handled by allowing certain endpoints to receive Cosmos-specific models switched by chain, eg. AddLiquidityRequest | CosmosAddLiquidityRequest.


**Tests performed by the developer**:
Jest tests added for all Osmosis functions. Very little patch use, instead a testnet wallet is instantiated and trades/liquidity actions are performed with it.
yarn test:cov is ~80% for Osmosis, improved for Cosmos.

**Tips for QA testing**:
THIS LINE MUST to be added to HBOT client native_tokens[]
    "osmosis": "OSMO",
in hummingbot/core/utils/gateway_config_utils.py

Submitting separate PR for that file as well.