### PR TITLE
Fix/ Kujira / Gas Price Change

### DIFF
--- a/src/templates/kujira.yml
+++ b/src/templates/kujira.yml
@@ -37,7 +37,7 @@ networks:
     tokenListSource: /home/gateway/conf/lists/kujira.json
 prefix: 'kujira'
 accountNumber: 0
-gasPrice: 0.00125
+gasPrice: 0.0034
 gasPriceSuffix: 'ukuji'
 gasLimitEstimate: 0.009147
 orderBook:


### PR DESCRIPTION
This pull request is changing the default gasPrice value on the kujira.yml configuration file.

The old gasPrice value cannot be used anymore.