### PR TITLE
Fix/Add retry and set submittx to submit and wait

### DIFF
--- a/src/connectors/xrpl/xrpl.ts
+++ b/src/connectors/xrpl/xrpl.ts
@@ -568,7 +568,7 @@ export class XRPLCLOB implements CLOBish {
     const prepared = await this._client.autofill(offer);
     const signed = wallet.sign(prepared);
     await this._xrpl.ensureConnection();
-    await this._client.submit(signed.tx_blob);
+    await this._client.submitAndWait(signed.tx_blob);
     this._isSubmittingTxn = false;
     return { prepared, signed };
   }

--- a/src/connectors/xrpl/xrpl.ts
+++ b/src/connectors/xrpl/xrpl.ts
@@ -44,6 +44,7 @@ import LRUCache from 'lru-cache';
 import { getXRPLConfig } from '../../chains/xrpl/xrpl.config';
 import { isUndefined } from 'mathjs';
 import { convertStringToHex } from './xrpl.utils';
+import { logger } from '../../services/logger';
 
 // const XRP_FACTOR = 1000000;
 const ORDERBOOK_LIMIT = 50;
@@ -145,7 +146,9 @@ export class XRPLCLOB implements CLOBish {
       loadedMarkets.push(processedMarket);
     };
 
-    await promiseAllInBatches(getMarket, markets, 1, 1);
+    logger.info(`Fetching markets for ${this.chain} ${this.network}`);
+
+    await promiseAllInBatches(getMarket, markets, 15, 300);
 
     return loadedMarkets;
   }


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
- Add retry for getting transaction data since rcp node could slow to sync up with latest transactions
- Set submitting transaction to `submitAndWait` to make sure transaction got posted on the ledger


**Tests performed by the developer**:
- Run PMM strategy on SOLO/XRP
- Run sample scripts:
  - `scripts/archived_scripts/examples_xrpl_scripts/xrpl_format_status.py`
  - `scripts/archived_scripts/examples_xrpl_scripts/xrpl_simple_arbitrage.py`
  - `scripts/archived_scripts/examples_xrpl_scripts/xrpl_simple_pmm.py`
  - `scripts/archived_scripts/examples_xrpl_scripts/xrpl_simple_rsi.py`
  - `scripts/archived_scripts/examples_xrpl_scripts/xrpl_simple_xemm.py`

**Tips for QA testing**:

