### PR TITLE
[DRAFT] fetch all v3 pools for pancake

### DIFF
--- a/src/connectors/pancakeswap/pancakeswap.ts
+++ b/src/connectors/pancakeswap/pancakeswap.ts
@@ -379,16 +379,16 @@ export class PancakeSwap implements Uniswapish {
     }
 
     // Define v3 pool on-chain fetcher with customized tvl references
-    const getV3CandidatePools = SmartRouter.createGetV3CandidatePools(
-      // Use your customized v3 pool fetcher by default
-      SmartRouter.getV3PoolsWithTvlFromOnChain,
-      {
-        fallbacks: [],
-        // In millisecond
-        // Will try fallback fetcher if the default doesn't respond in 2s
-        fallbackTimeout: 1500,
-      },
-    );
+    // const getV3CandidatePools = SmartRouter.createGetV3CandidatePools(
+    //   // Use your customized v3 pool fetcher by default
+    //   SmartRouter.getV3PoolsWithTvlFromOnChain,
+    //   {
+    //     fallbacks: [],
+    //     // In millisecond
+    //     // Will try fallback fetcher if the default doesn't respond in 2s
+    //     fallbackTimeout: 1500,
+    //   },
+    // );
 
     const allPools = await Promise.allSettled([
       // @ts-ignore
@@ -402,7 +402,7 @@ export class PancakeSwap implements Uniswapish {
         currencyA,
         currencyB,
       }),
-      getV3CandidatePools({
+      SmartRouter.getV3CandidatePools({
         // @ts-ignore
         onChainProvider: () => this.createPublicClient(),
         // @ts-ignore


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

- Test branch that fetches all v3 pools from the Pancakeswap router instead of calling its `getV3PoolsWithTvlFromOnChain` method.
- This enables fetching prices for BAI-USDT, but makes fetching prices for CAKE-USDT very slow
