### PR TITLE
update meteora pool and pos fns

### DIFF
--- a/src/connectors/meteora/routes/addLiquidity.ts
+++ b/src/connectors/meteora/routes/addLiquidity.ts
@@ -53,7 +53,7 @@ async function addLiquidity(
     throw httpNotFound(`Position not found: ${positionAddress}`);
   }
 
-  const dlmmPool = await meteora.getDlmmPool(info.publicKey.toBase58());
+  const dlmmPool = await meteora.getDlmmPool(info.toBase58());
   if (!dlmmPool) {
     throw httpNotFound(`Pool not found for position: ${positionAddress}`);
   }

--- a/src/connectors/meteora/routes/closePosition.ts
+++ b/src/connectors/meteora/routes/closePosition.ts
@@ -51,7 +51,10 @@ async function closePosition(
 
     const closePositionTx = await dlmmPool.closePosition({
       owner: wallet.publicKey,
-      position: position,
+      position: {
+        ...position,
+        version: 0
+      },
     });
 
     logger.debug('Close position transaction created:', closePositionTx);

--- a/src/connectors/meteora/routes/collectFees.ts
+++ b/src/connectors/meteora/routes/collectFees.ts
@@ -28,7 +28,7 @@ export async function collectFees(
     throw fastify.httpErrors.notFound(`Position not found: ${positionAddress}`);
   }
 
-  const dlmmPool = await meteora.getDlmmPool(info.publicKey.toBase58());
+  const dlmmPool = await meteora.getDlmmPool(info.toBase58());
   if (!dlmmPool) {
     throw fastify.httpErrors.notFound(`Pool not found for position: ${positionAddress}`);
   }
@@ -42,7 +42,10 @@ export async function collectFees(
 
   const claimSwapFeeTx = await dlmmPool.claimSwapFee({
     owner: wallet.publicKey,
-    position: position,
+    position: {
+      ...position,
+      version: 0
+    },
   });
 
   const { signature, fee } = await solana.sendAndConfirmTransaction(claimSwapFeeTx, [wallet], 300_000);

--- a/src/connectors/meteora/routes/removeLiquidity.ts
+++ b/src/connectors/meteora/routes/removeLiquidity.ts
@@ -32,7 +32,7 @@ export async function removeLiquidity(
   }
 
   const { position, info } = await meteora.getRawPosition(positionAddress, wallet.publicKey);
-  const dlmmPool = await meteora.getDlmmPool(info.publicKey.toBase58());
+  const dlmmPool = await meteora.getDlmmPool(info.toBase58());
   const tokenX = await solana.getToken(dlmmPool.tokenX.publicKey.toBase58());
   const tokenY = await solana.getToken(dlmmPool.tokenY.publicKey.toBase58());
   const tokenXSymbol = tokenX?.symbol || 'UNKNOWN';


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Attempt to address these issues reported by @cardosofede when running
```
/meteora/fetch-pools
/meteora/pool-info
/raydium/pool-info
```

errors:
```
2025-02-12 07:35:22 | info |     ⚡️ Gateway version 2.4.0 starting at http://localhost:15888/
2025-02-12 07:35:22 | info |     🔴 Running in development mode with (unsafe!) HTTP endpoints
2025-02-12 07:35:22 | info |     Read token file from conf/lists/solana.json, content length: 619001
2025-02-12 07:35:22 | info |     Parsed token count: 3854
2025-02-12 07:35:22 | info |     Loaded 3854 tokens for mainnet-beta
2025-02-12 07:35:23 | info |     📓 Documentation available at http://localhost:15888/docs
2025-02-12 07:35:35 | info |     Initializing Meteora
2025-02-12 07:35:35 | info |     Fetching Meteora pools...
2025-02-12 07:35:35 | error |     Error in fetch-pools: Converting circular structure to JSON
    --> starting at object with constructor 'Object'
    --- property 'issuerCertificate' closes the circle {}
2025-02-12 07:35:48 | info |     Raydium initialized with wallet: 4DeaBhUpXxsCxLJ6xnmpBq6MXroTrHEFJjJmiZthjxih
2025-02-12 07:35:48 | error |     Error getting pool info for 61R1ndXxvsWXXkWSyNkCxnzwd3zUNB8Q2ibmkiLPC8ht: failed to get info for multiple accounts, RPC_ERROR, fetch failed {}
2025-02-12 07:35:48 | error |     Pool not found {}
2025-02-12 07:35:57 | error |     Converting circular structure to JSON
    --> starting at object with constructor 'Object'
    --- property 'issuerCertificate' closes the circle {}
````
