### PR TITLE
Fix: Add support for baseToken and quoteToken fields in Jupiter price request

### DIFF
--- a/src/connectors/connector.requests.ts
+++ b/src/connectors/connector.requests.ts
@@ -14,8 +14,10 @@ const SideSchema = Type.Union([
 export const PriceRequestSchema = Type.Intersect([
   NetworkSelectionSchema,
   Type.Object({
-    quote: Type.String(),
     base: Type.String(),
+    quote: Type.String(),
+    baseToken: Type.String(),
+    quoteToken: Type.String(),
     amount: Type.String(),
     side: SideSchema,
     allowedSlippage: Type.Optional(Type.String()),

--- a/src/connectors/jupiter/jupiter.controllers.ts
+++ b/src/connectors/jupiter/jupiter.controllers.ts
@@ -48,7 +48,20 @@ export async function getTradeInfo(
 ): Promise<{ tradeInfo: TradeInfo; quote: QuoteResponse }> {
   const baseToken: TokenInfo = await solana.getToken(baseAsset);
   const quoteToken: TokenInfo = await solana.getToken(quoteAsset);
+  
+  if (!baseToken || !quoteToken) {
+    console.error('🔴 One or both tokens not found!');
+    console.error('baseAsset:', baseAsset, '=>', baseToken);
+    console.error('quoteAsset:', quoteAsset, '=>', quoteToken);
+    throw new Error('Token not found in token list');
+  }
+  
+  
   const requestAmount = Math.floor(amount * Math.pow(10, baseToken.decimals));
+
+  console.log("🪙 Token lookup:");
+  console.log("  baseAsset:", baseAsset, "→", baseToken?.symbol || "NOT FOUND");
+  console.log("  quoteAsset:", quoteAsset, "→", quoteToken?.symbol || "NOT FOUND");
 
   const slippagePct = allowedSlippage ? Number(allowedSlippage) : jupiter.getSlippagePct();
 
@@ -126,8 +139,8 @@ export async function price(
     const result = await getTradeInfo(
       solana,
       jupiter,
-      req.base,
-      req.quote,
+      req.baseToken,
+      req.quoteToken,
       Number(req.amount),
       req.side,
       req.allowedSlippage,

--- a/src/connectors/jupiter/jupiter.controllers.ts
+++ b/src/connectors/jupiter/jupiter.controllers.ts
@@ -59,10 +59,6 @@ export async function getTradeInfo(
   
   const requestAmount = Math.floor(amount * Math.pow(10, baseToken.decimals));
 
-  console.log("🪙 Token lookup:");
-  console.log("  baseAsset:", baseAsset, "→", baseToken?.symbol || "NOT FOUND");
-  console.log("  quoteAsset:", quoteAsset, "→", quoteToken?.symbol || "NOT FOUND");
-
   const slippagePct = allowedSlippage ? Number(allowedSlippage) : jupiter.getSlippagePct();
 
   let quote: QuoteResponse;


### PR DESCRIPTION
This is my first contribution. I ran into this issue while using the Gateway Jupiter connector from source. These changes resolved the error and allowed the /jupiter/price endpoint to function as expected.

## What this does

- Adds support for `baseToken` and `quoteToken` fields in the /jupiter/price endpoint
- This fixes validation errors that occur when trying to call the endpoint with token mint addresses

## Why it matters

Without these changes, valid requests using the expected mint address fields fail validation. These changes enable developers to properly integrate Jupiter connector in secure HTTPS mode using token mints.

## How to test

1. Launch Gateway in HTTPS mode
2. Use curl to hit `/jupiter/price` with this body:
```json
{
  "chain": "solana",
  "network": "mainnet-beta",
  "connector": "jupiter",
  "baseToken": "So11111111111111111111111111111111111111112",
  "quoteToken": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
  "amount": "1000000",
  "side": "SELL",
  "base": true,
  "quote": false
}
