### PR TITLE
fix: correct ConfigTemplatesDir path for Docker container initialization

### DIFF
--- a/src/services/config-manager-v2.ts
+++ b/src/services/config-manager-v2.ts
@@ -32,9 +32,9 @@ export const ConfigRootSchemaPath: string = path.join(
   'configuration-root-schema.json',
 );
 
-// Always use conf directory for both configs and templates
+// Use conf directory for configs and dist/src/templates for templates
 const ConfigDir: string = path.join(rootPath(), 'conf/');
-const ConfigTemplatesDir: string = ConfigDir;
+const ConfigTemplatesDir: string = path.join(rootPath(), 'dist/src/templates/');
 
 interface UnpackedConfigNamespace {
   namespace: ConfigurationNamespace;


### PR DESCRIPTION
- Changed ConfigTemplatesDir from ConfigDir to 'dist/src/templates/'
- Fixes ENOENT error when starting Docker container with empty volumes
- Ensures template files can be properly copied from build directory to conf directory

🤖 Generated with [Claude Code](https://claude.ai/code)

**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Fixes #462 
