### PR TITLE
Remove startup noise from heuristically retrieving an example address 

### DIFF
--- a/src/chains/ethereum/routes/allowances.ts
+++ b/src/chains/ethereum/routes/allowances.ts
@@ -163,15 +163,7 @@ export async function getEthereumAllowances(
 
 export const allowancesRoute: FastifyPluginAsync = async (fastify) => {
   // Get first wallet address for example
-  const ethereum = await Ethereum.getInstance('base');
-  let firstWalletAddress = '<ethereum-wallet-address>';
-
-  try {
-    firstWalletAddress =
-      (await ethereum.getFirstWalletAddress()) || firstWalletAddress;
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Ethereum.getWalletAddressExample();
 
   fastify.post<{
     Body: AllowancesRequestType;

--- a/src/chains/ethereum/routes/approve.ts
+++ b/src/chains/ethereum/routes/approve.ts
@@ -175,15 +175,7 @@ export async function approveEthereumToken(
 
 export const approveRoute: FastifyPluginAsync = async (fastify) => {
   // Get first wallet address for example
-  const ethereum = await Ethereum.getInstance('base');
-  let firstWalletAddress = '<ethereum-wallet-address>';
-
-  try {
-    firstWalletAddress =
-      (await ethereum.getFirstWalletAddress()) || firstWalletAddress;
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Ethereum.getWalletAddressExample();
 
   fastify.post<{
     Body: ApproveRequestType;

--- a/src/chains/ethereum/routes/balances.ts
+++ b/src/chains/ethereum/routes/balances.ts
@@ -163,30 +163,7 @@ export async function getEthereumBalances(
 
 export const balancesRoute: FastifyPluginAsync = async (fastify) => {
   // Get first wallet address for example
-  const ethereum = await Ethereum.getInstance('base');
-
-  // Default Ethereum address for examples if no wallet is available
-  let firstWalletAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
-
-  try {
-    // Try to get user's first Ethereum wallet if available
-    // getFirstWalletAddress specifically looks in the /ethereum directory
-    const userWallet = await ethereum.getFirstWalletAddress();
-    if (userWallet) {
-      // Make sure it's a valid Ethereum address (0x prefix and 42 chars)
-      const isValidEthAddress = /^0x[a-fA-F0-9]{40}$/i.test(userWallet);
-      if (isValidEthAddress) {
-        firstWalletAddress = userWallet;
-        logger.info(
-          `Using user's Ethereum wallet for examples: ${firstWalletAddress}`,
-        );
-      }
-    }
-  } catch (error) {
-    logger.warn('No Ethereum wallets found for examples in schema');
-  }
-
-  BalanceRequestSchema.properties.address.examples = [firstWalletAddress];
+  const firstWalletAddress = await Ethereum.getWalletAddressExample();
 
   fastify.post<{
     Body: BalanceRequestType;

--- a/src/chains/ethereum/routes/wrap.ts
+++ b/src/chains/ethereum/routes/wrap.ts
@@ -194,15 +194,7 @@ export async function wrapEthereum(
 
 export const wrapRoute: FastifyPluginAsync = async (fastify) => {
   // Get first wallet address for example
-  const ethereum = await Ethereum.getInstance('mainnet');
-  let firstWalletAddress = '<ethereum-wallet-address>';
-
-  try {
-    firstWalletAddress =
-      (await ethereum.getFirstWalletAddress()) || firstWalletAddress;
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Ethereum.getWalletAddressExample();
 
   fastify.post<{
     Body: WrapRequestType;

--- a/src/chains/solana/routes/balances.ts
+++ b/src/chains/solana/routes/balances.ts
@@ -329,15 +329,8 @@ async function getOptimizedBalance(
 }
 
 export const balancesRoute: FastifyPluginAsync = async (fastify) => {
-  // Get first wallet address for example - use a known Solana address as fallback
-  const solana = await Solana.getInstance('mainnet-beta');
-  let firstWalletAddress = '<solana-wallet-address>';
-
-  try {
-    firstWalletAddress = await solana.getFirstWalletAddress();
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  // Get first wallet address for example
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
   // Example address for Solana tokens
   const USDC_MINT_ADDRESS = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'; // USDC on Solana

--- a/src/chains/solana/solana.ts
+++ b/src/chains/solana/solana.ts
@@ -1238,7 +1238,7 @@ export class Solana {
   }
 
   // Add new method to get first wallet address
-  public async getFirstWalletAddress(): Promise<string | null> {
+  public static async getFirstWalletAddress(): Promise<string | null> {
     // Specifically look in the solana subdirectory, not in any other chain's directory
     const safeChain = sanitizePathComponent('solana');
     const path = `${walletPath}/${safeChain}`;
@@ -1269,6 +1269,23 @@ export class Solana {
     } catch (error) {
       logger.error(`Error getting Solana wallet address: ${error.message}`);
       return null;
+    }
+  }
+
+  public static async getWalletAddressExample(): Promise<string> {
+    const defaultAddress = '<solana-wallet-address>';
+    try {
+      const foundWallet = await this.getFirstWalletAddress();
+      if (foundWallet) {
+        return foundWallet;
+      }
+      logger.debug('No wallets found for examples in schema, using default.');
+      return defaultAddress;
+    } catch (error) {
+      logger.error(
+        `Error getting Solana wallet address for example: ${error.message}`,
+      );
+      return defaultAddress;
     }
   }
 

--- a/src/commands/balance.ts
+++ b/src/commands/balance.ts
@@ -60,7 +60,7 @@ export default class Balance extends Command {
       let keypair;
       let walletIdentifier = wallet;
       if (!walletIdentifier) {
-        walletIdentifier = await solana.getFirstWalletAddress();
+        walletIdentifier = await Solana.getFirstWalletAddress();
         if (!walletIdentifier) {
           this.error('No wallet provided and none found on file.');
         }

--- a/src/connectors/jupiter/routes/executeSwap.ts
+++ b/src/connectors/jupiter/routes/executeSwap.ts
@@ -96,15 +96,7 @@ async function executeJupiterSwap(
 
 export const executeSwapRoute: FastifyPluginAsync = async (fastify) => {
   // Get first wallet address for example
-  const solana = await Solana.getInstance('mainnet-beta');
-  let firstWalletAddress = '<solana-wallet-address>';
-
-  try {
-    firstWalletAddress =
-      (await solana.getFirstWalletAddress()) || firstWalletAddress;
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
   // Update schema example
   ExecuteSwapRequest.properties.walletAddress.examples = [firstWalletAddress];

--- a/src/connectors/meteora/clmm-routes/addLiquidity.ts
+++ b/src/connectors/meteora/clmm-routes/addLiquidity.ts
@@ -192,15 +192,7 @@ export type MeteoraAddLiquidityRequestType = Static<
 
 export const addLiquidityRoute: FastifyPluginAsync = async (fastify) => {
   // Get first wallet address for example
-  const solana = await Solana.getInstance('mainnet-beta');
-  let firstWalletAddress = '<solana-wallet-address>';
-
-  const foundWallet = await solana.getFirstWalletAddress();
-  if (foundWallet) {
-    firstWalletAddress = foundWallet;
-  } else {
-    logger.debug('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
   // Update schema example
   AddLiquidityRequest.properties.walletAddress.examples = [firstWalletAddress];

--- a/src/connectors/meteora/clmm-routes/closePosition.ts
+++ b/src/connectors/meteora/clmm-routes/closePosition.ts
@@ -119,15 +119,7 @@ async function closePosition(
 
 export const closePositionRoute: FastifyPluginAsync = async (fastify) => {
   // Get first wallet address for example
-  const solana = await Solana.getInstance('mainnet-beta');
-  let firstWalletAddress = '<solana-wallet-address>';
-
-  const foundWallet = await solana.getFirstWalletAddress();
-  if (foundWallet) {
-    firstWalletAddress = foundWallet;
-  } else {
-    logger.info('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
   // Update schema example
   ClosePositionRequest.properties.walletAddress.examples = [firstWalletAddress];

--- a/src/connectors/meteora/clmm-routes/collectFees.ts
+++ b/src/connectors/meteora/clmm-routes/collectFees.ts
@@ -90,15 +90,7 @@ export async function collectFees(
 
 export const collectFeesRoute: FastifyPluginAsync = async (fastify) => {
   // Get first wallet address for example
-  const solana = await Solana.getInstance('mainnet-beta');
-  let firstWalletAddress = '<solana-wallet-address>';
-
-  const foundWallet = await solana.getFirstWalletAddress();
-  if (foundWallet) {
-    firstWalletAddress = foundWallet;
-  } else {
-    logger.debug('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
   // Update schema example
   CollectFeesRequest.properties.walletAddress.examples = [firstWalletAddress];

--- a/src/connectors/meteora/clmm-routes/executeSwap.ts
+++ b/src/connectors/meteora/clmm-routes/executeSwap.ts
@@ -101,14 +101,7 @@ async function executeSwap(
 
 export const executeSwapRoute: FastifyPluginAsync = async (fastify) => {
   // Get first wallet address for example
-  const solana = await Solana.getInstance('mainnet-beta');
-  let firstWalletAddress = '<solana-wallet-address>';
-
-  try {
-    firstWalletAddress = await solana.getFirstWalletAddress();
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
   fastify.post<{
     Body: ExecuteSwapRequestType;

--- a/src/connectors/meteora/clmm-routes/openPosition.ts
+++ b/src/connectors/meteora/clmm-routes/openPosition.ts
@@ -257,15 +257,7 @@ export type MeteoraOpenPositionRequestType = Static<
 >;
 
 export const openPositionRoute: FastifyPluginAsync = async (fastify) => {
-  const solana = await Solana.getInstance('mainnet-beta');
-  let firstWalletAddress = '<solana-wallet-address>';
-
-  const foundWallet = await solana.getFirstWalletAddress();
-  if (foundWallet) {
-    firstWalletAddress = foundWallet;
-  } else {
-    logger.debug('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
   // Update schema example
   OpenPositionRequest.properties.walletAddress.examples = [firstWalletAddress];

--- a/src/connectors/meteora/clmm-routes/positionInfo.ts
+++ b/src/connectors/meteora/clmm-routes/positionInfo.ts
@@ -12,16 +12,7 @@ import { logger } from '../../../services/logger';
 import { Meteora } from '../meteora';
 
 export const positionInfoRoute: FastifyPluginAsync = async (fastify) => {
-  // Get first wallet address for example
-  const solana = await Solana.getInstance('mainnet-beta');
-  let firstWalletAddress = '<solana-wallet-address>';
-
-  const foundWallet = await solana.getFirstWalletAddress();
-  if (foundWallet) {
-    firstWalletAddress = foundWallet;
-  } else {
-    logger.debug('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
   // Update schema example
   GetPositionInfoRequest.properties.walletAddress.examples = [

--- a/src/connectors/meteora/clmm-routes/positionsOwned.ts
+++ b/src/connectors/meteora/clmm-routes/positionsOwned.ts
@@ -28,16 +28,7 @@ type GetPositionsOwnedRequestType = Static<typeof GetPositionsOwnedRequest>;
 type GetPositionsOwnedResponseType = Static<typeof GetPositionsOwnedResponse>;
 
 export const positionsOwnedRoute: FastifyPluginAsync = async (fastify) => {
-  // Get first wallet address for example
-  const solana = await Solana.getInstance('mainnet-beta');
-  let firstWalletAddress = '<solana-wallet-address>';
-
-  const foundWallet = await solana.getFirstWalletAddress();
-  if (foundWallet) {
-    firstWalletAddress = foundWallet;
-  } else {
-    logger.debug('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
   // Update schema example
   GetPositionsOwnedRequest.properties.walletAddress.examples = [

--- a/src/connectors/meteora/clmm-routes/removeLiquidity.ts
+++ b/src/connectors/meteora/clmm-routes/removeLiquidity.ts
@@ -104,15 +104,7 @@ export async function removeLiquidity(
 
 export const removeLiquidityRoute: FastifyPluginAsync = async (fastify) => {
   // Get first wallet address for example
-  const solana = await Solana.getInstance('mainnet-beta');
-  let firstWalletAddress = '<solana-wallet-address>';
-
-  const foundWallet = await solana.getFirstWalletAddress();
-  if (foundWallet) {
-    firstWalletAddress = foundWallet;
-  } else {
-    logger.debug('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
   // Update schema example
   RemoveLiquidityRequest.properties.walletAddress.examples = [

--- a/src/connectors/raydium/amm-routes/addLiquidity.ts
+++ b/src/connectors/raydium/amm-routes/addLiquidity.ts
@@ -216,16 +216,7 @@ async function addLiquidity(
 }
 
 export const addLiquidityRoute: FastifyPluginAsync = async (fastify) => {
-  // Get first wallet address for example
-  const solana = await Solana.getInstance('mainnet-beta');
-  let firstWalletAddress = '<solana-wallet-address>';
-
-  const foundWallet = await solana.getFirstWalletAddress();
-  if (foundWallet) {
-    firstWalletAddress = foundWallet;
-  } else {
-    logger.debug('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
   // Update schema example
   AddLiquidityRequest.properties.walletAddress.examples = [firstWalletAddress];

--- a/src/connectors/raydium/amm-routes/executeSwap.ts
+++ b/src/connectors/raydium/amm-routes/executeSwap.ts
@@ -185,15 +185,7 @@ async function executeSwap(
 
 export const executeSwapRoute: FastifyPluginAsync = async (fastify) => {
   // Get first wallet address for example
-  const solana = await Solana.getInstance('mainnet-beta');
-  let firstWalletAddress = '<solana-wallet-address>';
-
-  try {
-    firstWalletAddress =
-      (await solana.getFirstWalletAddress()) || firstWalletAddress;
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
   fastify.post<{
     Body: ExecuteSwapRequestType;

--- a/src/connectors/raydium/amm-routes/positionInfo.ts
+++ b/src/connectors/raydium/amm-routes/positionInfo.ts
@@ -79,17 +79,8 @@ async function calculateLpAmount(
 }
 
 export const positionInfoRoute: FastifyPluginAsync = async (fastify) => {
-  // Populate wallet address example
-  let firstWalletAddress = '<solana-wallet-address>';
-  try {
-    const solana = await Solana.getInstance('mainnet-beta');
-    const walletAddress = await solana.getFirstWalletAddress();
-    if (walletAddress) {
-      firstWalletAddress = walletAddress;
-    }
-  } catch (e) {
-    logger.warn('Could not populate wallet address example:', e);
-  }
+  // Get first wallet address for example
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
   fastify.get<{
     Querystring: GetPositionInfoRequestType;

--- a/src/connectors/raydium/amm-routes/removeLiquidity.ts
+++ b/src/connectors/raydium/amm-routes/removeLiquidity.ts
@@ -258,15 +258,7 @@ async function removeLiquidity(
 
 export const removeLiquidityRoute: FastifyPluginAsync = async (fastify) => {
   // Get first wallet address for example
-  const solana = await Solana.getInstance('mainnet-beta');
-  let firstWalletAddress = '<solana-wallet-address>';
-
-  const foundWallet = await solana.getFirstWalletAddress();
-  if (foundWallet) {
-    firstWalletAddress = foundWallet;
-  } else {
-    logger.debug('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
   // Update schema example
   RemoveLiquidityRequest.properties.walletAddress.examples = [

--- a/src/connectors/raydium/clmm-routes/closePosition.ts
+++ b/src/connectors/raydium/clmm-routes/closePosition.ts
@@ -100,15 +100,7 @@ async function closePosition(
 
 export const closePositionRoute: FastifyPluginAsync = async (fastify) => {
   // Get first wallet address for example
-  const solana = await Solana.getInstance('mainnet-beta');
-  let firstWalletAddress = '<solana-wallet-address>';
-
-  const foundWallet = await solana.getFirstWalletAddress();
-  if (foundWallet) {
-    firstWalletAddress = foundWallet;
-  } else {
-    logger.debug('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
   // Update schema example
   ClosePositionRequest.properties.walletAddress.examples = [firstWalletAddress];

--- a/src/connectors/raydium/clmm-routes/collectFees.ts
+++ b/src/connectors/raydium/clmm-routes/collectFees.ts
@@ -95,16 +95,10 @@ export async function collectFees(
 }
 
 export const collectFeesRoute: FastifyPluginAsync = async (fastify) => {
-  const solana = await Solana.getInstance('mainnet-beta');
-  let firstWalletAddress = '<solana-wallet-address>';
+  // Get first wallet address for example
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
-  try {
-    firstWalletAddress =
-      (await solana.getFirstWalletAddress()) || firstWalletAddress;
-  } catch (error) {
-    logger.debug('No wallets found for examples in schema');
-  }
-
+  // Update schema example
   CollectFeesRequest.properties.walletAddress.examples = [firstWalletAddress];
 
   fastify.post<{

--- a/src/connectors/raydium/clmm-routes/executeSwap.ts
+++ b/src/connectors/raydium/clmm-routes/executeSwap.ts
@@ -225,15 +225,7 @@ async function executeSwap(
 
 export const executeSwapRoute: FastifyPluginAsync = async (fastify) => {
   // Get first wallet address for example
-  const solana = await Solana.getInstance('mainnet-beta');
-  let firstWalletAddress = '<solana-wallet-address>';
-
-  try {
-    firstWalletAddress =
-      (await solana.getFirstWalletAddress()) || firstWalletAddress;
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
   fastify.post<{
     Body: ExecuteSwapRequestType;

--- a/src/connectors/raydium/clmm-routes/openPosition.ts
+++ b/src/connectors/raydium/clmm-routes/openPosition.ts
@@ -165,16 +165,7 @@ async function openPosition(
 }
 
 export const openPositionRoute: FastifyPluginAsync = async (fastify) => {
-  // Get first wallet address for example
-  const solana = await Solana.getInstance('mainnet-beta');
-  let firstWalletAddress = '<solana-wallet-address>';
-
-  const foundWallet = await solana.getFirstWalletAddress();
-  if (foundWallet) {
-    firstWalletAddress = foundWallet;
-  } else {
-    logger.debug('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Solana.getWalletAddressExample();
 
   // Update schema example
   OpenPositionRequest.properties.walletAddress.examples = [firstWalletAddress];

--- a/src/connectors/raydium/raydium.ts
+++ b/src/connectors/raydium/raydium.ts
@@ -67,7 +67,7 @@ export class Raydium {
       this.solana = await Solana.getInstance(network);
 
       // Load first wallet if available
-      const walletAddress = await this.solana.getFirstWalletAddress();
+      const walletAddress = await Solana.getFirstWalletAddress();
       if (walletAddress) {
         this.owner = await this.solana.getWallet(walletAddress);
       }

--- a/src/connectors/uniswap/amm-routes/addLiquidity.ts
+++ b/src/connectors/uniswap/amm-routes/addLiquidity.ts
@@ -311,15 +311,7 @@ export const addLiquidityRoute: FastifyPluginAsync = async (fastify) => {
   await fastify.register(require('@fastify/sensible'));
 
   // Get first wallet address for example
-  const ethereum = await Ethereum.getInstance('base');
-  let firstWalletAddress = '<ethereum-wallet-address>';
-
-  try {
-    firstWalletAddress =
-      (await ethereum.getFirstWalletAddress()) || firstWalletAddress;
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Ethereum.getWalletAddressExample();
 
   fastify.post<{
     Body: AddLiquidityRequestType;
@@ -380,11 +372,10 @@ export const addLiquidityRoute: FastifyPluginAsync = async (fastify) => {
         // Get wallet address - either from request or first available
         let walletAddress = requestedWalletAddress;
         if (!walletAddress) {
-          const ethereum = await Ethereum.getInstance(networkToUse);
-          walletAddress = await ethereum.getFirstWalletAddress();
+          walletAddress = await Ethereum.getFirstWalletAddress();
           if (!walletAddress) {
             throw fastify.httpErrors.badRequest(
-              'No wallet address provided and no default wallet found',
+              'No wallet address provided and no wallets found.',
             );
           }
           logger.info(`Using first available wallet address: ${walletAddress}`);

--- a/src/connectors/uniswap/amm-routes/executeSwap.ts
+++ b/src/connectors/uniswap/amm-routes/executeSwap.ts
@@ -24,15 +24,7 @@ export const executeSwapRoute: FastifyPluginAsync = async (fastify) => {
   await fastify.register(require('@fastify/sensible'));
 
   // Get first wallet address for example
-  const ethereum = await Ethereum.getInstance('base');
-  let firstWalletAddress = '<ethereum-wallet-address>';
-
-  try {
-    firstWalletAddress =
-      (await ethereum.getFirstWalletAddress()) || firstWalletAddress;
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Ethereum.getWalletAddressExample();
 
   fastify.post<{
     Body: ExecuteSwapRequestType;
@@ -85,11 +77,10 @@ export const executeSwapRoute: FastifyPluginAsync = async (fastify) => {
         // Get wallet address - either from request or first available
         let walletAddress = requestedWalletAddress;
         if (!walletAddress) {
-          const ethereum = await Ethereum.getInstance(networkToUse);
-          walletAddress = await ethereum.getFirstWalletAddress();
+          walletAddress = await Ethereum.getFirstWalletAddress();
           if (!walletAddress) {
             throw fastify.httpErrors.badRequest(
-              'No wallet address provided and no default wallet found',
+              'No wallet address provided and no wallets found.',
             );
           }
           logger.info(`Using first available wallet address: ${walletAddress}`);

--- a/src/connectors/uniswap/amm-routes/positionInfo.ts
+++ b/src/connectors/uniswap/amm-routes/positionInfo.ts
@@ -38,15 +38,7 @@ export async function checkLPAllowance(
 
 export const positionInfoRoute: FastifyPluginAsync = async (fastify) => {
   // Get first wallet address for example
-  const ethereum = await Ethereum.getInstance('base');
-  let firstWalletAddress = '<ethereum-wallet-address>';
-
-  try {
-    firstWalletAddress =
-      (await ethereum.getFirstWalletAddress()) || firstWalletAddress;
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Ethereum.getWalletAddressExample();
 
   fastify.get<{
     Querystring: GetPositionInfoRequestType;

--- a/src/connectors/uniswap/amm-routes/removeLiquidity.ts
+++ b/src/connectors/uniswap/amm-routes/removeLiquidity.ts
@@ -25,15 +25,7 @@ export const removeLiquidityRoute: FastifyPluginAsync = async (fastify) => {
   await fastify.register(require('@fastify/sensible'));
 
   // Get first wallet address for example
-  const ethereum = await Ethereum.getInstance('base');
-  let firstWalletAddress = '<ethereum-wallet-address>';
-
-  try {
-    firstWalletAddress =
-      (await ethereum.getFirstWalletAddress()) || firstWalletAddress;
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Ethereum.getWalletAddressExample();
 
   fastify.post<{
     Body: RemoveLiquidityRequestType;

--- a/src/connectors/uniswap/clmm-routes/executeSwap.ts
+++ b/src/connectors/uniswap/clmm-routes/executeSwap.ts
@@ -24,15 +24,7 @@ export const executeSwapRoute: FastifyPluginAsync = async (fastify) => {
   await fastify.register(require('@fastify/sensible'));
 
   // Get first wallet address for example
-  const ethereum = await Ethereum.getInstance('base');
-  let firstWalletAddress = '<ethereum-wallet-address>';
-
-  try {
-    firstWalletAddress =
-      (await ethereum.getFirstWalletAddress()) || firstWalletAddress;
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Ethereum.getWalletAddressExample();
 
   fastify.post<{
     Body: ExecuteSwapRequestType;
@@ -85,11 +77,10 @@ export const executeSwapRoute: FastifyPluginAsync = async (fastify) => {
         // Get wallet address - either from request or first available
         let walletAddress = requestedWalletAddress;
         if (!walletAddress) {
-          const ethereum = await Ethereum.getInstance(networkToUse);
-          walletAddress = await ethereum.getFirstWalletAddress();
+          walletAddress = await Ethereum.getFirstWalletAddress();
           if (!walletAddress) {
             throw fastify.httpErrors.badRequest(
-              'No wallet address provided and no default wallet found',
+              'No wallet address provided and no wallets found.',
             );
           }
           logger.info(`Using first available wallet address: ${walletAddress}`);

--- a/src/connectors/uniswap/clmm-routes/openPosition.ts
+++ b/src/connectors/uniswap/clmm-routes/openPosition.ts
@@ -28,15 +28,7 @@ export const openPositionRoute: FastifyPluginAsync = async (fastify) => {
   await fastify.register(require('@fastify/sensible'));
 
   // Get first wallet address for example
-  const ethereum = await Ethereum.getInstance('base');
-  let firstWalletAddress = '<ethereum-wallet-address>';
-
-  try {
-    firstWalletAddress =
-      (await ethereum.getFirstWalletAddress()) || firstWalletAddress;
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Ethereum.getWalletAddressExample();
 
   fastify.post<{
     Body: OpenPositionRequestType;

--- a/src/connectors/uniswap/clmm-routes/positionInfo.ts
+++ b/src/connectors/uniswap/clmm-routes/positionInfo.ts
@@ -25,15 +25,7 @@ import { formatTokenAmount } from '../uniswap.utils';
 export const positionInfoRoute: FastifyPluginAsync = async (fastify) => {
   await fastify.register(require('@fastify/sensible'));
   // Get first wallet address for example
-  const ethereum = await Ethereum.getInstance('base');
-  let firstWalletAddress = '<ethereum-wallet-address>';
-
-  try {
-    firstWalletAddress =
-      (await ethereum.getFirstWalletAddress()) || firstWalletAddress;
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Ethereum.getWalletAddressExample();
 
   fastify.get<{
     Querystring: GetPositionInfoRequestType;

--- a/src/connectors/uniswap/clmm-routes/positionsOwned.ts
+++ b/src/connectors/uniswap/clmm-routes/positionsOwned.ts
@@ -43,19 +43,11 @@ export const positionsOwnedRoute: FastifyPluginAsync = async (fastify) => {
   await fastify.register(require('@fastify/sensible'));
 
   // Get first wallet address for example
-  const ethereum = await Ethereum.getInstance('base');
-  let firstWalletAddress = '<ethereum-wallet-address>';
+  const firstWalletAddress = await Ethereum.getWalletAddressExample();
 
-  try {
-    firstWalletAddress =
-      (await ethereum.getFirstWalletAddress()) || firstWalletAddress;
-    // Update the example in the schema
-    PositionsOwnedRequest.properties.walletAddress.examples = [
-      firstWalletAddress,
-    ];
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  PositionsOwnedRequest.properties.walletAddress.examples = [
+    firstWalletAddress,
+  ];
 
   fastify.get<{
     Querystring: typeof PositionsOwnedRequest.static;

--- a/src/connectors/uniswap/routes/execute-swap.ts
+++ b/src/connectors/uniswap/routes/execute-swap.ts
@@ -20,15 +20,7 @@ export const executeSwapRoute: FastifyPluginAsync = async (
   await fastify.register(require('@fastify/sensible'));
 
   // Get first wallet address for example
-  const ethereum = await Ethereum.getInstance('mainnet');
-  let firstWalletAddress = '<ethereum-wallet-address>';
-
-  try {
-    firstWalletAddress =
-      (await ethereum.getFirstWalletAddress()) || firstWalletAddress;
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Ethereum.getWalletAddressExample();
 
   // Get available networks from Ethereum configuration (same method as chain.routes.ts)
   const { ConfigManagerV2 } = require('../../../services/config-manager-v2');
@@ -104,7 +96,7 @@ export const executeSwapRoute: FastifyPluginAsync = async (
         // Get wallet address - either from request or first available
         let walletAddress = requestedWalletAddress;
         if (!walletAddress) {
-          walletAddress = await ethereum.getFirstWalletAddress();
+          walletAddress = await Ethereum.getFirstWalletAddress();
           if (!walletAddress) {
             return reply.badRequest(
               'No wallet address provided and no default wallet found',

--- a/src/connectors/uniswap/routes/quote-swap.ts
+++ b/src/connectors/uniswap/routes/quote-swap.ts
@@ -415,15 +415,7 @@ export const quoteSwapRoute: FastifyPluginAsync = async (fastify, _options) => {
   await fastify.register(require('@fastify/sensible'));
 
   // Get first wallet address for example
-  const ethereum = await Ethereum.getInstance('mainnet');
-  let firstWalletAddress = '<ethereum-wallet-address>';
-
-  try {
-    firstWalletAddress =
-      (await ethereum.getFirstWalletAddress()) || firstWalletAddress;
-  } catch (error) {
-    logger.warn('No wallets found for examples in schema');
-  }
+  const firstWalletAddress = await Ethereum.getWalletAddressExample();
 
   // Get available networks from Ethereum configuration (same method as chain.routes.ts)
   const ethereumNetworks = Object.keys(

--- a/src/connectors/uniswap/uniswap.ts
+++ b/src/connectors/uniswap/uniswap.ts
@@ -507,7 +507,7 @@ export class Uniswap {
    */
   public async getFirstWalletAddress(): Promise<string | null> {
     try {
-      return await this.ethereum.getFirstWalletAddress();
+      return await Ethereum.getFirstWalletAddress();
     } catch (error) {
       logger.error(`Error getting first wallet address: ${error.message}`);
       return null;


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Switches to a static method for retrieving an example address. Allows tests which utilize app.ts to not have logs which are unrelated to the app.ts functionality. Personally I think this should be changed to just be a static value instead of having it be heuristic. 

**Tests performed by the developer**:
pnpm test. 


**Tips for QA testing**:
run pnpm test. 
