### PR TITLE
switch to husky as husky install is apparently deprecated.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "cli": "node dist/index.js",
     "typecheck": "tsc --noEmit",
     "rebuild-bigint": "cd node_modules/bigint-buffer && pnpm run rebuild",
-    "prepare": "husky install"
+    "prepare": "pnpm husky"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.29.0",


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
* husky install was giving a deprecation warning. 


**Tests performed by the developer**:
created a new worktree locally.

**Tips for QA testing**:
clone and run pnpm install
