### PR TITLE
Refactor/print width back down to 88

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,5 @@
   "semi": true,
   "singleQuote": true,
   "tabWidth": 2,
-  "printWidth": 120
+  "printWidth": 88
 }


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
I had recommended adjusting printWidth to 120 in https://github.com/hummingbot/gateway/pull/487 but now realizing that is causing too many unrelated changes due to autolinting. Recommend bumping down to 88 (still longer than 80) and slowly increasing if it feels necessary. 


**Tests performed by the developer**:
make a commit with a line length > 88. commit and prettier format to be less than 88


**Tips for QA testing**:

