### PR TITLE
feat: add Token2022 support and balance method migration

### DIFF
--- a/src/connectors/meteora/clmm-routes/addLiquidity.ts
+++ b/src/connectors/meteora/clmm-routes/addLiquidity.ts
@@ -72,7 +72,7 @@ async function addLiquidity(
   const tokenYSymbol = tokenY?.symbol || 'UNKNOWN';
 
   // Check balances with transaction buffer
-  const balances = await solana.getBalance(wallet, [tokenXSymbol, tokenYSymbol, 'SOL']);
+  const balances = await solana.getBalances(wallet.publicKey.toString(), [tokenXSymbol, tokenYSymbol, 'SOL']);
   const requiredBase = baseTokenAmount + (tokenXSymbol === 'SOL' ? SOL_TRANSACTION_BUFFER : 0);
   const requiredQuote = quoteTokenAmount + (tokenYSymbol === 'SOL' ? SOL_TRANSACTION_BUFFER : 0);
 

--- a/src/connectors/meteora/clmm-routes/openPosition.ts
+++ b/src/connectors/meteora/clmm-routes/openPosition.ts
@@ -75,7 +75,7 @@ async function openPosition(
   }
 
   // Check balances with SOL buffer
-  const balances = await solana.getBalance(wallet, [tokenXSymbol, tokenYSymbol, 'SOL']);
+  const balances = await solana.getBalances(wallet.publicKey.toString(), [tokenXSymbol, tokenYSymbol, 'SOL']);
   const requiredBaseAmount =
     (baseTokenAmount || 0) + (tokenXSymbol === 'SOL' ? SOL_POSITION_RENT + SOL_TRANSACTION_BUFFER : 0);
   const requiredQuoteAmount =

--- a/src/connectors/meteora/meteora.ts
+++ b/src/connectors/meteora/meteora.ts
@@ -134,8 +134,8 @@ export class Meteora {
       }
 
       const [reserveXBalance, reserveYBalance] = await Promise.all([
-        this.solana.connection.getTokenAccountBalance(dlmmPool.lbPair.reserveX),
-        this.solana.connection.getTokenAccountBalance(dlmmPool.lbPair.reserveY),
+        this.solana.getTokenAccountBalance(dlmmPool.lbPair.reserveX),
+        this.solana.getTokenAccountBalance(dlmmPool.lbPair.reserveY),
       ]);
       const feeInfo = await dlmmPool.getFeeInfo();
       const activeBin = await dlmmPool.getActiveBin();

--- a/src/connectors/raydium/amm-routes/positionInfo.ts
+++ b/src/connectors/raydium/amm-routes/positionInfo.ts
@@ -48,7 +48,7 @@ async function calculateLpAmount(
 
   // Get LP token balance
   const lpTokenAccount = lpTokenAccounts.value[0].pubkey;
-  const accountInfo = await solana.connection.getTokenAccountBalance(lpTokenAccount);
+  const accountInfo = await solana.getTokenAccountBalance(lpTokenAccount);
   const lpTokenAmount = accountInfo.value.uiAmount || 0;
 
   if (lpTokenAmount === 0) {

--- a/src/connectors/raydium/amm-routes/removeLiquidity.ts
+++ b/src/connectors/raydium/amm-routes/removeLiquidity.ts
@@ -126,7 +126,7 @@ async function calculateLpAmountToRemove(
 
   // Get LP token balance
   const lpTokenAccount = lpTokenAccounts.value[0].pubkey;
-  const accountInfo = await solana.connection.getTokenAccountBalance(lpTokenAccount);
+  const accountInfo = await solana.getTokenAccountBalance(lpTokenAccount);
   const lpBalance = new BN(new Decimal(accountInfo.value.uiAmount).mul(10 ** accountInfo.value.decimals).toFixed(0));
 
   if (lpBalance.isZero()) {

--- a/src/connectors/raydium/raydium.ts
+++ b/src/connectors/raydium/raydium.ts
@@ -167,8 +167,8 @@ export class Raydium {
         }
       }
 
-      const vaultABalance = (await this.solana.connection.getTokenAccountBalance(rawPool.vaultA)).value.uiAmount;
-      const vaultBBalance = (await this.solana.connection.getTokenAccountBalance(rawPool.vaultB)).value.uiAmount;
+      const vaultABalance = (await this.solana.getTokenAccountBalance(rawPool.vaultA)).value.uiAmount;
+      const vaultBBalance = (await this.solana.getTokenAccountBalance(rawPool.vaultB)).value.uiAmount;
 
       const poolInfo: ClmmPoolInfo = {
         address: poolAddress,


### PR DESCRIPTION
## Summary
- Fixed `TokenInvalidAccountOwnerError` when fetching pool info for Meteora pools with Token2022 reserve accounts
- Added unified `getTokenAccountBalance` method in Solana class to handle both Token and Token2022 programs
- Migrated Meteora connectors from deprecated `getBalance` to optimized `getBalances` method
- Updated all pool info methods (Meteora, Raydium CLMM, Raydium AMM) to use unified balance fetching
- Removed deprecated `getBalance` method to reduce code duplication

## Technical Details
### Root Cause
The error occurred because pool `2iUtrQHmMZjJoiRTXuxnwJCp4bg1FHwqpLnnoz534dBY` and other Token2022 pools have reserve accounts owned by `TOKEN_2022_PROGRAM_ID` instead of `TOKEN_PROGRAM_ID`. The standard `connection.getTokenAccountBalance()` only works with Token Program accounts.

### Solution
1. **Unified Token Account Balance Method**: Created `getTokenAccountBalance()` in Solana class that:
   - First tries standard `getTokenAccountBalance()`
   - On `TokenInvalidAccountOwnerError`, checks if account is Token2022
   - Falls back to parsing Token2022 accounts using `getParsedAccountInfo()`

2. **Updated Pool Info Methods**: 
   - Meteora: `meteora.ts:137-138`
   - Raydium CLMM: `raydium.ts:170-171`  
   - Raydium AMM: `amm-routes/removeLiquidity.ts:129`, `amm-routes/positionInfo.ts:51`

3. **Balance Method Migration**:
   - Migrated Meteora `addLiquidity.ts` and `openPosition.ts` from `getBalance(wallet, tokens)` to `getBalances(address, tokens)`
   - Removed deprecated 200+ line `getBalance` method

## Test plan
- [x] TypeScript compilation passes
- [x] Meteora pool info should now work for Token2022 pools like `2iUtrQHmMZjJoiRTXuxnwJCp4bg1FHwqpLnnoz534dBY`
- [x] Existing balance functionality maintained for both Token and Token2022
- [x] Meteora add/open position operations use optimized balance checking

🤖 Generated with [Claude Code](https://claude.ai/code)