### PR TITLE
feat: improve gas estimation with refactored parameters and better error handling

### DIFF
--- a/src/chains/ethereum/ethereum.config.ts
+++ b/src/chains/ethereum/ethereum.config.ts
@@ -6,9 +6,11 @@ export interface EthereumNetworkConfig {
   chainID: number;
   nodeURL: string;
   nativeCurrencySymbol: string;
-  minGasPrice?: number;
-  maxFeePerGas?: number;
-  maxPriorityFeePerGas?: number;
+  swapProvider?: string;
+  gasPrice?: number | null;
+  baseFee?: number | null;
+  priorityFee?: number | null;
+  baseFeeMultiplier?: number;
   infuraAPIKey?: string;
   useInfuraWebSocket?: boolean;
 }
@@ -29,9 +31,11 @@ export function getEthereumNetworkConfig(network: string): EthereumNetworkConfig
     chainID: ConfigManagerV2.getInstance().get(namespaceId + '.chainID'),
     nodeURL: ConfigManagerV2.getInstance().get(namespaceId + '.nodeURL'),
     nativeCurrencySymbol: ConfigManagerV2.getInstance().get(namespaceId + '.nativeCurrencySymbol'),
-    minGasPrice: ConfigManagerV2.getInstance().get(namespaceId + '.minGasPrice'),
-    maxFeePerGas: ConfigManagerV2.getInstance().get(namespaceId + '.maxFeePerGas'),
-    maxPriorityFeePerGas: ConfigManagerV2.getInstance().get(namespaceId + '.maxPriorityFeePerGas'),
+    swapProvider: ConfigManagerV2.getInstance().get(namespaceId + '.swapProvider'),
+    gasPrice: ConfigManagerV2.getInstance().get(namespaceId + '.gasPrice'),
+    baseFee: ConfigManagerV2.getInstance().get(namespaceId + '.baseFee'),
+    priorityFee: ConfigManagerV2.getInstance().get(namespaceId + '.priorityFee'),
+    baseFeeMultiplier: ConfigManagerV2.getInstance().get(namespaceId + '.baseFeeMultiplier'),
   };
 }
 

--- a/src/chains/ethereum/ethereum.ts
+++ b/src/chains/ethereum/ethereum.ts
@@ -35,20 +35,23 @@ export class Ethereum {
   public nativeTokenSymbol: string;
   public chainId: number;
   public rpcUrl: string;
-  public minGasPrice: number;
-  public maxFeePerGas?: number;
-  public maxPriorityFeePerGas?: number;
+  public gasPrice?: number | null;
+  public baseFee?: number | null;
+  public priorityFee?: number | null;
+  public baseFeeMultiplier: number;
   private _initialized: boolean = false;
   private infuraService?: InfuraService;
   private etherscanService?: EtherscanService;
 
   private static lastGasPriceEstimate: {
-    timestamp: number;
-    gasPrice: number;
-    maxFeePerGas?: number;
-    maxPriorityFeePerGas?: number;
-    isEIP1559?: boolean;
-  } | null = null;
+    [network: string]: {
+      timestamp: number;
+      gasPrice: number;
+      maxFeePerGas?: number;
+      maxPriorityFeePerGas?: number;
+      isEIP1559?: boolean;
+    };
+  } = {};
   private static GAS_PRICE_CACHE_MS = 10000; // 10 second cache
 
   // For backward compatibility
@@ -62,9 +65,10 @@ export class Ethereum {
     this.rpcUrl = config.nodeURL;
     this.network = network;
     this.nativeTokenSymbol = config.nativeCurrencySymbol;
-    this.minGasPrice = config.minGasPrice || 0.1; // Default to 0.1 GWEI if not specified
-    this.maxFeePerGas = config.maxFeePerGas;
-    this.maxPriorityFeePerGas = config.maxPriorityFeePerGas;
+    this.gasPrice = config.gasPrice;
+    this.baseFee = config.baseFee;
+    this.priorityFee = config.priorityFee;
+    this.baseFeeMultiplier = config.baseFeeMultiplier || 1.2; // Default to 1.2
 
     // Get chain config for etherscanAPIKey
     const chainConfig = getEthereumChainConfig();
@@ -131,12 +135,11 @@ export class Ethereum {
    * Returns the gas price in GWEI
    */
   public async estimateGasPrice(): Promise<number> {
-    // Check cache first
-    if (
-      Ethereum.lastGasPriceEstimate &&
-      Date.now() - Ethereum.lastGasPriceEstimate.timestamp < Ethereum.GAS_PRICE_CACHE_MS
-    ) {
-      return Ethereum.lastGasPriceEstimate.gasPrice;
+    // Check cache first (per-network)
+    const cachedEstimate = Ethereum.lastGasPriceEstimate[this.network];
+    if (cachedEstimate && Date.now() - cachedEstimate.timestamp < Ethereum.GAS_PRICE_CACHE_MS) {
+      logger.debug(`Using cached gas price for ${this.network}: ${cachedEstimate.gasPrice} GWEI`);
+      return cachedEstimate.gasPrice;
     }
 
     // Check if the network supports EIP-1559
@@ -149,22 +152,22 @@ export class Ethereum {
 
     if (supportsEIP1559) {
       try {
-        let maxFeePerGasGwei: number;
-        let maxPriorityFeePerGasGwei: number;
-        let networkMaxFeeGwei: number | undefined;
-        let networkPriorityFeeGwei: number | undefined;
+        let baseFeeGwei: number;
+        let priorityFeeGwei: number;
         let networkBaseFeeGwei: number | undefined;
+        let networkPriorityFeeGwei: number | undefined;
 
         // Try to fetch from Etherscan API first if available
         if (this.etherscanService) {
           try {
             const gasPrices = await this.etherscanService.getRecommendedGasPrices('propose');
-            networkMaxFeeGwei = gasPrices.maxFeePerGas;
-            networkPriorityFeeGwei = gasPrices.maxPriorityFeePerGas;
+            // Round to 4 decimal places to avoid floating-point precision issues
+            const networkMaxFeeGwei = Math.round(gasPrices.maxFeePerGas * 10000) / 10000;
+            networkPriorityFeeGwei = Math.round(gasPrices.maxPriorityFeePerGas * 10000) / 10000;
             // Estimate baseFee from the formula: baseFee ≈ (maxFee - priority) / 2
-            networkBaseFeeGwei = (networkMaxFeeGwei - networkPriorityFeeGwei) / 2;
+            networkBaseFeeGwei = Math.round(((networkMaxFeeGwei - networkPriorityFeeGwei) / 2) * 10000) / 10000;
             logger.info(
-              `Etherscan API EIP-1559 fees: baseFee≈${networkBaseFeeGwei.toFixed(4)} GWEI, maxFee=${networkMaxFeeGwei.toFixed(4)} GWEI, priority=${networkPriorityFeeGwei.toFixed(4)} GWEI`,
+              `Etherscan API EIP-1559 fees: baseFee≈${networkBaseFeeGwei.toFixed(4)} GWEI, priority=${networkPriorityFeeGwei.toFixed(4)} GWEI`,
             );
           } catch (scanError: any) {
             logger.warn(`Failed to fetch from Etherscan API: ${scanError.message}`);
@@ -173,25 +176,20 @@ export class Ethereum {
         }
 
         // Fallback to RPC provider if Etherscan not available or failed
-        if (networkMaxFeeGwei === undefined || networkPriorityFeeGwei === undefined) {
+        if (networkBaseFeeGwei === undefined || networkPriorityFeeGwei === undefined) {
           try {
             const feeData = await this.provider.getFeeData();
-            if (feeData.maxFeePerGas && feeData.maxPriorityFeePerGas) {
+            if (feeData.maxPriorityFeePerGas) {
               const block = await this.provider.getBlock('latest');
               const baseFee = block.baseFeePerGas || BigNumber.from('0');
 
-              // Calculate recommended maxFeePerGas as 2 * baseFee + maxPriorityFeePerGas
-              const recommendedMaxFee = baseFee.mul(2).add(feeData.maxPriorityFeePerGas);
-              const maxFeePerGas = feeData.maxFeePerGas.gt(recommendedMaxFee)
-                ? feeData.maxFeePerGas
-                : recommendedMaxFee;
-
-              networkBaseFeeGwei = parseFloat(utils.formatUnits(baseFee, 'gwei'));
-              networkMaxFeeGwei = parseFloat(utils.formatUnits(maxFeePerGas, 'gwei'));
-              networkPriorityFeeGwei = parseFloat(utils.formatUnits(feeData.maxPriorityFeePerGas, 'gwei'));
+              // Round to 4 decimal places to avoid floating-point precision issues
+              networkBaseFeeGwei = Math.round(parseFloat(utils.formatUnits(baseFee, 'gwei')) * 10000) / 10000;
+              networkPriorityFeeGwei =
+                Math.round(parseFloat(utils.formatUnits(feeData.maxPriorityFeePerGas, 'gwei')) * 10000) / 10000;
 
               logger.info(
-                `Network RPC EIP-1559 fees: baseFee=${networkBaseFeeGwei.toFixed(4)} GWEI, maxFee=${networkMaxFeeGwei.toFixed(4)} GWEI, priority=${networkPriorityFeeGwei.toFixed(4)} GWEI`,
+                `Network RPC EIP-1559 fees: baseFee=${networkBaseFeeGwei.toFixed(4)} GWEI, priority=${networkPriorityFeeGwei.toFixed(4)} GWEI`,
               );
             }
           } catch (networkError: any) {
@@ -199,35 +197,55 @@ export class Ethereum {
           }
         }
 
-        // Use configured values if available, otherwise use network values
-        if (this.maxFeePerGas !== undefined && this.maxPriorityFeePerGas !== undefined) {
-          maxFeePerGasGwei = this.maxFeePerGas;
-          maxPriorityFeePerGasGwei = this.maxPriorityFeePerGas;
-          logger.info(
-            `Using configured EIP-1559 fees: maxFee=${maxFeePerGasGwei} GWEI, priority=${maxPriorityFeePerGasGwei} GWEI`,
-          );
-        } else if (networkMaxFeeGwei !== undefined && networkPriorityFeeGwei !== undefined) {
-          // Use network values
-          maxFeePerGasGwei = networkMaxFeeGwei;
-          maxPriorityFeePerGasGwei = networkPriorityFeeGwei;
-          logger.info(
-            `Using network EIP-1559 fees: maxFee=${maxFeePerGasGwei.toFixed(4)} GWEI, priority=${maxPriorityFeePerGasGwei.toFixed(4)} GWEI`,
-          );
-        } else {
+        // Support partial configuration: use configured values if available, otherwise use network values
+        const hasConfiguredBaseFee = typeof this.baseFee === 'number';
+        const hasConfiguredPriority = typeof this.priorityFee === 'number';
+        const hasNetworkFees = networkBaseFeeGwei !== undefined && networkPriorityFeeGwei !== undefined;
+
+        if (!hasConfiguredBaseFee && !hasConfiguredPriority && !hasNetworkFees) {
           throw new Error('EIP-1559 fee data not available from network or config');
         }
 
-        // Apply minimum gas price
-        const minGasPrice = this.minGasPrice;
-        if (maxFeePerGasGwei < minGasPrice) {
-          logger.info(
-            `Using configured minimum gas price. Current maxFee: ${maxFeePerGasGwei} GWEI, Minimum: ${minGasPrice} GWEI`,
-          );
-          maxFeePerGasGwei = minGasPrice;
+        // Start with network values as defaults (if available)
+        baseFeeGwei = networkBaseFeeGwei ?? 0;
+        priorityFeeGwei = networkPriorityFeeGwei ?? 0;
+
+        // Override with configured values if present
+        if (hasConfiguredBaseFee) {
+          baseFeeGwei = this.baseFee!;
+        }
+        if (hasConfiguredPriority) {
+          priorityFeeGwei = this.priorityFee!;
         }
 
-        // Cache the result
-        Ethereum.lastGasPriceEstimate = {
+        // Log what was used
+        if (hasConfiguredBaseFee && hasConfiguredPriority) {
+          logger.info(`Using configured EIP-1559 fees: baseFee=${baseFeeGwei} GWEI, priority=${priorityFeeGwei} GWEI`);
+        } else if (hasConfiguredBaseFee) {
+          logger.info(
+            `Using mixed EIP-1559 fees: baseFee=${baseFeeGwei} GWEI (configured), priority=${priorityFeeGwei.toFixed(4)} GWEI (network)`,
+          );
+        } else if (hasConfiguredPriority) {
+          logger.info(
+            `Using mixed EIP-1559 fees: baseFee=${baseFeeGwei.toFixed(4)} GWEI (network), priority=${priorityFeeGwei} GWEI (configured)`,
+          );
+        } else {
+          logger.info(
+            `Using network EIP-1559 fees: baseFee=${baseFeeGwei.toFixed(4)} GWEI, priority=${priorityFeeGwei.toFixed(4)} GWEI`,
+          );
+        }
+
+        // Construct maxFeePerGas and maxPriorityFeePerGas from baseFee and priorityFee
+        // Formula: maxFeePerGas = (baseFee * baseFeeMultiplier) + priorityFee
+        const maxFeePerGasGwei = Math.round((baseFeeGwei * this.baseFeeMultiplier + priorityFeeGwei) * 10000) / 10000;
+        const maxPriorityFeePerGasGwei = priorityFeeGwei;
+
+        logger.info(
+          `Constructed tx fees (multiplier=${this.baseFeeMultiplier}): maxFeePerGas=${maxFeePerGasGwei.toFixed(4)} GWEI, maxPriorityFeePerGas=${maxPriorityFeePerGasGwei.toFixed(4)} GWEI`,
+        );
+
+        // Cache the result (per-network)
+        Ethereum.lastGasPriceEstimate[this.network] = {
           timestamp: Date.now(),
           gasPrice: maxFeePerGasGwei,
           maxFeePerGas: maxFeePerGasGwei,
@@ -244,47 +262,32 @@ export class Ethereum {
 
     // Legacy gas price estimation
     try {
-      const baseFee: BigNumber = await this.provider.getGasPrice();
-      let priorityFee: BigNumber = BigNumber.from('0');
-      // Only get priority fee for mainnet
-      if (this.network === 'mainnet') {
-        priorityFee = BigNumber.from(await this.provider.send('eth_maxPriorityFeePerGas', []));
-      }
+      let gasPriceGwei: number;
 
-      const baseWithPriority = baseFee.add(priorityFee);
-      const networkGasPriceGwei = baseWithPriority.toNumber() * 1e-9;
-
-      // Always log the network gas price
-      logger.info(`Network legacy gas price: ${networkGasPriceGwei.toFixed(4)} GWEI`);
-
-      // Apply minimum gas price for all networks
-      const minGasPriceWei = utils.parseUnits(this.minGasPrice.toString(), 'gwei');
-
-      // Use the larger of the current gas price or the configured minimum
-      const adjustedFee = baseWithPriority.lt(minGasPriceWei) ? minGasPriceWei : baseWithPriority;
-
-      if (baseWithPriority.lt(minGasPriceWei)) {
-        logger.info(
-          `Using configured minimum gas price: ${this.minGasPrice} GWEI (network: ${networkGasPriceGwei.toFixed(4)} GWEI)`,
-        );
+      // Check if configured gas price is available
+      if (typeof this.gasPrice === 'number') {
+        gasPriceGwei = this.gasPrice;
+        logger.info(`Using configured gas price: ${gasPriceGwei} GWEI`);
       } else {
-        logger.info(`Using network gas price: ${networkGasPriceGwei.toFixed(4)} GWEI`);
+        // Fetch from network
+        const networkGasPrice: BigNumber = await this.provider.getGasPrice();
+        gasPriceGwei = Math.round(parseFloat(utils.formatUnits(networkGasPrice, 'gwei')) * 10000) / 10000;
+        logger.info(`Using network gas price: ${gasPriceGwei.toFixed(4)} GWEI`);
       }
 
-      const totalFeeGwei = adjustedFee.toNumber() * 1e-9;
-      logger.info(`Estimated: ${totalFeeGwei} GWEI for network ${this.network}`);
+      logger.info(`Estimated: ${gasPriceGwei} GWEI for network ${this.network}`);
 
-      // Cache the result
-      Ethereum.lastGasPriceEstimate = {
+      // Cache the result (per-network)
+      Ethereum.lastGasPriceEstimate[this.network] = {
         timestamp: Date.now(),
-        gasPrice: totalFeeGwei,
+        gasPrice: gasPriceGwei,
         isEIP1559: false,
       };
 
-      return totalFeeGwei;
+      return gasPriceGwei;
     } catch (error: any) {
       logger.error(`Failed to estimate gas price: ${error.message}`);
-      return this.minGasPrice; // Return minimum gas price as fallback
+      throw error; // Throw error instead of returning fallback
     }
   }
 
@@ -310,29 +313,28 @@ export class Ethereum {
       this.network === 'base';
 
     if (supportsEIP1559) {
-      // Use cached EIP-1559 values from estimateGasPrice if available and gasPrice not explicitly provided
+      // Use cached EIP-1559 values from estimateGasPrice if available, not stale, and gasPrice not explicitly provided
+      const cachedEstimate = Ethereum.lastGasPriceEstimate[this.network];
       if (
         !gasPrice &&
-        Ethereum.lastGasPriceEstimate?.isEIP1559 &&
-        Ethereum.lastGasPriceEstimate?.maxFeePerGas !== undefined &&
-        Ethereum.lastGasPriceEstimate?.maxPriorityFeePerGas !== undefined
+        cachedEstimate?.isEIP1559 &&
+        cachedEstimate?.maxFeePerGas !== undefined &&
+        cachedEstimate?.maxPriorityFeePerGas !== undefined &&
+        Date.now() - cachedEstimate.timestamp < Ethereum.GAS_PRICE_CACHE_MS
       ) {
         gasOptions.type = 2;
-        gasOptions.maxFeePerGas = utils.parseUnits(Ethereum.lastGasPriceEstimate.maxFeePerGas.toString(), 'gwei');
-        gasOptions.maxPriorityFeePerGas = utils.parseUnits(
-          Ethereum.lastGasPriceEstimate.maxPriorityFeePerGas.toString(),
-          'gwei',
-        );
+        gasOptions.maxFeePerGas = utils.parseUnits(cachedEstimate.maxFeePerGas.toString(), 'gwei');
+        gasOptions.maxPriorityFeePerGas = utils.parseUnits(cachedEstimate.maxPriorityFeePerGas.toString(), 'gwei');
 
         logger.info(
-          `Using cached EIP-1559 pricing: maxFee=${Ethereum.lastGasPriceEstimate.maxFeePerGas} GWEI, priority=${Ethereum.lastGasPriceEstimate.maxPriorityFeePerGas} GWEI`,
+          `Using cached EIP-1559 pricing for ${this.network}: maxFee=${cachedEstimate.maxFeePerGas} GWEI, priority=${cachedEstimate.maxPriorityFeePerGas} GWEI`,
         );
         return gasOptions;
       }
 
-      // If gasPrice is provided, use it as maxFeePerGas with a default priority fee
+      // If gasPrice is provided, use it as maxFeePerGas with configured or default priority fee
       if (gasPrice) {
-        const priorityFee = this.maxPriorityFeePerGas || 0.01; // Default 0.01 GWEI priority fee
+        const priorityFee = (typeof this.priorityFee === 'number' ? this.priorityFee : null) || 0.001; // Default 0.001 GWEI priority fee
         gasOptions.type = 2;
         gasOptions.maxFeePerGas = utils.parseUnits(gasPrice.toString(), 'gwei');
         gasOptions.maxPriorityFeePerGas = utils.parseUnits(priorityFee.toString(), 'gwei');
@@ -347,21 +349,15 @@ export class Ethereum {
       logger.warn('No cached EIP-1559 data available, calling estimateGasPrice()');
       await this.estimateGasPrice();
 
-      // Try again with newly cached values
-      if (
-        Ethereum.lastGasPriceEstimate?.isEIP1559 &&
-        Ethereum.lastGasPriceEstimate?.maxFeePerGas !== undefined &&
-        Ethereum.lastGasPriceEstimate?.maxPriorityFeePerGas !== undefined
-      ) {
+      // Try again with newly cached values (per-network)
+      const newCache = Ethereum.lastGasPriceEstimate[this.network];
+      if (newCache?.isEIP1559 && newCache?.maxFeePerGas !== undefined && newCache?.maxPriorityFeePerGas !== undefined) {
         gasOptions.type = 2;
-        gasOptions.maxFeePerGas = utils.parseUnits(Ethereum.lastGasPriceEstimate.maxFeePerGas.toString(), 'gwei');
-        gasOptions.maxPriorityFeePerGas = utils.parseUnits(
-          Ethereum.lastGasPriceEstimate.maxPriorityFeePerGas.toString(),
-          'gwei',
-        );
+        gasOptions.maxFeePerGas = utils.parseUnits(newCache.maxFeePerGas.toString(), 'gwei');
+        gasOptions.maxPriorityFeePerGas = utils.parseUnits(newCache.maxPriorityFeePerGas.toString(), 'gwei');
 
         logger.info(
-          `Using newly fetched EIP-1559 pricing: maxFee=${Ethereum.lastGasPriceEstimate.maxFeePerGas} GWEI, priority=${Ethereum.lastGasPriceEstimate.maxPriorityFeePerGas} GWEI`,
+          `Using newly fetched EIP-1559 pricing for ${this.network}: maxFee=${newCache.maxFeePerGas} GWEI, priority=${newCache.maxPriorityFeePerGas} GWEI`,
         );
         return gasOptions;
       }

--- a/src/chains/ethereum/routes/estimate-gas.ts
+++ b/src/chains/ethereum/routes/estimate-gas.ts
@@ -52,34 +52,22 @@ export async function estimateGasEthereum(fastify: FastifyInstance, network: str
   } catch (error) {
     logger.error(`Error estimating gas for network ${network}: ${error.message}`);
 
-    try {
-      // If estimation fails but we can still get the instance, return the minGasPrice
-      const ethereum = await Ethereum.getInstance(network);
-
-      // Default gas limit for Ethereum is 300000
-      const DEFAULT_GAS_LIMIT = 300000;
-
-      // Calculate total fee in GWEI using minGasPrice
-      const totalFeeInGwei = ethereum.minGasPrice * DEFAULT_GAS_LIMIT;
-
-      // Convert GWEI to ETH (1 ETH = 10^9 GWEI)
-      const totalFeeInEth = totalFeeInGwei / 1e9;
-
-      return {
-        feePerComputeUnit: ethereum.minGasPrice,
-        denomination: 'gwei',
-        computeUnits: DEFAULT_GAS_LIMIT,
-        feeAsset: ethereum.nativeTokenSymbol,
-        fee: totalFeeInEth,
-        timestamp: Date.now(),
-        gasType: 'legacy',
-      };
-    } catch (instanceError) {
-      logger.error(`Error getting Ethereum instance for network ${network}: ${instanceError.message}`);
-      throw fastify.httpErrors.internalServerError(
-        `Failed to get Ethereum instance for network ${network}: ${instanceError.message}`,
-      );
+    // Check if it's a network/RPC error
+    if (error.message?.includes('RPC') || error.message?.includes('network') || error.message?.includes('provider')) {
+      throw fastify.httpErrors.serviceUnavailable(`RPC provider unavailable for network ${network}: ${error.message}`);
     }
+
+    // Check if it's an invalid network
+    if (
+      error.message?.includes('Invalid') ||
+      error.message?.includes('not found') ||
+      error.message?.includes('Unsupported')
+    ) {
+      throw fastify.httpErrors.badRequest(`Invalid network ${network}: ${error.message}`);
+    }
+
+    // Generic error
+    throw fastify.httpErrors.internalServerError(`Failed to estimate gas for network ${network}: ${error.message}`);
   }
 }
 

--- a/src/chains/solana/solana.ts
+++ b/src/chains/solana/solana.ts
@@ -998,7 +998,7 @@ export class Solana {
   }
 
   async estimateGasPrice(): Promise<number> {
-    return await SolanaPriorityFees.estimatePriorityFee(this.config);
+    return await SolanaPriorityFees.estimatePriorityFee(this.config, this.network);
   }
 
   public async confirmTransaction(

--- a/src/templates/chains/ethereum/arbitrum.yml
+++ b/src/templates/chains/ethereum/arbitrum.yml
@@ -1,9 +1,10 @@
 chainID: 42161
 nodeURL: https://arb1.arbitrum.io/rpc
 nativeCurrencySymbol: ETH
-minGasPrice: 0.01
+swapProvider: uniswap/router
 
 # EIP-1559 gas parameters (in GWEI)
 # If not set, will fetch from Etherscan API (if etherscanAPIKey is set in ethereum.yml) or network RPC
-maxFeePerGas: 0.01
-maxPriorityFeePerGas: 0.001
+baseFee:
+baseFeeMultiplier: 1.2
+priorityFee: 0.001

--- a/src/templates/chains/ethereum/avalanche.yml
+++ b/src/templates/chains/ethereum/avalanche.yml
@@ -1,4 +1,8 @@
 chainID: 43114
 nodeURL: https://api.avax.network/ext/bc/C/rpc
 nativeCurrencySymbol: AVAX
-minGasPrice: 0.1
+swapProvider: uniswap/router
+
+# Legacy gas price (in GWEI)
+# If not set, will fetch from network RPC
+gasPrice:

--- a/src/templates/chains/ethereum/base.yml
+++ b/src/templates/chains/ethereum/base.yml
@@ -1,9 +1,10 @@
 chainID: 8453
 nodeURL: https://mainnet.base.org
 nativeCurrencySymbol: ETH
-minGasPrice: 0.01
+swapProvider: uniswap/router
 
 # EIP-1559 gas parameters (in GWEI)
 # If not set, will fetch from Etherscan API (if etherscanAPIKey is set in ethereum.yml) or network RPC
-maxFeePerGas: 0.01
-maxPriorityFeePerGas: 0.01
+baseFee:
+baseFeeMultiplier: 1.2
+priorityFee: 0.001

--- a/src/templates/chains/ethereum/bsc.yml
+++ b/src/templates/chains/ethereum/bsc.yml
@@ -1,4 +1,8 @@
 chainID: 56
 nodeURL: https://binance.llamarpc.com
 nativeCurrencySymbol: BNB
-minGasPrice: 3
+swapProvider: pancakeswap/router
+
+# Legacy gas price (in GWEI)
+# If not set, will fetch from network RPC
+gasPrice:

--- a/src/templates/chains/ethereum/celo.yml
+++ b/src/templates/chains/ethereum/celo.yml
@@ -1,4 +1,8 @@
 chainID: 42220
 nodeURL: https://rpc.ankr.com/celo
 nativeCurrencySymbol: CELO
-minGasPrice: 0.1
+swapProvider: uniswap/router
+
+# Legacy gas price (in GWEI)
+# If not set, will fetch from network RPC
+gasPrice:

--- a/src/templates/chains/ethereum/mainnet.yml
+++ b/src/templates/chains/ethereum/mainnet.yml
@@ -1,9 +1,10 @@
 chainID: 1
 nodeURL: https://eth.llamarpc.com
 nativeCurrencySymbol: ETH
-minGasPrice: 0.1
+swapProvider: uniswap/router
 
 # EIP-1559 gas parameters (in GWEI)
 # If not set, will fetch from Etherscan API (if etherscanAPIKey is set in ethereum.yml) or network RPC
-# maxFeePerGas: 0.1
-# maxPriorityFeePerGas: 0.01
+baseFee:
+baseFeeMultiplier: 1.2
+priorityFee: 0.001

--- a/src/templates/chains/ethereum/optimism.yml
+++ b/src/templates/chains/ethereum/optimism.yml
@@ -1,9 +1,10 @@
 chainID: 10
 nodeURL: https://mainnet.optimism.io
 nativeCurrencySymbol: OETH
-minGasPrice: 0.01
+swapProvider: uniswap/router
 
 # EIP-1559 gas parameters (in GWEI)
 # If not set, will fetch from Etherscan API (if etherscanAPIKey is set in ethereum.yml) or network RPC
-maxFeePerGas: 0.01
-maxPriorityFeePerGas: 0.01
+baseFee:
+baseFeeMultiplier: 1.2
+priorityFee: 0.001

--- a/src/templates/chains/ethereum/polygon.yml
+++ b/src/templates/chains/ethereum/polygon.yml
@@ -1,9 +1,10 @@
 chainID: 137
 nodeURL: https://rpc.ankr.com/polygon
 nativeCurrencySymbol: POL
-minGasPrice: 10
+swapProvider: uniswap/router
 
 # EIP-1559 gas parameters (in GWEI)
 # If not set, will fetch from Etherscan API (if etherscanAPIKey is set in ethereum.yml) or network RPC
-# maxFeePerGas: 10
-# maxPriorityFeePerGas: 10
+baseFee:
+baseFeeMultiplier: 1.2
+priorityFee: 0.001

--- a/src/templates/chains/ethereum/sepolia.yml
+++ b/src/templates/chains/ethereum/sepolia.yml
@@ -1,4 +1,8 @@
 chainID: 11155111
-nodeURL: https://rpc.ankr.com/eth_sepolia 
+nodeURL: https://rpc.ankr.com/eth_sepolia
 nativeCurrencySymbol: ETH
-minGasPrice: 0.1
+swapProvider: uniswap/router
+
+# Legacy gas price (in GWEI)
+# If not set, will fetch from network RPC
+gasPrice:

--- a/src/templates/chains/solana/devnet.yml
+++ b/src/templates/chains/solana/devnet.yml
@@ -1,5 +1,6 @@
 nodeURL: https://api.devnet.solana.com
 nativeCurrencySymbol: SOL
+swapProvider: jupiter/router
 
 # Default compute units for a transaction
 # This sets the compute unit limit for transactions when not specified by the user

--- a/src/templates/chains/solana/mainnet-beta.yml
+++ b/src/templates/chains/solana/mainnet-beta.yml
@@ -1,5 +1,6 @@
 nodeURL: https://api.mainnet-beta.solana.com
 nativeCurrencySymbol: SOL
+swapProvider: jupiter/router
 
 # Default compute units for a transaction
 # This sets the compute unit limit for transactions when not specified by the user

--- a/src/templates/namespace/ethereum-network-schema.json
+++ b/src/templates/namespace/ethereum-network-schema.json
@@ -5,17 +5,27 @@
     "chainID": { "type": "integer" },
     "nodeURL": { "type": "string" },
     "nativeCurrencySymbol": { "type": "string" },
-    "minGasPrice": {
-      "type": "number",
-      "description": "Minimum gas price in GWEI"
+    "swapProvider": {
+      "type": "string",
+      "description": "Default swap router provider for this network (format: connector/type, e.g., uniswap/router)",
+      "default": "uniswap/router"
     },
-    "maxFeePerGas": {
-      "type": "number",
-      "description": "EIP-1559 maximum fee per gas in GWEI (optional, will fetch from network or Etherscan API if not set)"
+    "gasPrice": {
+      "type": ["number", "null"],
+      "description": "Gas price in GWEI for legacy (non-EIP-1559) networks (optional, will fetch from network RPC if not set)"
     },
-    "maxPriorityFeePerGas": {
+    "baseFee": {
+      "type": ["number", "null"],
+      "description": "EIP-1559 base fee in GWEI (optional, will fetch from network or Etherscan API if not set)"
+    },
+    "priorityFee": {
+      "type": ["number", "null"],
+      "description": "EIP-1559 priority fee in GWEI (optional, will fetch from network or Etherscan API if not set)"
+    },
+    "baseFeeMultiplier": {
       "type": "number",
-      "description": "EIP-1559 maximum priority fee per gas in GWEI (optional, will fetch from network or Etherscan API if not set)"
+      "description": "EIP-1559 base fee multiplier for maxFeePerGas calculation (default: 1.2)",
+      "default": 1.2
     }
   },
   "required": ["chainID", "nodeURL", "nativeCurrencySymbol"],

--- a/src/templates/namespace/solana-network-schema.json
+++ b/src/templates/namespace/solana-network-schema.json
@@ -4,6 +4,11 @@
   "properties": {
     "nodeURL": { "type": "string" },
     "nativeCurrencySymbol": { "type": "string" },
+    "swapProvider": {
+      "type": "string",
+      "description": "Default swap router provider for this network (format: connector/type, e.g., jupiter/router)",
+      "default": "jupiter/router"
+    },
     "defaultComputeUnits": { "type": "number" },
     "confirmRetryInterval": { "type": "number" },
     "confirmRetryCount": { "type": "number" },

--- a/test/chains/ethereum/infura-service.test.ts
+++ b/test/chains/ethereum/infura-service.test.ts
@@ -10,7 +10,6 @@ describe('InfuraService', () => {
       chainID: 1,
       nodeURL: 'https://eth.llamarpc.com',
       nativeCurrencySymbol: 'ETH',
-      minGasPrice: 0.1,
       infuraAPIKey: 'test-infura-key-123',
       useInfuraWebSocket: false,
     };


### PR DESCRIPTION
## Summary

This PR improves gas estimation across Ethereum and Solana chains with refactored configuration parameters, per-network caching, and enhanced error handling.

### Key Changes

#### 1. Gas Configuration Refactoring

**EIP-1559 Networks** (Ethereum Mainnet, Polygon, Arbitrum, Optimism, Base):
- ✅ Replace `maxFeePerGas` and `maxPriorityFeePerGas` with `baseFee` and `priorityFee`
- ✅ Add configurable `baseFeeMultiplier` parameter (default: 1.2 for 20% buffer)
- ✅ Transaction fee formula: `maxFeePerGas = baseFee * baseFeeMultiplier + priorityFee`
- ✅ Change default `priorityFee` from 0.01 to 0.001 GWEI
- ✅ Support partial configuration (can override individual parameters)
- ✅ Fetch from Etherscan API or network RPC when not configured

**Legacy Networks** (Avalanche, BSC, Celo, Sepolia):
- ✅ Rename `minGasPrice` to `gasPrice`
- ✅ Fetch from network RPC when not configured
- ✅ Remove hardcoded fallback values (throw clear errors instead)

#### 2. Per-Network Gas Caching

**Bug Fix**: Fixed cross-network cache contamination where Base network was returning Mainnet gas prices

- ✅ Change from single static cache to per-network map
- ✅ Each network maintains independent 10-second cache
- ✅ Applies to both Ethereum (`ethereum.ts`) and Solana (`solana-priority-fees.ts`)

#### 3. Enhanced Error Handling

Better HTTP status codes and error messages for gas estimation failures:

- **503 Service Unavailable**: RPC provider/network connectivity errors
- **400 Bad Request**: Invalid network configuration
- **500 Internal Server Error**: Generic failures

Error messages now include network context and specific failure reasons.

#### 4. Schema and Configuration Updates

- ✅ Update `ethereum-network-schema.json` with new gas parameters
- ✅ Update `solana-network-schema.json` for consistency
- ✅ Update all 9 Ethereum network templates (src/templates/chains/ethereum/)
- ✅ Update 2 Solana network templates (src/templates/chains/solana/)
- ✅ Add type unions `["number", "null"]` for optional numeric fields

### Files Changed

**Core Implementation** (5 files):
- `src/chains/ethereum/ethereum.config.ts` - Update interface with new gas parameters
- `src/chains/ethereum/ethereum.ts` - Refactor gas estimation logic, per-network cache
- `src/chains/ethereum/routes/estimate-gas.ts` - Enhanced error handling
- `src/chains/solana/solana-priority-fees.ts` - Per-network cache for Solana
- `src/chains/solana/solana.ts` - Pass network parameter to priority fee estimation

**Templates** (13 files):
- All Ethereum network configs (9 networks)
- All Solana network configs (2 networks)
- Network JSON schemas (2 files)

**Tests** (2 files):
- `test/chains/ethereum/routes/estimate-gas.test.ts` - Updated for new params and error handling
- `test/chains/ethereum/infura-service.test.ts` - Removed deprecated `minGasPrice`

## Test Plan

- ✅ All estimate-gas route tests passing (6 tests)
- ✅ All Infura service tests passing (10 tests)
- ✅ All Etherscan service tests passing (17 tests)
- ✅ All main Ethereum chain tests passing (12 tests)
- ✅ TypeScript compilation successful
- ✅ Linter checks passing

### Test Coverage

```bash
# Run estimate-gas tests
TMPDIR=/tmp GATEWAY_TEST_MODE=dev pnpm test test/chains/ethereum/routes/estimate-gas.test.ts

# Run Infura service tests
TMPDIR=/tmp GATEWAY_TEST_MODE=dev pnpm test test/chains/ethereum/infura-service.test.ts

# Run Etherscan service tests
TMPDIR=/tmp GATEWAY_TEST_MODE=dev pnpm test test/chains/ethereum/etherscan-service.test.ts
```

## Migration Notes

**Breaking Changes**: Gas parameter names have changed in network configuration files. Users will need to update their `conf/chains/ethereum/*.yml` and `conf/chains/solana/*.yml` files.

**Before** (EIP-1559):
```yaml
maxFeePerGas: 100
maxPriorityFeePerGas: 2
```

**After** (EIP-1559):
```yaml
baseFee:
baseFeeMultiplier: 1.2
priorityFee: 0.001
```

**Before** (Legacy):
```yaml
minGasPrice: 25
```

**After** (Legacy):
```yaml
gasPrice:
```

Leave values empty to fetch from network. The `baseFeeMultiplier` defaults to 1.2 if not specified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)