### PR TITLE
fix: meteora sdk failed at token2022 involved pool

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@ledgerhq/hw-app-solana": "^7.5.0",
     "@ledgerhq/hw-transport-node-hid": "^6.29.8",
     "@ledgerhq/hw-transport-node-hid-singleton": "^6.31.8",
-    "@meteora-ag/dlmm": "1.3.12",
+    "@meteora-ag/dlmm": "1.7.5",
     "@orca-so/common-sdk": "^0.6.11",
     "@pancakeswap/permit2-sdk": "^1.1.5",
     "@pancakeswap/sdk": "^5.8.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ importers:
         specifier: ^6.31.8
         version: 6.31.8
       '@meteora-ag/dlmm':
-        specifier: 1.3.12
-        version: 1.3.12(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+        specifier: 1.7.5
+        version: 1.7.5(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@orca-so/common-sdk':
         specifier: ^0.6.11
         version: 0.6.11(@solana/spl-token@0.4.8(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))
@@ -700,25 +700,29 @@ packages:
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
     engines: {node: '>=0.1.90'}
 
-  '@coral-xyz/anchor@0.28.0':
-    resolution: {integrity: sha512-kQ02Hv2ZqxtWP30WN1d4xxT4QqlOXYDxmEd3k/bbneqhV3X5QMO4LAtoUFs7otxyivOgoqam5Il5qx81FuI4vw==}
-    engines: {node: '>=11'}
+  '@coral-xyz/anchor-errors@0.31.1':
+    resolution: {integrity: sha512-NhNEku4F3zzUSBtrYz84FzYWm48+9OvmT1Hhnwr6GnPQry2dsEqH/ti/7ASjjpoFTWRnPXrjAIT1qM6Isop+LQ==}
+    engines: {node: '>=10'}
 
   '@coral-xyz/anchor@0.29.0':
     resolution: {integrity: sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA==}
     engines: {node: '>=11'}
 
-  '@coral-xyz/borsh@0.28.0':
-    resolution: {integrity: sha512-/u1VTzw7XooK7rqeD7JLUSwOyRSesPUk0U37BV9zK0axJc1q0nRbKFGFLYCQ16OtdOJTTwGfGp11Lx9B45bRCQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@solana/web3.js': ^1.68.0
+  '@coral-xyz/anchor@0.31.0':
+    resolution: {integrity: sha512-Yb1NwP1s4cWhAw7wL7vOLHSWWw3cD5D9pRCVSeJpdqPaI+w7sfRLScnVJL6ViYMZynB7nAG/5HcUPKUnY0L9rw==}
+    engines: {node: '>=17'}
 
   '@coral-xyz/borsh@0.29.0':
     resolution: {integrity: sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==}
     engines: {node: '>=10'}
     peerDependencies:
       '@solana/web3.js': ^1.68.0
+
+  '@coral-xyz/borsh@0.31.0':
+    resolution: {integrity: sha512-DwdQ5fuj+rGQCTKRnxnW1W2lvcpBaFc9m9M1TcGGlm+bwCcggmDgbLKLgF+LjIrKnc7Nd+bCACx5RA9YTK2I4Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@solana/web3.js': ^1.69.0
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1317,8 +1321,8 @@ packages:
   '@metaplex-foundation/mpl-token-metadata@2.13.0':
     resolution: {integrity: sha512-Fl/8I0L9rv4bKTV/RAl5YIbJe9SnQPInKvLz+xR1fEc4/VQkuCn3RPgypfUMEKWmCznzaw4sApDxy6CFS4qmJw==}
 
-  '@meteora-ag/dlmm@1.3.12':
-    resolution: {integrity: sha512-uoBjrl8yLVqKmpdcoC9Jj6Zg5mmo/2CeDEsWFrk6OiAoQ6g1+WBnr8lX/RWxXZ6r18YeP+QAKQbo1Tjf3HU0Cg==}
+  '@meteora-ag/dlmm@1.7.5':
+    resolution: {integrity: sha512-cXfEvAaInhuBwz4pKcMaJHMWbysEEApMTeYnL4kMD38e6YyOht6hfJme2cjaWXct5jAbVvA0AEoFZdjcC/nQhA==}
 
   '@napi-rs/wasm-runtime@0.2.11':
     resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==}
@@ -7468,28 +7472,7 @@ snapshots:
 
   '@colors/colors@1.6.0': {}
 
-  '@coral-xyz/anchor@0.28.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@coral-xyz/borsh': 0.28.0(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))
-      '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      base64-js: 1.5.1
-      bn.js: 5.2.1
-      bs58: 4.0.1
-      buffer-layout: 1.2.2
-      camelcase: 6.3.0
-      cross-fetch: 3.2.0(encoding@0.1.13)
-      crypto-hash: 1.3.0
-      eventemitter3: 4.0.7
-      js-sha256: 0.9.0
-      pako: 2.1.0
-      snake-case: 3.0.4
-      superstruct: 0.15.5
-      toml: 3.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
+  '@coral-xyz/anchor-errors@0.31.1': {}
 
   '@coral-xyz/anchor@0.29.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
@@ -7513,13 +7496,34 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@coral-xyz/borsh@0.28.0(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))':
+  '@coral-xyz/anchor@0.31.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@coral-xyz/anchor-errors': 0.31.1
+      '@coral-xyz/borsh': 0.31.0(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@noble/hashes': 1.8.0
+      '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      bn.js: 5.2.1
+      bs58: 4.0.1
+      buffer-layout: 1.2.2
+      camelcase: 6.3.0
+      cross-fetch: 3.2.0(encoding@0.1.13)
+      eventemitter3: 4.0.7
+      pako: 2.1.0
+      superstruct: 0.15.5
+      toml: 3.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
+  '@coral-xyz/borsh@0.29.0(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
       bn.js: 5.2.1
       buffer-layout: 1.2.2
 
-  '@coral-xyz/borsh@0.29.0(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))':
+  '@coral-xyz/borsh@0.31.0(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
       bn.js: 5.2.1
@@ -8663,10 +8667,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@meteora-ag/dlmm@1.3.12(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+  '@meteora-ag/dlmm@1.7.5(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@coral-xyz/anchor': 0.28.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@coral-xyz/borsh': 0.28.0(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@coral-xyz/anchor': 0.31.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@coral-xyz/borsh': 0.31.0(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))
       '@solana/buffer-layout': 4.0.1
       '@solana/spl-token': 0.4.8(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)

--- a/src/connectors/meteora/clmm-routes/addLiquidity.ts
+++ b/src/connectors/meteora/clmm-routes/addLiquidity.ts
@@ -94,8 +94,8 @@ async function addLiquidity(
   const maxBinId = position.positionData.upperBinId;
   const minBinId = position.positionData.lowerBinId;
 
-  const totalXAmount = new BN(DecimalUtil.toBN(new Decimal(baseTokenAmount), dlmmPool.tokenX.decimal));
-  const totalYAmount = new BN(DecimalUtil.toBN(new Decimal(quoteTokenAmount), dlmmPool.tokenY.decimal));
+  const totalXAmount = new BN(DecimalUtil.toBN(new Decimal(baseTokenAmount), dlmmPool.tokenX.mint.decimals));
+  const totalYAmount = new BN(DecimalUtil.toBN(new Decimal(quoteTokenAmount), dlmmPool.tokenY.mint.decimals));
 
   const addLiquidityTx = await dlmmPool.addLiquidityByStrategy({
     positionPubKey: new PublicKey(position.publicKey),

--- a/src/connectors/meteora/clmm-routes/quotePosition.ts
+++ b/src/connectors/meteora/clmm-routes/quotePosition.ts
@@ -39,7 +39,7 @@ export async function quotePosition(
     const strategy = {
       minBinId: Math.min(lowerBinId, upperBinId),
       maxBinId: Math.max(lowerBinId, upperBinId),
-      strategyType: strategyType ?? StrategyType.SpotBalanced,
+      strategyType: strategyType ?? StrategyType.Spot,
     };
 
     // Quote the position creation to get cost estimates

--- a/src/connectors/meteora/meteora.ts
+++ b/src/connectors/meteora/meteora.ts
@@ -177,8 +177,8 @@ export class Meteora {
     return binData.bins.map((bin) => ({
       binId: bin.binId,
       price: Number(bin.pricePerToken),
-      baseTokenAmount: Number(convertDecimals(bin.xAmount, dlmmPool.tokenX.decimal)),
-      quoteTokenAmount: Number(convertDecimals(bin.yAmount, dlmmPool.tokenY.decimal)),
+      baseTokenAmount: Number(convertDecimals(bin.xAmount, dlmmPool.tokenX.mint.decimals)),
+      quoteTokenAmount: Number(convertDecimals(bin.yAmount, dlmmPool.tokenY.mint.decimals)),
     }));
   }
 
@@ -202,7 +202,7 @@ export class Meteora {
       const upperPrice = getPriceOfBinByBinId(positionData.upperBinId, dlmmPool.lbPair.binStep);
 
       // Adjust for decimal difference (tokenX.decimal - tokenY.decimal)
-      const decimalDiff = dlmmPool.tokenX.decimal - dlmmPool.tokenY.decimal; // 9 - 6 = 3
+      const decimalDiff = dlmmPool.tokenX.mint.decimals - dlmmPool.tokenY.mint.decimals; // 9 - 6 = 3
       const adjustmentFactor = Math.pow(10, decimalDiff);
 
       const adjustedLowerPrice = Number(lowerPrice) * adjustmentFactor;
@@ -213,10 +213,10 @@ export class Meteora {
         poolAddress,
         baseTokenAddress: dlmmPool.tokenX.publicKey.toBase58(),
         quoteTokenAddress: dlmmPool.tokenY.publicKey.toBase58(),
-        baseTokenAmount: Number(convertDecimals(positionData.totalXAmount, dlmmPool.tokenX.decimal)),
-        quoteTokenAmount: Number(convertDecimals(positionData.totalYAmount, dlmmPool.tokenY.decimal)),
-        baseFeeAmount: Number(convertDecimals(positionData.feeX, dlmmPool.tokenX.decimal)),
-        quoteFeeAmount: Number(convertDecimals(positionData.feeY, dlmmPool.tokenY.decimal)),
+        baseTokenAmount: Number(convertDecimals(positionData.totalXAmount, dlmmPool.tokenX.mint.decimals)),
+        quoteTokenAmount: Number(convertDecimals(positionData.totalYAmount, dlmmPool.tokenY.mint.decimals)),
+        baseFeeAmount: Number(convertDecimals(positionData.feeX, dlmmPool.tokenX.mint.decimals)),
+        quoteFeeAmount: Number(convertDecimals(positionData.feeY, dlmmPool.tokenY.mint.decimals)),
         lowerBinId: positionData.lowerBinId,
         upperBinId: positionData.upperBinId,
         lowerPrice: adjustedLowerPrice,
@@ -266,7 +266,7 @@ export class Meteora {
     const upperPrice = getPriceOfBinByBinId(position.positionData.upperBinId, dlmmPool.lbPair.binStep);
 
     // Adjust for decimal difference (tokenX.decimal - tokenY.decimal)
-    const decimalDiff = dlmmPool.tokenX.decimal - dlmmPool.tokenY.decimal;
+    const decimalDiff = dlmmPool.tokenX.mint.decimals - dlmmPool.tokenY.mint.decimals;
     const adjustmentFactor = Math.pow(10, decimalDiff);
 
     const adjustedLowerPrice = Number(lowerPrice) * adjustmentFactor;
@@ -277,10 +277,10 @@ export class Meteora {
       poolAddress: info.publicKey.toString(),
       baseTokenAddress: dlmmPool.tokenX.publicKey.toBase58(),
       quoteTokenAddress: dlmmPool.tokenY.publicKey.toBase58(),
-      baseTokenAmount: Number(convertDecimals(position.positionData.totalXAmount, dlmmPool.tokenX.decimal)),
-      quoteTokenAmount: Number(convertDecimals(position.positionData.totalYAmount, dlmmPool.tokenY.decimal)),
-      baseFeeAmount: Number(convertDecimals(position.positionData.feeX, dlmmPool.tokenX.decimal)),
-      quoteFeeAmount: Number(convertDecimals(position.positionData.feeY, dlmmPool.tokenY.decimal)),
+      baseTokenAmount: Number(convertDecimals(position.positionData.totalXAmount, dlmmPool.tokenX.mint.decimals)),
+      quoteTokenAmount: Number(convertDecimals(position.positionData.totalYAmount, dlmmPool.tokenY.mint.decimals)),
+      baseFeeAmount: Number(convertDecimals(position.positionData.feeX, dlmmPool.tokenX.mint.decimals)),
+      quoteFeeAmount: Number(convertDecimals(position.positionData.feeY, dlmmPool.tokenY.mint.decimals)),
       lowerBinId: position.positionData.lowerBinId,
       upperBinId: position.positionData.upperBinId,
       lowerPrice: adjustedLowerPrice,

--- a/src/connectors/meteora/schemas.ts
+++ b/src/connectors/meteora/schemas.ts
@@ -225,7 +225,7 @@ export const MeteoraClmmOpenPositionRequest = Type.Object({
   strategyType: Type.Optional(
     Type.Number({
       description: 'Strategy type for the position',
-      examples: [StrategyType.SpotImBalanced],
+      examples: [StrategyType.Spot],
       enum: Object.values(StrategyType).filter((x) => typeof x === 'number'),
     }),
   ),
@@ -275,7 +275,7 @@ export const MeteoraClmmAddLiquidityRequest = Type.Object({
   strategyType: Type.Optional(
     Type.Number({
       description: 'Strategy type for the position',
-      examples: [StrategyType.SpotImBalanced],
+      examples: [StrategyType.Spot],
       enum: Object.values(StrategyType).filter((x) => typeof x === 'number'),
     }),
   ),
@@ -491,7 +491,7 @@ export const MeteoraClmmQuotePositionRequest = Type.Object({
   strategyType: Type.Optional(
     Type.Number({
       description: 'Strategy type for the position',
-      examples: [StrategyType.SpotImBalanced],
+      examples: [StrategyType.Spot],
       enum: Object.values(StrategyType).filter((x) => typeof x === 'number'),
     }),
   ),


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

- Fix `meteora/clmm/pool-info` failed with token 2022 pool. See https://github.com/hummingbot/gateway/issues/519. The issue occurred because the older version of the DLMM SDK did not support Token-2022.

**Tests performed by the developer**:



**Tips for QA testing**:

