### PR TITLE
fix(solana): handle Helius mixed parsed/base64 responses and Meteora position width errors

### DIFF
--- a/src/connectors/meteora/clmm-routes/openPosition.ts
+++ b/src/connectors/meteora/clmm-routes/openPosition.ts
@@ -74,24 +74,8 @@ export async function openPosition(
     throw fastify.httpErrors.badRequest(MISSING_AMOUNTS_MESSAGE);
   }
 
-  // Check balances with SOL buffer
-  const balances = await solana.getBalance(wallet, [tokenXSymbol, tokenYSymbol, 'SOL']);
-  const requiredBaseAmount =
-    (baseTokenAmount || 0) + (tokenXSymbol === 'SOL' ? SOL_POSITION_RENT + SOL_TRANSACTION_BUFFER : 0);
-  const requiredQuoteAmount =
-    (quoteTokenAmount || 0) + (tokenYSymbol === 'SOL' ? SOL_POSITION_RENT + SOL_TRANSACTION_BUFFER : 0);
-
-  if (balances[tokenXSymbol] < requiredBaseAmount) {
-    throw fastify.httpErrors.badRequest(
-      INSUFFICIENT_BALANCE_MESSAGE(tokenXSymbol, requiredBaseAmount.toString(), balances[tokenXSymbol].toString()),
-    );
-  }
-
-  if (tokenYSymbol && balances[tokenYSymbol] < requiredQuoteAmount) {
-    throw fastify.httpErrors.badRequest(
-      `Insufficient ${tokenYSymbol} balance. Required: ${requiredQuoteAmount}, Available: ${balances[tokenYSymbol]}`,
-    );
-  }
+  // Note: Balance validation removed - insufficient balance will be caught during transaction execution
+  // This avoids issues with the deprecated getBalance() method and aligns with PancakeSwap-Sol behavior
 
   // Get current pool price from active bin
   const activeBin = await dlmmPool.getActiveBin();
@@ -268,9 +252,9 @@ export const openPositionRoute: FastifyPluginAsync = async (fastify) => {
       } catch (e) {
         logger.error(e);
         if (e.statusCode) {
-          throw fastify.httpErrors.createError(e.statusCode, 'Request failed');
+          throw fastify.httpErrors.createError(e.statusCode, e.message || 'Request failed');
         }
-        throw fastify.httpErrors.internalServerError('Internal server error');
+        throw fastify.httpErrors.internalServerError(e.message || 'Internal server error');
       }
     },
   );


### PR DESCRIPTION
## Summary
This PR fixes two critical issues with Solana token account handling and Meteora position creation:

1. **StructError from Helius mixed responses** - When Helius RPC returns token accounts with mixed parsed/base64 data, the Solana web3.js library throws a StructError during validation
2. **Meteora InvalidPositionWidth error handling** - Position width constraint violations now return clear error messages to users

## Changes

### Helius Mixed Response Handling
- Added `fetchTokenAccountsBase64()` fallback method that uses base64 encoding exclusively
- Updated `fetchTokenAccounts()` to catch StructError and fall back to base64 encoding
- Updated deprecated `getBalance()` method to handle mixed responses
- Ensures compatibility with Helius RPC's occasional base64 fallback for unparseable token accounts

### Meteora Position Width Error Handling  
- Added specific error handler for InvalidPositionWidth (error code 6040/0x1798)
- Returns clear message: "Error Code: InvalidPositionWidth. Error Number: 6040. Error Message: Invalid position width. Please use a position width of 69 bins or lower."
- Fixed Meteora openPosition route to preserve actual error messages instead of generic "Request failed"

### Code Quality Improvements
- Removed balance validation from Meteora openPosition to align with PancakeSwap-Sol behavior
- Balance checks now happen at transaction execution time (cleaner approach)
- Avoids deprecated `getBalance()` method in connector code

## Test Plan
- [x] Tested Meteora position opening with valid narrow range (120-170) - succeeds
- [x] Tested Meteora position opening with invalid wide range (100-200) - returns proper error message
- [x] Verified quote-position endpoint still works correctly
- [x] Confirmed StructError no longer occurs with Helius RPC

🤖 Generated with [Claude Code](https://claude.com/claude-code)