### PR TITLE
feat: add Solana signer abstraction layer

### DIFF
--- a/src/chains/solana/signers/factory.ts
+++ b/src/chains/solana/signers/factory.ts
@@ -1,0 +1,181 @@
+import { Keypair, PublicKey } from '@solana/web3.js';
+import bs58 from 'bs58';
+import * as fse from 'fs-extra';
+
+import { ConfigManagerCertPassphrase } from '../../../services/config-manager-cert-passphrase';
+import { logger } from '../../../services/logger';
+import { getHardwareWalletByAddress, isHardwareWallet, getSafeWalletFilePath } from '../../../wallet/utils';
+
+import { KeypairSigner } from './keypair-signer';
+import { LedgerSigner } from './ledger-signer';
+import { SolanaSigner, SignerError, SignerErrorCode, SignerType, WalletInfo } from './types';
+
+/**
+ * Factory for creating Solana signers
+ *
+ * This factory automatically detects the wallet type and creates the appropriate signer.
+ * It provides a unified interface for getting signers regardless of the underlying implementation.
+ */
+export class SignerFactory {
+  private static decryptCache: Map<string, Keypair> = new Map();
+
+  /**
+   * Get a signer for the given address
+   * Automatically detects the wallet type (keypair, hardware, etc.)
+   */
+  static async getSigner(address: string): Promise<SolanaSigner> {
+    // Validate address format
+    try {
+      new PublicKey(address);
+    } catch {
+      throw new SignerError(SignerErrorCode.INVALID_PUBLIC_KEY, `Invalid Solana address: ${address}`);
+    }
+
+    // Check if it's a hardware wallet
+    const hardwareWallet = await getHardwareWalletByAddress('solana', address);
+    if (hardwareWallet) {
+      logger.debug(`[SignerFactory] Creating LedgerSigner for ${address}`);
+      return new LedgerSigner(address, hardwareWallet.derivationPath);
+    }
+
+    // Check if it's a regular keypair wallet
+    const keypair = await SignerFactory.loadKeypair(address);
+    if (keypair) {
+      logger.debug(`[SignerFactory] Creating KeypairSigner for ${address}`);
+      return new KeypairSigner(keypair);
+    }
+
+    throw new SignerError(SignerErrorCode.NOT_AVAILABLE, `No wallet found for address: ${address}`);
+  }
+
+  /**
+   * Get wallet info for an address (type, derivation path, etc.)
+   */
+  static async getWalletInfo(address: string): Promise<WalletInfo> {
+    // Check hardware wallet first
+    const hardwareWallet = await getHardwareWalletByAddress('solana', address);
+    if (hardwareWallet) {
+      return {
+        type: 'ledger',
+        address,
+        derivationPath: hardwareWallet.derivationPath,
+      };
+    }
+
+    // Check regular wallet
+    const walletPath = getSafeWalletFilePath('solana', address);
+    const exists = await fse.pathExists(walletPath);
+    if (exists) {
+      return {
+        type: 'keypair',
+        address,
+      };
+    }
+
+    throw new SignerError(SignerErrorCode.NOT_AVAILABLE, `No wallet found for address: ${address}`);
+  }
+
+  /**
+   * Get the signer type for an address
+   */
+  static async getSignerType(address: string): Promise<SignerType> {
+    if (await isHardwareWallet('solana', address)) {
+      return 'ledger';
+    }
+
+    const walletPath = getSafeWalletFilePath('solana', address);
+    const exists = await fse.pathExists(walletPath);
+    if (exists) {
+      return 'keypair';
+    }
+
+    throw new SignerError(SignerErrorCode.NOT_AVAILABLE, `No wallet found for address: ${address}`);
+  }
+
+  /**
+   * Check if an address has a wallet configured
+   */
+  static async hasWallet(address: string): Promise<boolean> {
+    try {
+      await SignerFactory.getSignerType(address);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Load a keypair from the encrypted wallet file
+   */
+  private static async loadKeypair(address: string): Promise<Keypair | null> {
+    try {
+      // Check cache first
+      if (SignerFactory.decryptCache.has(address)) {
+        return SignerFactory.decryptCache.get(address)!;
+      }
+
+      const walletPath = getSafeWalletFilePath('solana', address);
+
+      // Check if file exists
+      const exists = await fse.pathExists(walletPath);
+      if (!exists) {
+        return null;
+      }
+
+      // Read encrypted wallet
+      const encryptedPrivateKey = await fse.readFile(walletPath, 'utf8');
+
+      // Get passphrase
+      const passphrase = ConfigManagerCertPassphrase.readPassphrase();
+      if (!passphrase) {
+        throw new SignerError(SignerErrorCode.CONFIG_ERROR, 'Missing passphrase for wallet decryption');
+      }
+
+      // Decrypt (we need to use Solana's decrypt method)
+      // For now, we'll use a simplified approach - import the decrypt logic
+      const decrypted = await SignerFactory.decrypt(encryptedPrivateKey, passphrase);
+      const keypair = Keypair.fromSecretKey(new Uint8Array(bs58.decode(decrypted)));
+
+      // Cache the decrypted keypair
+      SignerFactory.decryptCache.set(address, keypair);
+
+      return keypair;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Decrypt an encrypted private key
+   * This mirrors the Solana.decrypt method
+   */
+  private static async decrypt(encryptedStr: string, password: string): Promise<string> {
+    const crypto = await import('crypto');
+
+    const encrypted = JSON.parse(encryptedStr);
+    const salt = Buffer.from(encrypted.salt, 'hex');
+    const iv = Buffer.from(encrypted.iv, 'hex');
+    const content = Buffer.from(encrypted.content, 'hex');
+
+    const key = crypto.pbkdf2Sync(password, new Uint8Array(salt), 5000, 32, 'sha512');
+
+    const decipher = crypto.createDecipheriv('aes-256-ctr', new Uint8Array(key), new Uint8Array(iv));
+
+    const decrypted = Buffer.concat([
+      new Uint8Array(decipher.update(new Uint8Array(content))),
+      new Uint8Array(decipher.final()),
+    ]);
+
+    return decrypted.toString();
+  }
+
+  /**
+   * Clear the keypair cache (useful for testing or when passphrase changes)
+   */
+  static clearCache(): void {
+    SignerFactory.decryptCache.clear();
+  }
+}

--- a/src/chains/solana/signers/index.ts
+++ b/src/chains/solana/signers/index.ts
@@ -5,13 +5,17 @@ export {
   SignerConfig,
   SignerError,
   SignerErrorCode,
+  SignerErrorContext,
   SignatureResult,
   WalletInfo,
 } from './types';
+
+// Utility functions (matches keychain-core patterns)
+export { createSignerError, throwSignerError, isSolanaSigner, assertIsSolanaSigner } from './types';
 
 // Signer implementations
 export { KeypairSigner } from './keypair-signer';
 export { LedgerSigner } from './ledger-signer';
 
-// Factory (to be added)
+// Factory
 export { SignerFactory } from './factory';

--- a/src/chains/solana/signers/index.ts
+++ b/src/chains/solana/signers/index.ts
@@ -1,0 +1,17 @@
+// Types and interfaces
+export {
+  SolanaSigner,
+  SignerType,
+  SignerConfig,
+  SignerError,
+  SignerErrorCode,
+  SignatureResult,
+  WalletInfo,
+} from './types';
+
+// Signer implementations
+export { KeypairSigner } from './keypair-signer';
+export { LedgerSigner } from './ledger-signer';
+
+// Factory (to be added)
+export { SignerFactory } from './factory';

--- a/src/chains/solana/signers/keypair-signer.ts
+++ b/src/chains/solana/signers/keypair-signer.ts
@@ -1,0 +1,145 @@
+import { Keypair, PublicKey, Transaction, VersionedTransaction } from '@solana/web3.js';
+import bs58 from 'bs58';
+
+import { logger } from '../../../services/logger';
+
+import { SolanaSigner, SignerError, SignerErrorCode, SignatureResult } from './types';
+
+/**
+ * Signer implementation for Solana Keypair-based wallets (hot wallets)
+ *
+ * This wraps the standard Solana Keypair for signing transactions.
+ * The keypair is typically loaded from an encrypted wallet file.
+ */
+export class KeypairSigner implements SolanaSigner {
+  readonly type = 'keypair' as const;
+  readonly address: string;
+
+  private readonly keypair: Keypair;
+
+  constructor(keypair: Keypair) {
+    this.keypair = keypair;
+    this.address = keypair.publicKey.toBase58();
+  }
+
+  /**
+   * Create a KeypairSigner from a base58-encoded private key
+   */
+  static fromPrivateKey(privateKeyBase58: string): KeypairSigner {
+    try {
+      const secretKey = new Uint8Array(bs58.decode(privateKeyBase58));
+      const keypair = Keypair.fromSecretKey(secretKey);
+      return new KeypairSigner(keypair);
+    } catch (error) {
+      throw new SignerError(
+        SignerErrorCode.INVALID_PRIVATE_KEY,
+        'Failed to create keypair from private key',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Create a KeypairSigner from a secret key (Uint8Array)
+   */
+  static fromSecretKey(secretKey: Uint8Array): KeypairSigner {
+    try {
+      const keypair = Keypair.fromSecretKey(secretKey);
+      return new KeypairSigner(keypair);
+    } catch (error) {
+      throw new SignerError(
+        SignerErrorCode.INVALID_PRIVATE_KEY,
+        'Failed to create keypair from secret key',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Keypair signers are always available (the key is in memory)
+   */
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  /**
+   * Get the public key
+   */
+  getPublicKey(): PublicKey {
+    return this.keypair.publicKey;
+  }
+
+  /**
+   * Sign transactions using the keypair
+   */
+  async signTransactions<T extends Transaction | VersionedTransaction>(transactions: T[]): Promise<T[]> {
+    logger.debug(`[KeypairSigner] Signing ${transactions.length} transaction(s) for ${this.address}`);
+
+    try {
+      for (const tx of transactions) {
+        if (tx instanceof VersionedTransaction) {
+          tx.sign([this.keypair]);
+        } else {
+          (tx as Transaction).sign(this.keypair);
+        }
+      }
+
+      logger.debug(`[KeypairSigner] Successfully signed ${transactions.length} transaction(s)`);
+      return transactions;
+    } catch (error) {
+      logger.error(`[KeypairSigner] Failed to sign transactions: ${(error as Error).message}`);
+      throw new SignerError(SignerErrorCode.SIGNING_FAILED, 'Failed to sign transactions', error as Error);
+    }
+  }
+
+  /**
+   * Sign arbitrary messages using Ed25519
+   * Uses Node.js crypto module for Ed25519 signing
+   */
+  async signMessages(messages: Uint8Array[]): Promise<SignatureResult[]> {
+    logger.debug(`[KeypairSigner] Signing ${messages.length} message(s) for ${this.address}`);
+
+    try {
+      const crypto = await import('crypto');
+      const results: SignatureResult[] = [];
+
+      for (const message of messages) {
+        // Create Ed25519 private key from the keypair's secret key
+        // The secret key is 64 bytes: first 32 are the seed, last 32 are the public key
+        const derPrefix = new Uint8Array(Buffer.from('302e020100300506032b657004220420', 'hex'));
+        const seed = new Uint8Array(this.keypair.secretKey.slice(0, 32));
+        const privateKeyDer = new Uint8Array(derPrefix.length + seed.length);
+        privateKeyDer.set(derPrefix);
+        privateKeyDer.set(seed, derPrefix.length);
+
+        const privateKey = crypto.createPrivateKey({
+          key: Buffer.from(privateKeyDer),
+          format: 'der',
+          type: 'pkcs8',
+        });
+
+        const signatureBuffer = crypto.sign(null, new Uint8Array(message), privateKey);
+        const signatureBytes = new Uint8Array(signatureBuffer);
+
+        results.push({
+          signature: bs58.encode(signatureBytes),
+          signatureBytes,
+        });
+      }
+
+      logger.debug(`[KeypairSigner] Successfully signed ${messages.length} message(s)`);
+      return results;
+    } catch (error) {
+      logger.error(`[KeypairSigner] Failed to sign messages: ${(error as Error).message}`);
+      throw new SignerError(SignerErrorCode.SIGNING_FAILED, 'Failed to sign messages', error as Error);
+    }
+  }
+
+  /**
+   * Get the underlying keypair (for compatibility with existing code)
+   * @deprecated Use signTransactions instead
+   */
+  getKeypair(): Keypair {
+    return this.keypair;
+  }
+}

--- a/src/chains/solana/signers/ledger-signer.ts
+++ b/src/chains/solana/signers/ledger-signer.ts
@@ -1,0 +1,134 @@
+import { PublicKey, Transaction, VersionedTransaction } from '@solana/web3.js';
+
+import { HardwareWalletService } from '../../../services/hardware-wallet-service';
+import { logger } from '../../../services/logger';
+
+import { SolanaSigner, SignerError, SignerErrorCode } from './types';
+
+/**
+ * Signer implementation for Ledger hardware wallets
+ *
+ * This wraps the existing HardwareWalletService for Ledger device communication.
+ * Transactions are built locally and sent to the Ledger for signing.
+ */
+export class LedgerSigner implements SolanaSigner {
+  readonly type = 'ledger' as const;
+  readonly address: string;
+
+  private readonly publicKey: PublicKey;
+  private readonly derivationPath: string;
+  private readonly hardwareWalletService: HardwareWalletService;
+
+  constructor(address: string, derivationPath: string) {
+    this.address = address;
+    this.publicKey = new PublicKey(address);
+    this.derivationPath = derivationPath;
+    this.hardwareWalletService = HardwareWalletService.getInstance();
+  }
+
+  /**
+   * Check if the Ledger device is connected and available
+   */
+  async isAvailable(): Promise<boolean> {
+    try {
+      // Try to get the app info to check if device is connected
+      const isConnected = await this.hardwareWalletService.isDeviceConnected();
+      return isConnected;
+    } catch (error) {
+      logger.warn(`[LedgerSigner] Device availability check failed: ${(error as Error).message}`);
+      return false;
+    }
+  }
+
+  /**
+   * Get the public key
+   */
+  getPublicKey(): PublicKey {
+    return this.publicKey;
+  }
+
+  /**
+   * Sign transactions using the Ledger device
+   */
+  async signTransactions<T extends Transaction | VersionedTransaction>(transactions: T[]): Promise<T[]> {
+    logger.info(`[LedgerSigner] Signing ${transactions.length} transaction(s) for ${this.address}`);
+
+    try {
+      for (const tx of transactions) {
+        await this.signSingleTransaction(tx);
+      }
+
+      logger.info(`[LedgerSigner] Successfully signed ${transactions.length} transaction(s)`);
+      return transactions;
+    } catch (error) {
+      const err = error as Error;
+      logger.error(`[LedgerSigner] Failed to sign transactions: ${err.message}`);
+
+      // Map specific error messages to SignerErrorCode
+      if (err.message.includes('rejected by user') || err.message.includes('denied')) {
+        throw new SignerError(SignerErrorCode.USER_REJECTED, 'Transaction rejected on Ledger device', err);
+      } else if (err.message.includes('Timeout') || err.message.includes('timeout')) {
+        throw new SignerError(SignerErrorCode.TIMEOUT, 'Transaction signing timed out', err);
+      } else if (err.message.includes('locked') || err.message.includes('Locked')) {
+        throw new SignerError(SignerErrorCode.DEVICE_LOCKED, 'Ledger device is locked', err);
+      } else if (err.message.includes('not found') || err.message.includes('disconnected')) {
+        throw new SignerError(SignerErrorCode.NOT_AVAILABLE, 'Ledger device not connected', err);
+      }
+
+      throw new SignerError(SignerErrorCode.SIGNING_FAILED, 'Failed to sign transaction with Ledger', err);
+    }
+  }
+
+  /**
+   * Sign a single transaction with Ledger
+   */
+  private async signSingleTransaction(transaction: Transaction | VersionedTransaction): Promise<void> {
+    // Get signature from Ledger
+    const signature = await this.hardwareWalletService.signSolanaTransaction(this.derivationPath, transaction, {
+      timeout: 60000,
+      displayMessage: `Please confirm the transaction on your Ledger device for address ${this.address}`,
+    });
+
+    // Add signature to transaction
+    if (transaction instanceof VersionedTransaction) {
+      // Convert Buffer to Uint8Array for VersionedTransaction
+      const signatureArray = new Uint8Array(signature);
+      transaction.addSignature(this.publicKey, signatureArray);
+    } else {
+      // For legacy Transaction
+      if (!transaction.signatures) {
+        transaction.signatures = [];
+      }
+
+      // Find the signer's index
+      const signerIndex = transaction.signatures.findIndex((sig) => sig.publicKey.equals(this.publicKey));
+
+      if (signerIndex >= 0) {
+        transaction.signatures[signerIndex].signature = signature;
+      } else {
+        transaction.signatures.push({
+          publicKey: this.publicKey,
+          signature: signature,
+        });
+      }
+    }
+  }
+
+  /**
+   * Sign arbitrary messages with Ledger
+   * Note: Not all Ledger apps support message signing
+   */
+  async signMessages(_messages: Uint8Array[]): Promise<never> {
+    throw new SignerError(
+      SignerErrorCode.SIGNING_FAILED,
+      'Message signing is not supported by Ledger Solana app. Use signTransactions instead.',
+    );
+  }
+
+  /**
+   * Get the derivation path for this signer
+   */
+  getDerivationPath(): string {
+    return this.derivationPath;
+  }
+}

--- a/src/chains/solana/signers/types.ts
+++ b/src/chains/solana/signers/types.ts
@@ -8,39 +8,81 @@ export type SignerType = 'keypair' | 'ledger' | 'aws-kms' | 'fireblocks' | 'turn
 /**
  * Error codes for signer operations
  * Modeled after @solana/keychain-core SignerErrorCode
+ *
+ * When @solana/keychain becomes available on npm, these codes should be
+ * compatible for easy migration.
  */
 export enum SignerErrorCode {
-  // Key validation
-  INVALID_PRIVATE_KEY = 'INVALID_PRIVATE_KEY',
-  INVALID_PUBLIC_KEY = 'INVALID_PUBLIC_KEY',
+  // Key validation (matches keychain-core)
+  INVALID_PRIVATE_KEY = 'SIGNER_INVALID_PRIVATE_KEY',
+  INVALID_PUBLIC_KEY = 'SIGNER_INVALID_PUBLIC_KEY',
 
-  // Operation failures
-  SIGNING_FAILED = 'SIGNING_FAILED',
-  SERIALIZATION_ERROR = 'SERIALIZATION_ERROR',
-  USER_REJECTED = 'USER_REJECTED',
-  TIMEOUT = 'TIMEOUT',
+  // Operation failures (matches keychain-core)
+  SIGNING_FAILED = 'SIGNER_SIGNING_FAILED',
+  SERIALIZATION_ERROR = 'SIGNER_SERIALIZATION_ERROR',
+  PARSING_ERROR = 'SIGNER_PARSING_ERROR',
+  USER_REJECTED = 'SIGNER_USER_REJECTED',
+  TIMEOUT = 'SIGNER_TIMEOUT',
 
-  // Infrastructure issues
-  NOT_AVAILABLE = 'NOT_AVAILABLE',
-  CONNECTION_ERROR = 'CONNECTION_ERROR',
-  DEVICE_LOCKED = 'DEVICE_LOCKED',
+  // Infrastructure issues (matches keychain-core)
+  NOT_AVAILABLE = 'SIGNER_NOT_AVAILABLE',
+  CONNECTION_ERROR = 'SIGNER_CONNECTION_ERROR',
+  HTTP_ERROR = 'SIGNER_HTTP_ERROR',
+  REMOTE_API_ERROR = 'SIGNER_REMOTE_API_ERROR',
+  IO_ERROR = 'SIGNER_IO_ERROR',
+  DEVICE_LOCKED = 'SIGNER_DEVICE_LOCKED',
 
-  // Configuration
-  CONFIG_ERROR = 'CONFIG_ERROR',
+  // Configuration (matches keychain-core)
+  CONFIG_ERROR = 'SIGNER_CONFIG_ERROR',
+
+  // Type checking (matches keychain-core)
+  EXPECTED_SOLANA_SIGNER = 'SIGNER_EXPECTED_SOLANA_SIGNER',
+}
+
+/**
+ * Context for signer errors (matches keychain-core pattern)
+ */
+export interface SignerErrorContext {
+  message?: string;
+  cause?: Error;
+  address?: string;
+  [key: string]: unknown;
 }
 
 /**
  * Custom error class for signer operations
+ * Modeled after @solana/keychain-core SignerError
  */
 export class SignerError extends Error {
   constructor(
     public readonly code: SignerErrorCode,
-    message: string,
+    messageOrContext: string | SignerErrorContext,
     public readonly cause?: Error,
   ) {
+    const message =
+      typeof messageOrContext === 'string' ? messageOrContext : messageOrContext.message || `Signer error: ${code}`;
     super(message);
     this.name = 'SignerError';
+    if (typeof messageOrContext !== 'string' && messageOrContext.cause) {
+      this.cause = messageOrContext.cause;
+    }
   }
+}
+
+/**
+ * Create a SignerError without throwing
+ * Matches keychain-core createSignerError pattern
+ */
+export function createSignerError(code: SignerErrorCode, context?: SignerErrorContext): SignerError {
+  return new SignerError(code, context || {});
+}
+
+/**
+ * Throw a SignerError immediately
+ * Matches keychain-core throwSignerError pattern
+ */
+export function throwSignerError(code: SignerErrorCode, context?: SignerErrorContext): never {
+  throw createSignerError(code, context);
 }
 
 /**
@@ -141,4 +183,35 @@ export interface WalletInfo {
   keyId?: string;
   vaultId?: string;
   region?: string;
+}
+
+/**
+ * Type guard to check if a value is a SolanaSigner
+ * Matches keychain-core isSolanaSigner pattern
+ */
+export function isSolanaSigner(value: unknown): value is SolanaSigner {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const signer = value as Record<string, unknown>;
+  return (
+    typeof signer.address === 'string' &&
+    typeof signer.type === 'string' &&
+    typeof signer.isAvailable === 'function' &&
+    typeof signer.getPublicKey === 'function' &&
+    typeof signer.signTransactions === 'function'
+  );
+}
+
+/**
+ * Assert that a value is a SolanaSigner
+ * Matches keychain-core assertIsSolanaSigner pattern
+ */
+export function assertIsSolanaSigner(value: unknown): asserts value is SolanaSigner {
+  if (!isSolanaSigner(value)) {
+    throwSignerError(SignerErrorCode.EXPECTED_SOLANA_SIGNER, {
+      message: 'Expected a SolanaSigner but received something else',
+    });
+  }
 }

--- a/src/chains/solana/signers/types.ts
+++ b/src/chains/solana/signers/types.ts
@@ -1,0 +1,144 @@
+import { PublicKey, Transaction, VersionedTransaction } from '@solana/web3.js';
+
+/**
+ * Supported signer types in Gateway
+ */
+export type SignerType = 'keypair' | 'ledger' | 'aws-kms' | 'fireblocks' | 'turnkey' | 'vault';
+
+/**
+ * Error codes for signer operations
+ * Modeled after @solana/keychain-core SignerErrorCode
+ */
+export enum SignerErrorCode {
+  // Key validation
+  INVALID_PRIVATE_KEY = 'INVALID_PRIVATE_KEY',
+  INVALID_PUBLIC_KEY = 'INVALID_PUBLIC_KEY',
+
+  // Operation failures
+  SIGNING_FAILED = 'SIGNING_FAILED',
+  SERIALIZATION_ERROR = 'SERIALIZATION_ERROR',
+  USER_REJECTED = 'USER_REJECTED',
+  TIMEOUT = 'TIMEOUT',
+
+  // Infrastructure issues
+  NOT_AVAILABLE = 'NOT_AVAILABLE',
+  CONNECTION_ERROR = 'CONNECTION_ERROR',
+  DEVICE_LOCKED = 'DEVICE_LOCKED',
+
+  // Configuration
+  CONFIG_ERROR = 'CONFIG_ERROR',
+}
+
+/**
+ * Custom error class for signer operations
+ */
+export class SignerError extends Error {
+  constructor(
+    public readonly code: SignerErrorCode,
+    message: string,
+    public readonly cause?: Error,
+  ) {
+    super(message);
+    this.name = 'SignerError';
+  }
+}
+
+/**
+ * Result of a signing operation
+ * Contains the signature bytes for each transaction
+ */
+export interface SignatureResult {
+  /** Base58-encoded signature */
+  signature: string;
+  /** Raw signature bytes (64 bytes for Ed25519) */
+  signatureBytes: Uint8Array;
+}
+
+/**
+ * Core signer interface for Solana transactions
+ *
+ * This interface is inspired by @solana/keychain-core's SolanaSigner
+ * but adapted for Gateway's specific needs (server-side, transaction-focused).
+ *
+ * Implementations:
+ * - KeypairSigner: For encrypted file-based wallets (hot wallets)
+ * - LedgerSigner: For Ledger hardware wallets
+ * - AwsKmsSigner: For AWS Key Management Service (future)
+ * - FireblocksSigner: For Fireblocks custody (future)
+ */
+export interface SolanaSigner {
+  /** The type of signer (for logging and debugging) */
+  readonly type: SignerType;
+
+  /** The public key address of the signer (base58-encoded) */
+  readonly address: string;
+
+  /**
+   * Check if the signer is available and ready to sign
+   * For hardware wallets, this checks device connectivity
+   * For KMS, this validates credentials and key availability
+   */
+  isAvailable(): Promise<boolean>;
+
+  /**
+   * Get the public key as a Solana PublicKey object
+   */
+  getPublicKey(): PublicKey;
+
+  /**
+   * Sign one or more transactions
+   * Returns the signed transactions (mutates in place for efficiency)
+   *
+   * @param transactions - Array of transactions to sign
+   * @returns The same transactions, now signed
+   */
+  signTransactions<T extends Transaction | VersionedTransaction>(transactions: T[]): Promise<T[]>;
+
+  /**
+   * Sign arbitrary messages (for authentication, etc.)
+   * Not all signers support this (e.g., some custody solutions restrict to transactions)
+   *
+   * @param messages - Array of message bytes to sign
+   * @returns Array of signatures
+   */
+  signMessages?(messages: Uint8Array[]): Promise<SignatureResult[]>;
+}
+
+/**
+ * Configuration for creating a signer
+ */
+export interface SignerConfig {
+  type: SignerType;
+  address: string;
+
+  // Type-specific configuration
+  /** For keypair signers: the encrypted private key file path */
+  keyFilePath?: string;
+
+  /** For ledger signers: BIP44 derivation path */
+  derivationPath?: string;
+
+  /** For AWS KMS signers: the KMS key ID or ARN */
+  awsKeyId?: string;
+  awsRegion?: string;
+
+  /** For Fireblocks signers: vault account ID */
+  fireblocksVaultId?: string;
+  fireblocksAssetId?: string;
+}
+
+/**
+ * Wallet info stored in Gateway's wallet registry
+ */
+export interface WalletInfo {
+  type: SignerType;
+  address: string;
+
+  // For hardware wallets
+  derivationPath?: string;
+
+  // For KMS/custody
+  keyId?: string;
+  vaultId?: string;
+  region?: string;
+}

--- a/src/chains/solana/solana.ts
+++ b/src/chains/solana/solana.ts
@@ -41,6 +41,7 @@ import { logger, redactUrl } from '../../services/logger';
 import { TokenService } from '../../services/token-service';
 import { getSafeWalletFilePath, isHardwareWallet as isHardwareWalletUtil } from '../../wallet/utils';
 
+import { SignerFactory, SolanaSigner } from './signers';
 import { SolanaPriorityFees } from './solana-priority-fees';
 import { SolanaNetworkConfig, getSolanaNetworkConfig, getSolanaChainConfig } from './solana.config';
 
@@ -325,6 +326,67 @@ export class Solana {
     } catch (error) {
       throw new Error(`Invalid Solana address: ${address}`);
     }
+  }
+
+  /**
+   * Get a signer for the given wallet address
+   * Automatically detects wallet type (keypair, hardware, etc.)
+   *
+   * This is the recommended way to get a signer for signing transactions.
+   * It provides a unified interface regardless of the underlying wallet type.
+   *
+   * @param address - The wallet address to get a signer for
+   * @returns A SolanaSigner instance
+   */
+  async getSigner(address: string): Promise<SolanaSigner> {
+    return SignerFactory.getSigner(address);
+  }
+
+  /**
+   * Sign, simulate, and send a transaction using the abstract signer
+   *
+   * This method provides a unified way to sign and send transactions
+   * regardless of the wallet type (keypair, hardware, KMS, etc.)
+   *
+   * @param transaction - The transaction to sign and send
+   * @param signer - The signer to use
+   * @param options - Optional configuration
+   * @returns Transaction result with signature and confirmation status
+   */
+  async signAndSend(
+    transaction: Transaction | VersionedTransaction,
+    signer: SolanaSigner,
+    options?: {
+      skipSimulation?: boolean;
+      maxRetries?: number;
+    },
+  ): Promise<{ signature: string; confirmed: boolean; fee?: number }> {
+    const skipSimulation = options?.skipSimulation ?? false;
+
+    logger.info(`[Solana] Signing transaction with ${signer.type} signer for ${signer.address}`);
+
+    // Sign the transaction using the abstract signer
+    const [signedTx] = await signer.signTransactions([transaction]);
+
+    // Simulate if not skipped
+    if (!skipSimulation) {
+      logger.debug(`[Solana] Simulating transaction...`);
+      await this.simulateWithErrorHandling(signedTx);
+      logger.debug(`[Solana] Simulation successful`);
+    }
+
+    // Send and confirm
+    logger.debug(`[Solana] Sending transaction...`);
+    const { confirmed, signature, txData } = await this.sendAndConfirmRawTransaction(signedTx);
+
+    // Calculate fee if confirmed
+    let fee: number | undefined;
+    if (confirmed && txData) {
+      fee = this.getFee(txData);
+      logger.info(`[Solana] Transaction ${signature} confirmed with fee: ${fee.toFixed(6)} SOL`);
+    }
+
+    return { signature, confirmed, fee };
   }
 
   async encrypt(secret: string, password: string): Promise<string> {

--- a/src/chains/solana/solana.ts
+++ b/src/chains/solana/solana.ts
@@ -359,11 +359,23 @@ export class Solana {
     options?: {
       skipSimulation?: boolean;
       maxRetries?: number;
+      additionalKeypairs?: Keypair[];
     },
   ): Promise<{ signature: string; confirmed: boolean; fee?: number }> {
     const skipSimulation = options?.skipSimulation ?? false;
+    const additionalKeypairs = options?.additionalKeypairs ?? [];
 
     logger.info(`[Solana] Signing transaction with ${signer.type} signer for ${signer.address}`);
+
+    // Sign with additional keypairs first (e.g., new position accounts)
+    if (additionalKeypairs.length > 0) {
+      logger.debug(`[Solana] Signing with ${additionalKeypairs.length} additional keypair(s)`);
+      if (transaction instanceof VersionedTransaction) {
+        transaction.sign(additionalKeypairs);
+      } else {
+        transaction.partialSign(...additionalKeypairs);
+      }
+    }
 
     // Sign the transaction using the abstract signer
     const [signedTx] = await signer.signTransactions([transaction]);
@@ -435,8 +447,8 @@ export class Solana {
   /**
    * @deprecated Use the optimized implementation in routes/balances.ts instead
    */
-  async getBalance(wallet: Keypair, symbols?: string[]): Promise<Record<string, number>> {
-    const publicKey = wallet.publicKey;
+  async getBalance(wallet: Keypair | PublicKey, symbols?: string[]): Promise<Record<string, number>> {
+    const publicKey = wallet instanceof PublicKey ? wallet : wallet.publicKey;
     const balances: Record<string, number> = {};
 
     // Treat empty array as if no tokens were specified

--- a/src/connectors/jupiter/jupiter.ts
+++ b/src/connectors/jupiter/jupiter.ts
@@ -273,7 +273,27 @@ export class Jupiter {
   }
 
   /**
+   * Builds an unsigned swap transaction
+   * This is the preferred method for use with the signer abstraction pattern.
+   *
+   * @param walletAddress The public key of the wallet
+   * @param quote The quote response from Jupiter API
+   * @param maxLamports Maximum priority fee in lamports (optional)
+   * @param priorityLevel Priority level for transaction (optional)
+   * @returns Unsigned transaction ready for signing
+   */
+  public async buildUnsignedSwapTransaction(
+    walletAddress: string,
+    quote: QuoteResponse,
+    maxLamports?: number,
+    priorityLevel?: string,
+  ): Promise<VersionedTransaction> {
+    return this.buildSwapTransactionForHardwareWallet(walletAddress, quote, maxLamports, priorityLevel);
+  }
+
+  /**
    * Builds a swap transaction for hardware wallets (returns unsigned transaction)
+   * @deprecated Use buildUnsignedSwapTransaction instead
    * @param walletAddress The public key of the hardware wallet
    * @param quote The quote response from Jupiter API
    * @param maxLamports Maximum priority fee in lamports (optional)

--- a/src/connectors/jupiter/router-routes/executeQuote.ts
+++ b/src/connectors/jupiter/router-routes/executeQuote.ts
@@ -1,8 +1,6 @@
-import { Wallet } from '@coral-xyz/anchor';
 import { FastifyPluginAsync } from 'fastify';
 
 import { Solana } from '../../../chains/solana/solana';
-import { SolanaLedger } from '../../../chains/solana/solana-ledger';
 import { ExecuteQuoteRequestType, SwapExecuteResponseType, SwapExecuteResponse } from '../../../schemas/router-schema';
 import { httpErrors } from '../../../services/error-handler';
 import { logger } from '../../../services/logger';
@@ -34,41 +32,23 @@ export async function executeQuote(
     throw httpErrors.badRequest('Invalid tokens in quote');
   }
 
-  // Check if this is a hardware wallet
-  const isHardwareWallet = await solana.isHardwareWallet(walletAddress);
-  let transaction;
+  logger.info(`Executing quote ${quoteId} for ${inputToken.symbol} -> ${outputToken.symbol}`);
 
-  if (isHardwareWallet) {
-    // For hardware wallets, we need to build the transaction with the actual public key
-    // but sign it separately with Ledger
-    logger.info(`Hardware wallet detected for ${walletAddress}. Building transaction for Ledger signing.`);
+  // Get signer for the wallet (automatically handles keypair vs hardware wallet)
+  const signer = await solana.getSigner(walletAddress);
+  logger.info(`Using ${signer.type} signer for ${walletAddress}`);
 
-    // Jupiter needs to build the transaction with the actual user's public key
-    // We'll pass the hardware wallet address to Jupiter's buildSwapTransactionForHardwareWallet
-    logger.info(`Executing quote ${quoteId} for ${inputToken.symbol} -> ${outputToken.symbol} with hardware wallet`);
+  // Build unsigned transaction
+  const transaction = await jupiter.buildUnsignedSwapTransaction(walletAddress, quote, maxLamports, priorityLevel);
 
-    // Build the swap transaction for hardware wallet
-    transaction = await jupiter.buildSwapTransactionForHardwareWallet(walletAddress, quote, maxLamports, priorityLevel);
+  // Sign, simulate, and send using unified method
+  const { signature, confirmed, fee } = await solana.signAndSend(transaction, signer);
 
-    // Now sign with Ledger
-    const ledger = new SolanaLedger();
-    transaction = await ledger.signTransaction(walletAddress, transaction);
-  } else {
-    // Regular wallet flow
-    const keypair = await solana.getWallet(walletAddress);
-    const wallet = new Wallet(keypair as any);
-
-    logger.info(`Executing quote ${quoteId} for ${inputToken.symbol} -> ${outputToken.symbol}`);
-
-    // Build the swap transaction (will be signed by Jupiter)
-    transaction = await jupiter.buildSwapTransaction(wallet, quote, maxLamports, priorityLevel);
-  }
-
-  // Simulate transaction with proper error handling before sending
-  await solana.simulateWithErrorHandling(transaction);
-
-  // Send and confirm transaction using Solana's method
-  const { confirmed, signature, txData } = await solana.sendAndConfirmRawTransaction(transaction);
+  // Get transaction data for confirmation handling
+  const txData = await solana.connection.getTransaction(signature, {
+    commitment: 'confirmed',
+    maxSupportedTransactionVersion: 0,
+  });
 
   // Handle confirmation status
   const result = await solana.handleConfirmation(

--- a/src/connectors/meteora/clmm-routes/addLiquidity.ts
+++ b/src/connectors/meteora/clmm-routes/addLiquidity.ts
@@ -47,7 +47,8 @@ export async function addLiquidity(
 
   const solana = await Solana.getInstance(network);
   const meteora = await Meteora.getInstance(network);
-  const wallet = await solana.getWallet(address);
+  const signer = await solana.getSigner(address);
+  const publicKey = signer.getPublicKey();
 
   // Validate amounts
   if (baseTokenAmount <= 0 && quoteTokenAmount <= 0) {
@@ -55,7 +56,7 @@ export async function addLiquidity(
   }
 
   // Get position - handle null return gracefully
-  const positionResult = await meteora.getRawPosition(positionAddress, wallet.publicKey);
+  const positionResult = await meteora.getRawPosition(positionAddress, publicKey);
 
   if (!positionResult || !positionResult.position) {
     throw httpErrors.notFound(`Position not found: ${positionAddress}. Please provide a valid position address`);
@@ -74,7 +75,7 @@ export async function addLiquidity(
   const tokenYSymbol = tokenY?.symbol || 'UNKNOWN';
 
   // Check balances with transaction buffer
-  const balances = await solana.getBalance(wallet, [tokenXSymbol, tokenYSymbol, 'SOL']);
+  const balances = await solana.getBalance(publicKey, [tokenXSymbol, tokenYSymbol, 'SOL']);
   const requiredBase = baseTokenAmount + (tokenXSymbol === 'SOL' ? SOL_TRANSACTION_BUFFER : 0);
   const requiredQuote = quoteTokenAmount + (tokenYSymbol === 'SOL' ? SOL_TRANSACTION_BUFFER : 0);
 
@@ -101,7 +102,7 @@ export async function addLiquidity(
 
   const addLiquidityTx = await dlmmPool.addLiquidityByStrategy({
     positionPubKey: new PublicKey(position.publicKey),
-    user: wallet.publicKey,
+    user: publicKey,
     totalXAmount,
     totalYAmount,
     strategy: {
@@ -113,16 +114,11 @@ export async function addLiquidity(
   });
 
   // Set the fee payer for simulation
-  addLiquidityTx.feePayer = wallet.publicKey;
+  addLiquidityTx.feePayer = publicKey;
 
-  // Simulate with error handling
-  await solana.simulateWithErrorHandling(addLiquidityTx);
-
-  logger.info('Transaction simulated successfully, sending to network...');
-
-  // Send and confirm transaction using sendAndConfirmTransaction which handles signing
-  // Transaction will automatically simulate to determine optimal compute units
-  const { signature, fee } = await solana.sendAndConfirmTransaction(addLiquidityTx, [wallet]);
+  // Sign and send using unified signer pattern
+  logger.info(`Using ${signer.type} signer for ${address}`);
+  const { signature, fee } = await solana.signAndSend(addLiquidityTx, signer);
 
   // Get transaction data for confirmation
   const txData = await solana.connection.getTransaction(signature, {

--- a/src/connectors/meteora/clmm-routes/closePosition.ts
+++ b/src/connectors/meteora/clmm-routes/closePosition.ts
@@ -21,10 +21,11 @@ export async function closePosition(
   try {
     const solana = await Solana.getInstance(network);
     const meteora = await Meteora.getInstance(network);
-    const wallet = await solana.getWallet(walletAddress);
+    const signer = await solana.getSigner(walletAddress);
+    const publicKey = signer.getPublicKey();
 
     // Get position and pool info
-    const positionResult = await meteora.getRawPosition(positionAddress, wallet.publicKey);
+    const positionResult = await meteora.getRawPosition(positionAddress, publicKey);
 
     if (!positionResult || !positionResult.position) {
       throw httpErrors.notFound(`Position not found: ${positionAddress}. Please provide a valid position address`);
@@ -38,7 +39,7 @@ export async function closePosition(
     const tokenYSymbol = tokenY?.symbol || 'UNKNOWN';
 
     // Get position info to track fees separately
-    const positionInfo = await meteora.getPositionInfo(positionAddress, wallet.publicKey);
+    const positionInfo = await meteora.getPositionInfo(positionAddress, publicKey);
     const baseFeeAmount = positionInfo.baseFeeAmount;
     const quoteFeeAmount = positionInfo.quoteFeeAmount;
 
@@ -52,7 +53,7 @@ export async function closePosition(
 
     const removeLiquidityTxs = await dlmmPool.removeLiquidity({
       position: position.publicKey,
-      user: wallet.publicKey,
+      user: publicKey,
       fromBinId,
       toBinId,
       bps: bps,
@@ -65,6 +66,8 @@ export async function closePosition(
     let totalFee = 0;
     let lastSignature = '';
 
+    logger.info(`Using ${signer.type} signer for ${walletAddress}`);
+
     for (let i = 0; i < transactions.length; i++) {
       const tx = transactions[i];
       if (transactions.length > 1) {
@@ -72,16 +75,11 @@ export async function closePosition(
       }
 
       // Set fee payer for simulation
-      tx.feePayer = wallet.publicKey;
+      tx.feePayer = publicKey;
 
-      // Simulate with error handling
-      await solana.simulateWithErrorHandling(tx);
-
-      logger.info('Transaction simulated successfully, sending to network...');
-
-      // Send and confirm transaction
-      const result = await solana.sendAndConfirmTransaction(tx, [wallet]);
-      totalFee += result.fee;
+      // Sign and send using unified signer pattern
+      const result = await solana.signAndSend(tx, signer);
+      totalFee += result.fee || 0;
       lastSignature = result.signature;
     }
 
@@ -99,7 +97,7 @@ export async function closePosition(
       logger.info(`Position ${positionAddress} closed successfully with signature: ${signature}`);
 
       // Extract balance changes for the tokens
-      const { balanceChanges } = await solana.extractBalanceChangesAndFee(signature, wallet.publicKey.toBase58(), [
+      const { balanceChanges } = await solana.extractBalanceChangesAndFee(signature, publicKey.toBase58(), [
         dlmmPool.tokenX.publicKey.toBase58(),
         dlmmPool.tokenY.publicKey.toBase58(),
         'So11111111111111111111111111111111111111112', // SOL (for rent refund)

--- a/src/connectors/meteora/clmm-routes/collectFees.ts
+++ b/src/connectors/meteora/clmm-routes/collectFees.ts
@@ -15,10 +15,11 @@ export async function collectFees(
 ): Promise<CollectFeesResponseType> {
   const solana = await Solana.getInstance(network);
   const meteora = await Meteora.getInstance(network);
-  const wallet = await solana.getWallet(address);
+  const signer = await solana.getSigner(address);
+  const publicKey = signer.getPublicKey();
 
   // Get position result and check if it's null before destructuring
-  const positionResult = await meteora.getRawPosition(positionAddress, wallet.publicKey);
+  const positionResult = await meteora.getRawPosition(positionAddress, publicKey);
 
   if (!positionResult || !positionResult.position) {
     throw httpErrors.notFound(`Position not found: ${positionAddress}. Please provide a valid position address`);
@@ -38,9 +39,10 @@ export async function collectFees(
   const tokenYSymbol = tokenY?.symbol || 'UNKNOWN';
 
   logger.info(`Collecting fees from position ${positionAddress}`);
+  logger.info(`Using ${signer.type} signer for ${address}`);
 
   const claimSwapFeeTxs = await dlmmPool.claimSwapFee({
-    owner: wallet.publicKey,
+    owner: publicKey,
     position: position,
   });
 
@@ -49,23 +51,18 @@ export async function collectFees(
 
   // Set fee payer for all transactions
   transactions.forEach((tx) => {
-    tx.feePayer = wallet.publicKey;
+    tx.feePayer = publicKey;
   });
 
-  // Simulate and send all transactions
+  // Send all transactions using unified signer pattern
   let totalFee = 0;
   let lastSignature = '';
 
   for (const tx of transactions) {
-    // Simulate with error handling
-    await solana.simulateWithErrorHandling(tx);
-
-    logger.info('Transaction simulated successfully, sending to network...');
-
-    // Send and confirm transaction using sendAndConfirmTransaction which handles signing
-    const { signature, fee } = await solana.sendAndConfirmTransaction(tx, [wallet]);
-    lastSignature = signature;
-    totalFee += fee;
+    // Sign and send using unified signer pattern
+    const result = await solana.signAndSend(tx, signer);
+    lastSignature = result.signature;
+    totalFee += result.fee || 0;
   }
 
   const signature = lastSignature;
@@ -80,7 +77,7 @@ export async function collectFees(
   const confirmed = txData !== null;
 
   if (confirmed && txData) {
-    const { balanceChanges } = await solana.extractBalanceChangesAndFee(signature, wallet.publicKey.toBase58(), [
+    const { balanceChanges } = await solana.extractBalanceChangesAndFee(signature, publicKey.toBase58(), [
       dlmmPool.tokenX.publicKey.toBase58(),
       dlmmPool.tokenY.publicKey.toBase58(),
     ]);

--- a/src/connectors/meteora/clmm-routes/executeSwap.ts
+++ b/src/connectors/meteora/clmm-routes/executeSwap.ts
@@ -25,7 +25,8 @@ export async function executeSwap(
   slippagePct: number = MeteoraConfig.config.slippagePct,
 ): Promise<ExecuteSwapResponseType> {
   const solana = await Solana.getInstance(network);
-  const wallet = await solana.getWallet(address);
+  const signer = await solana.getSigner(address);
+  const publicKey = signer.getPublicKey();
 
   const {
     inputToken,
@@ -45,7 +46,7 @@ export async function executeSwap(
           outAmount: (swapQuote as SwapQuoteExactOut).outAmount,
           maxInAmount: (swapQuote as SwapQuoteExactOut).maxInAmount,
           lbPair: dlmmPool.pubkey,
-          user: wallet.publicKey,
+          user: publicKey,
           binArraysPubkey: (swapQuote as SwapQuoteExactOut).binArraysPubkey,
         })
       : await dlmmPool.swap({
@@ -54,17 +55,14 @@ export async function executeSwap(
           inAmount: swapAmount,
           minOutAmount: (swapQuote as SwapQuote).minOutAmount,
           lbPair: dlmmPool.pubkey,
-          user: wallet.publicKey,
+          user: publicKey,
           binArraysPubkey: (swapQuote as SwapQuote).binArraysPubkey,
         });
 
-  // Simulate transaction with proper error handling (before signing)
-  await solana.simulateWithErrorHandling(swapTx);
+  logger.info(`Using ${signer.type} signer for ${address}`);
 
-  logger.info('Transaction simulated successfully, sending to network...');
-
-  // Send and confirm transaction using sendAndConfirmTransaction which handles signing
-  const { signature, fee } = await solana.sendAndConfirmTransaction(swapTx, [wallet]);
+  // Sign and send using unified signer pattern
+  const { signature, fee } = await solana.signAndSend(swapTx, signer);
 
   logger.info(`Transaction sent with signature: ${signature}`);
 
@@ -81,7 +79,7 @@ export async function executeSwap(
     // Extract fee from the response
     const txFee = fee;
     // Transaction confirmed, extract balance changes
-    const { balanceChanges } = await solana.extractBalanceChangesAndFee(signature, wallet.publicKey.toBase58(), [
+    const { balanceChanges } = await solana.extractBalanceChangesAndFee(signature, publicKey.toBase58(), [
       inputToken.address,
       outputToken.address,
     ]);

--- a/src/connectors/meteora/clmm-routes/openPosition.ts
+++ b/src/connectors/meteora/clmm-routes/openPosition.ts
@@ -52,7 +52,8 @@ export async function openPosition(
     throw httpErrors.badRequest(`Invalid wallet address: ${walletAddress}`);
   }
 
-  const wallet = await solana.getWallet(walletAddress);
+  const signer = await solana.getSigner(walletAddress);
+  const publicKey = signer.getPublicKey();
   const newImbalancePosition = new Keypair();
 
   let dlmmPool;
@@ -124,7 +125,7 @@ export async function openPosition(
 
   const createPositionTx = await dlmmPool.initializePositionAndAddLiquidityByStrategy({
     positionPubKey: newImbalancePosition.publicKey,
-    user: wallet.publicKey,
+    user: publicKey,
     totalXAmount,
     totalYAmount,
     strategy: {
@@ -149,21 +150,16 @@ export async function openPosition(
 
   // Log the transaction details before sending
   logger.info(`Transaction details: ${createPositionTx.instructions.length} instructions`);
+  logger.info(`Using ${signer.type} signer for ${walletAddress}`);
 
   // Set the fee payer for simulation
-  createPositionTx.feePayer = wallet.publicKey;
+  createPositionTx.feePayer = publicKey;
 
-  // Simulate with error handling (no signing needed for simulation)
-  await solana.simulateWithErrorHandling(createPositionTx);
-
-  logger.info('Transaction simulated successfully, sending to network...');
-
-  // Send and confirm the ORIGINAL unsigned transaction
-  // sendAndConfirmTransaction will handle the signing and auto-simulate for optimal compute units
-  const { signature, fee: txFee } = await solana.sendAndConfirmTransaction(createPositionTx, [
-    wallet,
-    newImbalancePosition,
-  ]);
+  // Sign and send using unified signer pattern
+  // Pass newImbalancePosition as additional keypair since it's a new account that needs to sign
+  const { signature, fee: txFee } = await solana.signAndSend(createPositionTx, signer, {
+    additionalKeypairs: [newImbalancePosition],
+  });
 
   // Get transaction data for confirmation
   const txData = await solana.connection.getTransaction(signature, {
@@ -174,7 +170,7 @@ export async function openPosition(
   const confirmed = txData !== null;
 
   if (confirmed && txData) {
-    const { balanceChanges } = await solana.extractBalanceChangesAndFee(signature, wallet.publicKey.toBase58(), [
+    const { balanceChanges } = await solana.extractBalanceChangesAndFee(signature, publicKey.toBase58(), [
       tokenX?.address || dlmmPool.tokenX.publicKey.toBase58(),
       tokenY?.address || dlmmPool.tokenY.publicKey.toBase58(),
     ]);

--- a/src/connectors/meteora/clmm-routes/removeLiquidity.ts
+++ b/src/connectors/meteora/clmm-routes/removeLiquidity.ts
@@ -25,7 +25,8 @@ export async function removeLiquidity(
 ): Promise<RemoveLiquidityResponseType> {
   const solana = await Solana.getInstance(network);
   const meteora = await Meteora.getInstance(network);
-  const wallet = await solana.getWallet(walletAddress);
+  const signer = await solana.getSigner(walletAddress);
+  const publicKey = signer.getPublicKey();
 
   try {
     new PublicKey(positionAddress);
@@ -38,7 +39,7 @@ export async function removeLiquidity(
     throw httpErrors.badRequest(`Invalid wallet address: ${walletAddress}`);
   }
 
-  const positionResult = await meteora.getRawPosition(positionAddress, wallet.publicKey);
+  const positionResult = await meteora.getRawPosition(positionAddress, publicKey);
 
   if (!positionResult || !positionResult.position) {
     throw httpErrors.notFound(`Position not found: ${positionAddress}. Please provide a valid position address`);
@@ -60,7 +61,7 @@ export async function removeLiquidity(
 
   const removeLiquidityTx = await dlmmPool.removeLiquidity({
     position: position.publicKey,
-    user: wallet.publicKey,
+    user: publicKey,
     fromBinId,
     toBinId,
     bps: bps,
@@ -73,6 +74,8 @@ export async function removeLiquidity(
   let totalFee = 0;
   let lastSignature = '';
 
+  logger.info(`Using ${signer.type} signer for ${walletAddress}`);
+
   for (let i = 0; i < transactions.length; i++) {
     const tx = transactions[i];
     if (transactions.length > 1) {
@@ -80,15 +83,11 @@ export async function removeLiquidity(
     }
 
     // Set fee payer for simulation
-    tx.feePayer = wallet.publicKey;
+    tx.feePayer = publicKey;
 
-    // Simulate before sending
-    await solana.simulateWithErrorHandling(tx);
-
-    logger.info('Transaction simulated successfully, sending to network...');
-
-    const result = await solana.sendAndConfirmTransaction(tx, [wallet]);
-    totalFee += result.fee;
+    // Sign and send using unified signer pattern
+    const result = await solana.signAndSend(tx, signer);
+    totalFee += result.fee || 0;
     lastSignature = result.signature;
   }
 
@@ -104,7 +103,7 @@ export async function removeLiquidity(
   const confirmed = txData !== null;
 
   if (confirmed && txData) {
-    const { balanceChanges } = await solana.extractBalanceChangesAndFee(signature, wallet.publicKey.toBase58(), [
+    const { balanceChanges } = await solana.extractBalanceChangesAndFee(signature, publicKey.toBase58(), [
       dlmmPool.tokenX.publicKey.toBase58(),
       dlmmPool.tokenY.publicKey.toBase58(),
     ]);

--- a/test/chains/solana/signers/signers.test.ts
+++ b/test/chains/solana/signers/signers.test.ts
@@ -1,0 +1,392 @@
+// Mock fs-extra to prevent actual file writes
+jest.mock('fs-extra');
+
+// Mock wallet utils before importing factory
+jest.mock('../../../../src/wallet/utils', () => ({
+  getHardwareWalletByAddress: jest.fn(),
+  isHardwareWallet: jest.fn(),
+  getSafeWalletFilePath: jest.fn(),
+}));
+
+import { Keypair, PublicKey, VersionedTransaction, TransactionMessage, TransactionInstruction } from '@solana/web3.js';
+import bs58 from 'bs58';
+import * as fse from 'fs-extra';
+
+import { SignerFactory } from '../../../../src/chains/solana/signers/factory';
+import { KeypairSigner } from '../../../../src/chains/solana/signers/keypair-signer';
+import { LedgerSigner } from '../../../../src/chains/solana/signers/ledger-signer';
+import { SignerError, SignerErrorCode } from '../../../../src/chains/solana/signers/types';
+import { ConfigManagerCertPassphrase } from '../../../../src/services/config-manager-cert-passphrase';
+import { HardwareWalletService } from '../../../../src/services/hardware-wallet-service';
+import * as walletUtils from '../../../../src/wallet/utils';
+import { patch, unpatch } from '../../../services/patch';
+
+const mockFse = fse as jest.Mocked<typeof fse>;
+const mockWalletUtils = walletUtils as jest.Mocked<typeof walletUtils>;
+
+// Generate test keypairs
+const testKeypair = Keypair.generate();
+const testAddress = testKeypair.publicKey.toBase58();
+const testPrivateKey = bs58.encode(testKeypair.secretKey);
+
+// Mock encrypted wallet data
+const mockEncryptedWallet = JSON.stringify({
+  salt: '0123456789abcdef',
+  iv: '0123456789abcdef0123456789abcdef',
+  content: '0123456789abcdef', // dummy encrypted content
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  SignerFactory.clearCache();
+});
+
+afterEach(() => {
+  unpatch();
+});
+
+describe('SignerError', () => {
+  it('should create error with code and message', () => {
+    const error = new SignerError(SignerErrorCode.SIGNING_FAILED, 'Test error');
+    expect(error.code).toBe(SignerErrorCode.SIGNING_FAILED);
+    expect(error.message).toBe('Test error');
+    expect(error.name).toBe('SignerError');
+  });
+
+  it('should include cause when provided', () => {
+    const cause = new Error('Original error');
+    const error = new SignerError(SignerErrorCode.SIGNING_FAILED, 'Test error', cause);
+    expect(error.cause).toBe(cause);
+  });
+});
+
+describe('KeypairSigner', () => {
+  describe('constructor', () => {
+    it('should create signer from keypair', () => {
+      const signer = new KeypairSigner(testKeypair);
+      expect(signer.type).toBe('keypair');
+      expect(signer.address).toBe(testAddress);
+    });
+  });
+
+  describe('fromPrivateKey', () => {
+    it('should create signer from base58 private key', () => {
+      const signer = KeypairSigner.fromPrivateKey(testPrivateKey);
+      expect(signer.type).toBe('keypair');
+      expect(signer.address).toBe(testAddress);
+    });
+
+    it('should throw SignerError for invalid private key', () => {
+      expect(() => KeypairSigner.fromPrivateKey('invalid-key')).toThrow(SignerError);
+    });
+  });
+
+  describe('fromSecretKey', () => {
+    it('should create signer from secret key Uint8Array', () => {
+      const signer = KeypairSigner.fromSecretKey(testKeypair.secretKey);
+      expect(signer.type).toBe('keypair');
+      expect(signer.address).toBe(testAddress);
+    });
+
+    it('should throw SignerError for invalid secret key', () => {
+      expect(() => KeypairSigner.fromSecretKey(new Uint8Array(16))).toThrow(SignerError);
+    });
+  });
+
+  describe('isAvailable', () => {
+    it('should always return true for keypair signer', async () => {
+      const signer = new KeypairSigner(testKeypair);
+      expect(await signer.isAvailable()).toBe(true);
+    });
+  });
+
+  describe('getPublicKey', () => {
+    it('should return the public key', () => {
+      const signer = new KeypairSigner(testKeypair);
+      expect(signer.getPublicKey().equals(testKeypair.publicKey)).toBe(true);
+    });
+  });
+
+  describe('getKeypair', () => {
+    it('should return the underlying keypair', () => {
+      const signer = new KeypairSigner(testKeypair);
+      expect(signer.getKeypair()).toBe(testKeypair);
+    });
+  });
+
+  describe('signTransactions', () => {
+    it('should sign versioned transactions', async () => {
+      const signer = new KeypairSigner(testKeypair);
+
+      // Create a minimal versioned transaction
+      const instruction = new TransactionInstruction({
+        keys: [],
+        programId: new PublicKey('11111111111111111111111111111111'),
+        data: Buffer.from([]),
+      });
+
+      const messageV0 = new TransactionMessage({
+        payerKey: testKeypair.publicKey,
+        recentBlockhash: 'EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N', // dummy blockhash
+        instructions: [instruction],
+      }).compileToV0Message();
+
+      const tx = new VersionedTransaction(messageV0);
+
+      const signedTxs = await signer.signTransactions([tx]);
+      expect(signedTxs).toHaveLength(1);
+      expect(signedTxs[0].signatures[0]).toBeDefined();
+      // Verify signature is not all zeros
+      expect(signedTxs[0].signatures[0].every((b) => b === 0)).toBe(false);
+    });
+
+    it('should sign multiple transactions', async () => {
+      const signer = new KeypairSigner(testKeypair);
+
+      const instruction = new TransactionInstruction({
+        keys: [],
+        programId: new PublicKey('11111111111111111111111111111111'),
+        data: Buffer.from([]),
+      });
+
+      const messageV0 = new TransactionMessage({
+        payerKey: testKeypair.publicKey,
+        recentBlockhash: 'EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N',
+        instructions: [instruction],
+      }).compileToV0Message();
+
+      const tx1 = new VersionedTransaction(messageV0);
+      const tx2 = new VersionedTransaction(messageV0);
+
+      const signedTxs = await signer.signTransactions([tx1, tx2]);
+      expect(signedTxs).toHaveLength(2);
+    });
+  });
+
+  describe('signMessages', () => {
+    it('should sign arbitrary messages', async () => {
+      const signer = new KeypairSigner(testKeypair);
+      const message = new TextEncoder().encode('Hello, Solana!');
+
+      const results = await signer.signMessages([message]);
+      expect(results).toHaveLength(1);
+      expect(results[0].signature).toBeDefined();
+      expect(results[0].signatureBytes).toBeInstanceOf(Uint8Array);
+      expect(results[0].signatureBytes.length).toBe(64); // Ed25519 signature length
+    });
+
+    it('should sign multiple messages', async () => {
+      const signer = new KeypairSigner(testKeypair);
+      const message1 = new TextEncoder().encode('Message 1');
+      const message2 = new TextEncoder().encode('Message 2');
+
+      const results = await signer.signMessages([message1, message2]);
+      expect(results).toHaveLength(2);
+      // Verify different messages produce different signatures
+      expect(results[0].signature).not.toBe(results[1].signature);
+    });
+  });
+});
+
+describe('LedgerSigner', () => {
+  const mockDerivationPath = "m/44'/501'/0'/0'";
+
+  describe('constructor', () => {
+    it('should create signer with address and derivation path', () => {
+      const signer = new LedgerSigner(testAddress, mockDerivationPath);
+      expect(signer.type).toBe('ledger');
+      expect(signer.address).toBe(testAddress);
+    });
+  });
+
+  describe('getPublicKey', () => {
+    it('should return the public key from address', () => {
+      const signer = new LedgerSigner(testAddress, mockDerivationPath);
+      expect(signer.getPublicKey().toBase58()).toBe(testAddress);
+    });
+  });
+
+  describe('isAvailable', () => {
+    it('should return false when hardware wallet service fails', async () => {
+      // Mock the hardware wallet service to throw
+      patch(HardwareWalletService.prototype, 'isDeviceConnected', async () => {
+        throw new Error('Ledger not connected');
+      });
+
+      const signer = new LedgerSigner(testAddress, mockDerivationPath);
+      const isAvailable = await signer.isAvailable();
+      expect(isAvailable).toBe(false);
+    });
+
+    it('should return true when device is connected', async () => {
+      patch(HardwareWalletService.prototype, 'isDeviceConnected', async () => true);
+
+      const signer = new LedgerSigner(testAddress, mockDerivationPath);
+      const isAvailable = await signer.isAvailable();
+      expect(isAvailable).toBe(true);
+    });
+  });
+
+  describe('getDerivationPath', () => {
+    it('should return the derivation path', () => {
+      const signer = new LedgerSigner(testAddress, mockDerivationPath);
+      expect(signer.getDerivationPath()).toBe(mockDerivationPath);
+    });
+  });
+
+  describe('signMessages', () => {
+    it('should throw SignerError as Ledger does not support message signing', async () => {
+      const signer = new LedgerSigner(testAddress, mockDerivationPath);
+      const message = new TextEncoder().encode('Test message');
+
+      await expect(signer.signMessages([message])).rejects.toThrow(SignerError);
+    });
+  });
+});
+
+describe('SignerFactory', () => {
+  beforeEach(() => {
+    SignerFactory.clearCache();
+    patch(ConfigManagerCertPassphrase, 'readPassphrase', () => 'test-passphrase');
+    jest.clearAllMocks();
+  });
+
+  describe('getSigner', () => {
+    it('should throw error for invalid address format', async () => {
+      await expect(SignerFactory.getSigner('invalid-address')).rejects.toThrow(SignerError);
+    });
+
+    it('should throw error when no wallet found', async () => {
+      mockWalletUtils.getHardwareWalletByAddress.mockResolvedValue(null);
+      mockWalletUtils.getSafeWalletFilePath.mockReturnValue('/mock/path/wallet.json');
+      (mockFse.pathExists as jest.Mock).mockResolvedValue(false);
+
+      await expect(SignerFactory.getSigner(testAddress)).rejects.toThrow(SignerError);
+    });
+
+    it('should return KeypairSigner for regular wallet', async () => {
+      // Mock no hardware wallet
+      mockWalletUtils.getHardwareWalletByAddress.mockResolvedValue(null);
+      mockWalletUtils.getSafeWalletFilePath.mockReturnValue('/mock/wallet/path.json');
+
+      // Mock wallet file exists
+      (mockFse.pathExists as jest.Mock).mockResolvedValue(true);
+      (mockFse.readFile as jest.Mock).mockResolvedValue(mockEncryptedWallet);
+
+      // Mock the decrypt function to return the test private key
+      patch(SignerFactory as any, 'decrypt', async () => testPrivateKey);
+
+      const signer = await SignerFactory.getSigner(testAddress);
+      expect(signer).toBeInstanceOf(KeypairSigner);
+      expect(signer.type).toBe('keypair');
+      expect(signer.address).toBe(testAddress);
+    });
+
+    it('should return LedgerSigner for hardware wallet', async () => {
+      mockWalletUtils.getHardwareWalletByAddress.mockResolvedValue({
+        address: testAddress,
+        publicKey: testAddress,
+        derivationPath: "m/44'/501'/0'/0'",
+        addedAt: new Date().toISOString(),
+      });
+
+      const signer = await SignerFactory.getSigner(testAddress);
+      expect(signer).toBeInstanceOf(LedgerSigner);
+      expect(signer.type).toBe('ledger');
+    });
+  });
+
+  describe('getWalletInfo', () => {
+    it('should return info for hardware wallet', async () => {
+      mockWalletUtils.getHardwareWalletByAddress.mockResolvedValue({
+        address: testAddress,
+        publicKey: testAddress,
+        derivationPath: "m/44'/501'/0'/0'",
+        addedAt: new Date().toISOString(),
+      });
+
+      const info = await SignerFactory.getWalletInfo(testAddress);
+      expect(info.type).toBe('ledger');
+      expect(info.address).toBe(testAddress);
+      expect(info.derivationPath).toBe("m/44'/501'/0'/0'");
+    });
+
+    it('should return info for regular wallet', async () => {
+      mockWalletUtils.getHardwareWalletByAddress.mockResolvedValue(null);
+      mockWalletUtils.getSafeWalletFilePath.mockReturnValue('/mock/wallet/path.json');
+      (mockFse.pathExists as jest.Mock).mockResolvedValue(true);
+
+      const info = await SignerFactory.getWalletInfo(testAddress);
+      expect(info.type).toBe('keypair');
+      expect(info.address).toBe(testAddress);
+    });
+
+    it('should throw when wallet not found', async () => {
+      mockWalletUtils.getHardwareWalletByAddress.mockResolvedValue(null);
+      mockWalletUtils.getSafeWalletFilePath.mockReturnValue('/mock/wallet/path.json');
+      (mockFse.pathExists as jest.Mock).mockResolvedValue(false);
+
+      await expect(SignerFactory.getWalletInfo(testAddress)).rejects.toThrow(SignerError);
+    });
+  });
+
+  describe('getSignerType', () => {
+    it('should return ledger for hardware wallet', async () => {
+      mockWalletUtils.isHardwareWallet.mockResolvedValue(true);
+
+      const type = await SignerFactory.getSignerType(testAddress);
+      expect(type).toBe('ledger');
+    });
+
+    it('should return keypair for regular wallet', async () => {
+      mockWalletUtils.isHardwareWallet.mockResolvedValue(false);
+      mockWalletUtils.getSafeWalletFilePath.mockReturnValue('/mock/wallet/path.json');
+      (mockFse.pathExists as jest.Mock).mockResolvedValue(true);
+
+      const type = await SignerFactory.getSignerType(testAddress);
+      expect(type).toBe('keypair');
+    });
+  });
+
+  describe('hasWallet', () => {
+    it('should return true when wallet exists', async () => {
+      mockWalletUtils.isHardwareWallet.mockResolvedValue(false);
+      mockWalletUtils.getSafeWalletFilePath.mockReturnValue('/mock/wallet/path.json');
+      (mockFse.pathExists as jest.Mock).mockResolvedValue(true);
+
+      const hasWallet = await SignerFactory.hasWallet(testAddress);
+      expect(hasWallet).toBe(true);
+    });
+
+    it('should return false when wallet does not exist', async () => {
+      mockWalletUtils.isHardwareWallet.mockResolvedValue(false);
+      mockWalletUtils.getSafeWalletFilePath.mockReturnValue('/mock/wallet/path.json');
+      (mockFse.pathExists as jest.Mock).mockResolvedValue(false);
+
+      const hasWallet = await SignerFactory.hasWallet(testAddress);
+      expect(hasWallet).toBe(false);
+    });
+  });
+
+  describe('clearCache', () => {
+    it('should clear the keypair cache', async () => {
+      // Setup mocks
+      mockWalletUtils.getHardwareWalletByAddress.mockResolvedValue(null);
+      mockWalletUtils.getSafeWalletFilePath.mockReturnValue('/mock/wallet/path.json');
+      (mockFse.pathExists as jest.Mock).mockResolvedValue(true);
+      (mockFse.readFile as jest.Mock).mockResolvedValue(mockEncryptedWallet);
+      patch(SignerFactory as any, 'decrypt', async () => testPrivateKey);
+
+      // Get signer to populate cache
+      await SignerFactory.getSigner(testAddress);
+
+      // Clear cache
+      SignerFactory.clearCache();
+
+      // Verify cache is cleared by checking pathExists is called again
+      (mockFse.pathExists as jest.Mock).mockClear();
+      await SignerFactory.getSigner(testAddress);
+      expect(mockFse.pathExists).toHaveBeenCalled();
+    });
+  });
+});

--- a/test/connectors/meteora/clmm-routes/execute-swap.test.ts
+++ b/test/connectors/meteora/clmm-routes/execute-swap.test.ts
@@ -96,8 +96,13 @@ describe('POST /execute-swap', () => {
   });
 
   it('should execute a CLMM swap for SELL side', async () => {
+    const mockSigner = {
+      type: 'keypair',
+      address: '11111111111111111111111111111111',
+      getPublicKey: () => mockWallet.publicKey,
+    };
     const mockSolanaInstance = {
-      getWallet: jest.fn().mockResolvedValue(mockWallet),
+      getSigner: jest.fn().mockResolvedValue(mockSigner),
       getToken: jest
         .fn()
         .mockResolvedValueOnce(mockSOL)
@@ -110,8 +115,9 @@ describe('POST /execute-swap', () => {
         meta: { fee: 5000 },
         transaction: {},
       }),
-      sendAndConfirmTransaction: jest.fn().mockResolvedValue({
+      signAndSend: jest.fn().mockResolvedValue({
         signature: mockTransaction.signature,
+        confirmed: true,
         fee: 0.000005,
       }),
       connection: {
@@ -170,8 +176,13 @@ describe('POST /execute-swap', () => {
   });
 
   it('should execute a CLMM swap for BUY side', async () => {
+    const mockSigner = {
+      type: 'keypair',
+      address: '11111111111111111111111111111111',
+      getPublicKey: () => mockWallet.publicKey,
+    };
     const mockSolanaInstance = {
-      getWallet: jest.fn().mockResolvedValue(mockWallet),
+      getSigner: jest.fn().mockResolvedValue(mockSigner),
       getToken: jest
         .fn()
         .mockResolvedValueOnce(mockSOL)
@@ -184,8 +195,9 @@ describe('POST /execute-swap', () => {
         meta: { fee: 5000 },
         transaction: {},
       }),
-      sendAndConfirmTransaction: jest.fn().mockResolvedValue({
+      signAndSend: jest.fn().mockResolvedValue({
         signature: mockTransaction.signature,
+        confirmed: true,
         fee: 0.000005,
       }),
       connection: {
@@ -246,8 +258,13 @@ describe('POST /execute-swap', () => {
   });
 
   it('should return 400 if token not found', async () => {
+    const mockSigner = {
+      type: 'keypair',
+      address: '11111111111111111111111111111111',
+      getPublicKey: () => mockWallet.publicKey,
+    };
     const mockSolanaInstance = {
-      getWallet: jest.fn().mockResolvedValue(mockWallet),
+      getSigner: jest.fn().mockResolvedValue(mockSigner),
       getToken: jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(mockUSDC),
     };
     (Solana.getInstance as jest.Mock).mockResolvedValue(mockSolanaInstance);


### PR DESCRIPTION
## Summary

This PR introduces a pluggable signer abstraction layer for Solana, modeled after the [`@solana/keychain`](https://github.com/solana-foundation/solana-keychain) library patterns. The abstraction provides a unified interface for signing transactions regardless of wallet type (hot wallet, hardware wallet, or future integrations like AWS KMS).

### Relationship to @solana/keychain

The `@solana/keychain` library from the Solana Foundation provides a standardized signer abstraction for the Solana ecosystem. However, it is **not yet published to npm** and uses the new `@solana/kit` (v2) SDK which would require a significant migration from our current `@solana/web3.js` (v1) implementation.

This PR implements the **same patterns and interfaces** from `@solana/keychain-core` adapted for `@solana/web3.js` v1:

- **`SolanaSigner` interface** - Matches keychain-core's unified signer interface with `signTransactions()`, `signMessages()`, `isAvailable()`, and `address` properties
- **`SignerErrorCode` enum** - Uses `SIGNER_` prefixed codes matching keychain-core (e.g., `SIGNER_SIGNING_FAILED`, `SIGNER_NOT_AVAILABLE`)
- **Utility functions** - Implements keychain-core patterns:
  - `createSignerError()` / `throwSignerError()` - Error creation helpers
  - `isSolanaSigner()` / `assertIsSolanaSigner()` - Type guards

When `@solana/keychain` is published to npm, we can migrate to use it directly with minimal changes.

### Key Changes

- **New signer interface and implementations** (`src/chains/solana/signers/`)
  - `SolanaSigner` interface with standardized methods for signing
  - `KeypairSigner` for hot wallets (encrypted keypair files)
  - `LedgerSigner` for hardware wallets (wraps existing HardwareWalletService)
  - `SignerFactory` for automatic wallet type detection

- **Solana chain enhancements** (`src/chains/solana/solana.ts`)
  - Added `getSigner(address)` method to get appropriate signer for any wallet
  - Added `signAndSend(transaction, signer, options)` for unified transaction signing and submission
  - Support for `additionalKeypairs` option for multi-signer transactions (e.g., new position accounts)
  - Updated `getBalance` to accept `PublicKey` in addition to `Keypair`

- **Jupiter connector update** (`src/connectors/jupiter/`)
  - Added `buildUnsignedSwapTransaction()` method
  - Simplified `executeQuote` route using new signer pattern

- **Meteora connector update** (`src/connectors/meteora/clmm-routes/`)
  - Updated all CLMM routes to use signer abstraction:
    - `addLiquidity` - now supports hardware wallets
    - `removeLiquidity` - now supports hardware wallets
    - `openPosition` - now supports hardware wallets (with additionalKeypairs for position account)
    - `closePosition` - now supports hardware wallets
    - `collectFees` - now supports hardware wallets
    - `executeSwap` - now supports hardware wallets

### Benefits

1. **Wallet-agnostic signing** - Connectors don't need to check wallet type or implement separate code paths
2. **Simplified connector code** - Jupiter executeQuote reduced from ~30 lines to ~10 lines
3. **Extensible** - Easy to add AWS KMS, Fireblocks, Turnkey, Privy, or other signers in the future
4. **Unified error handling** - Consistent `SignerError` with error codes across all implementations
5. **Hardware wallet support** - All Meteora and Jupiter operations now work with Ledger devices
6. **Future-proof** - Interface compatible with `@solana/keychain` for easy migration when available

### Usage Example

```typescript
// Old pattern (connector must handle wallet types)
const isHardware = await solana.isHardwareWallet(address);
if (isHardware) {
  const tx = await connector.buildTxForHardwareWallet(...);
  const ledger = new SolanaLedger();
  tx = await ledger.signTransaction(address, tx);
  // ... send
} else {
  const wallet = await solana.getWallet(address);
  const tx = await connector.buildSwapTransaction(wallet, ...);
  // ... send
}

// New pattern (simplified)
const signer = await solana.getSigner(walletAddress);
const tx = await connector.buildUnsignedTransaction(...);
const result = await solana.signAndSend(tx, signer);

// For transactions needing additional signers (e.g., new position account)
const newPosition = new Keypair();
const result = await solana.signAndSend(tx, signer, {
  additionalKeypairs: [newPosition]
});
```

## Test plan

- [x] Run signer unit tests: `GATEWAY_TEST_MODE=dev npx jest test/chains/solana/signers/` (32 passed)
- [x] Run Jupiter connector tests: `GATEWAY_TEST_MODE=dev npx jest test/connectors/jupiter/` (25 passed)
- [x] Run Solana chain tests: `GATEWAY_TEST_MODE=dev npx jest test/chains/solana/` (102 passed)
- [x] Run Meteora connector tests: `GATEWAY_TEST_MODE=dev npx jest test/connectors/meteora/` (44 passed)
- [x] TypeScript typecheck passes
- [ ] Manual testing with hot wallet swap
- [ ] Manual testing with Ledger hardware wallet swap (if available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)