### PR TITLE
fix: rename and fix Pancakeswap routes test

### DIFF
--- a/test/connectors/pancakeswap/pancakeswap.routes.test.ts
+++ b/test/connectors/pancakeswap/pancakeswap.routes.test.ts
@@ -45,17 +45,29 @@ describe('Pancakeswap Routes Structure', () => {
 
   describe('Route Registration', () => {
     it('should register all Pancakeswap route types', async () => {
-      const routes = fastify.printRoutes();
+      // Verify routes are registered by checking they return non-404 responses
+      // (they may return 400 for missing params, but 404 means route doesn't exist)
 
-      // Check that Pancakeswap routes are registered (both EVM and Solana)
-      expect(routes).toContain('pancakeswap');
-      expect(routes).toContain('router/');
+      // Check router route
+      const routerResponse = await fastify.inject({
+        method: 'GET',
+        url: '/connectors/pancakeswap/router/quote-swap',
+      });
+      expect(routerResponse.statusCode).not.toBe(404);
 
-      // Check that Pancakeswap AMM routes are registered
-      expect(routes).toContain('amm/');
+      // Check AMM route
+      const ammResponse = await fastify.inject({
+        method: 'GET',
+        url: '/connectors/pancakeswap/amm/pool-info',
+      });
+      expect(ammResponse.statusCode).not.toBe(404);
 
-      // Check that Pancakeswap CLMM routes are registered
-      expect(routes).toContain('clmm/');
+      // Check CLMM route
+      const clmmResponse = await fastify.inject({
+        method: 'GET',
+        url: '/connectors/pancakeswap/clmm/pool-info',
+      });
+      expect(clmmResponse.statusCode).not.toBe(404);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Renamed `uniswap.routes.test.ts` to `pancakeswap.routes.test.ts` (copy-paste naming error)
- Replaced `printRoutes()` string matching with `inject()` requests to verify routes are registered

The original test failed because Fastify's `printRoutes()` uses a trie structure where common prefixes are shared. Since "pancakeswap" and "pumpswap" both start with "p", the trie shows "ancakeswap" under a shared "p" node, so `expect(routes).toContain('pancakeswap')` fails.

The new approach uses `fastify.inject()` to make actual requests to the routes, verifying they don't return 404 (route not found). This is more robust and directly tests what we care about.

## Test plan
- [x] Run `GATEWAY_TEST_MODE=dev npx jest --runInBand test/connectors/pancakeswap/pancakeswap.routes.test.ts` - passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)