### PR TITLE
fix: use Token-2022 positions for full rent recovery on close for Orca

### DIFF
--- a/src/connectors/orca/clmm-routes/closePosition.ts
+++ b/src/connectors/orca/clmm-routes/closePosition.ts
@@ -236,7 +236,9 @@ export async function closePosition(
       }),
     );
 
-    // Note: We'll extract actual fee amounts from balance changes after transaction
+    // Use collectQuote for fee amounts (derived from on-chain position data)
+    baseFeeAmountCollected = Number(collectQuote.feeOwedA) / Math.pow(10, mintA.decimals);
+    quoteFeeAmountCollected = Number(collectQuote.feeOwedB) / Math.pow(10, mintB.decimals);
   }
 
   // Step 4: Auto-unwrap WSOL to native SOL after receiving all tokens
@@ -281,52 +283,37 @@ export async function closePosition(
     }),
   );
 
+  // Calculate rent refund by querying position account balances BEFORE the TX.
+  // These accounts will be closed by the transaction, so we must read them now.
+  // This is more accurate than deriving from wallet SOL changes, which can be
+  // skewed by ephemeral wSOL wrapper create/close cycles within the same TX.
+  const LAMPORT_TO_SOL = 1e-9;
+  const positionMintPubkey = position.getData().positionMint;
+  const positionTokenAccount = getAssociatedTokenAddressSync(
+    positionMintPubkey,
+    client.getContext().wallet.publicKey,
+    undefined,
+    isToken2022 ? TOKEN_2022_PROGRAM_ID : undefined,
+  );
+  const [positionMintBalance, positionDataBalance, positionAtaBalance] = await Promise.all([
+    solana.connection.getBalance(positionMintPubkey),
+    solana.connection.getBalance(positionPubkey),
+    solana.connection.getBalance(positionTokenAccount),
+  ]);
+  const positionRentRefunded = (positionMintBalance + positionDataBalance + positionAtaBalance) * LAMPORT_TO_SOL;
+
+  logger.info(
+    `Position rent refund: mint=${positionMintBalance}, data=${positionDataBalance}, ata=${positionAtaBalance}, total=${positionRentRefunded} SOL`,
+  );
+
   // Build, simulate, and send transaction
   const txPayload = await builder.build();
   await solana.simulateWithErrorHandling(txPayload.transaction);
   const { signature, fee } = await solana.sendAndConfirmTransaction(txPayload.transaction, [wallet]);
 
-  // Extract actual amounts from balance changes (more accurate than quotes)
-  const tokenAAddress = whirlpool.getTokenAInfo().address.toString();
-  const tokenBAddress = whirlpool.getTokenBInfo().address.toString();
-  const tokenA = await solana.getToken(tokenAAddress);
-  const tokenB = await solana.getToken(tokenBAddress);
-
-  const { balanceChanges } = await solana.extractBalanceChangesAndFee(
-    signature,
-    client.getContext().wallet.publicKey.toString(),
-    [tokenAAddress, tokenBAddress],
-  );
-
-  // Total balance changes (positive values = received)
-  const totalBaseChange = Math.abs(balanceChanges[0]);
-  const totalQuoteChange = Math.abs(balanceChanges[1]);
-
-  // If we removed liquidity, use the quote estimates as basis
-  // Otherwise, all balance change is from fees
-  if (hasLiquidity) {
-    // We have estimates from decreaseQuote, but actual amounts might differ slightly
-    // Use the estimates as reference, but ensure fees aren't negative
-    baseFeeAmountCollected = Math.max(0, totalBaseChange - baseTokenAmountRemoved);
-    quoteFeeAmountCollected = Math.max(0, totalQuoteChange - quoteTokenAmountRemoved);
-
-    // If fees would be negative, it means the estimate was slightly high
-    // Adjust the liquidity removed to match actual total
-    if (totalBaseChange < baseTokenAmountRemoved) {
-      baseTokenAmountRemoved = totalBaseChange;
-      baseFeeAmountCollected = 0;
-    }
-    if (totalQuoteChange < quoteTokenAmountRemoved) {
-      quoteTokenAmountRemoved = totalQuoteChange;
-      quoteFeeAmountCollected = 0;
-    }
-  } else {
-    // No liquidity removed, all balance change is fees
-    baseFeeAmountCollected = totalBaseChange;
-    quoteFeeAmountCollected = totalQuoteChange;
-  }
-
-  const positionRentRefunded = 0.00203928;
+  // Token amounts are already set from quotes:
+  // - baseTokenAmountRemoved / quoteTokenAmountRemoved from decreaseQuote (Step 2)
+  // - baseFeeAmountCollected / quoteFeeAmountCollected from collectQuote (Step 3)
 
   return {
     signature,

--- a/src/connectors/orca/clmm-routes/executeSwap.ts
+++ b/src/connectors/orca/clmm-routes/executeSwap.ts
@@ -7,6 +7,7 @@ import {
   swapQuoteByOutputToken,
   IGNORE_CACHE,
   SwapQuote,
+  TokenExtensionUtil,
 } from '@orca-so/whirlpools-sdk';
 import { getAssociatedTokenAddressSync } from '@solana/spl-token';
 import { PublicKey } from '@solana/web3.js';
@@ -187,16 +188,34 @@ export async function executeSwap(
   // Get oracle PDA
   const oraclePda = PDAUtil.getOracle(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolPubkey);
 
-  // Add swap instruction
+  // Add swap V2 instruction (supports Token-2022 tokens)
   builder.addInstruction(
-    WhirlpoolIx.swapIx(client.getContext().program, {
+    WhirlpoolIx.swapV2Ix(client.getContext().program, {
       ...quote,
       whirlpool: whirlpoolPubkey,
       tokenAuthority: client.getContext().wallet.publicKey,
+      tokenMintA: whirlpool.getTokenAInfo().address,
+      tokenMintB: whirlpool.getTokenBInfo().address,
       tokenOwnerAccountA,
       tokenVaultA: whirlpool.getTokenVaultAInfo().address,
       tokenOwnerAccountB,
       tokenVaultB: whirlpool.getTokenVaultBInfo().address,
+      tokenProgramA: mintA.tokenProgram,
+      tokenProgramB: mintB.tokenProgram,
+      tokenTransferHookAccountsA: await TokenExtensionUtil.getExtraAccountMetasForTransferHook(
+        client.getContext().connection,
+        mintA,
+        tokenOwnerAccountA,
+        whirlpool.getTokenVaultAInfo().address,
+        client.getContext().wallet.publicKey,
+      ),
+      tokenTransferHookAccountsB: await TokenExtensionUtil.getExtraAccountMetasForTransferHook(
+        client.getContext().connection,
+        mintB,
+        tokenOwnerAccountB,
+        whirlpool.getTokenVaultBInfo().address,
+        client.getContext().wallet.publicKey,
+      ),
       oracle: oraclePda.publicKey,
     }),
   );

--- a/src/connectors/orca/clmm-routes/openPosition.ts
+++ b/src/connectors/orca/clmm-routes/openPosition.ts
@@ -12,7 +12,7 @@ import {
   IGNORE_CACHE,
 } from '@orca-so/whirlpools-sdk';
 import { Static } from '@sinclair/typebox';
-import { getAssociatedTokenAddressSync } from '@solana/spl-token';
+import { TOKEN_2022_PROGRAM_ID, getAssociatedTokenAddressSync } from '@solana/spl-token';
 import { Keypair, PublicKey } from '@solana/web3.js';
 import BN from 'bn.js';
 import { Decimal } from 'decimal.js';
@@ -135,6 +135,8 @@ async function addLiquidityInstructions(
       positionTokenAccount: getAssociatedTokenAddressSync(
         positionMintKeypair.publicKey,
         client.getContext().wallet.publicKey,
+        undefined,
+        TOKEN_2022_PROGRAM_ID,
       ),
       tokenMintA: whirlpool.getTokenAInfo().address,
       tokenMintB: whirlpool.getTokenBInfo().address,
@@ -361,23 +363,24 @@ export async function openPosition(
   const positionMintKeypair = Keypair.generate();
   const positionPda = PDAUtil.getPosition(ORCA_WHIRLPOOL_PROGRAM_ID, positionMintKeypair.publicKey);
 
-  // Always use TOKEN_PROGRAM with metadata (standard Orca positions)
-  // Position NFT token program is independent of pool's token programs
-  const metadataPda = PDAUtil.getPositionMetadata(positionMintKeypair.publicKey);
+  // Use Token-2022 position mint (embeds metadata in the mint account itself)
+  // This ensures all rent is fully refundable on close (fixes #584)
   builder.addInstruction(
-    WhirlpoolIx.openPositionWithMetadataIx(client.getContext().program, {
+    WhirlpoolIx.openPositionWithTokenExtensionsIx(client.getContext().program, {
       funder: client.getContext().wallet.publicKey,
       whirlpool: whirlpoolPubkey,
       tickLowerIndex: lowerTickIndex,
       tickUpperIndex: upperTickIndex,
       owner: client.getContext().wallet.publicKey,
-      positionMintAddress: positionMintKeypair.publicKey,
+      positionMint: positionMintKeypair.publicKey,
       positionPda,
       positionTokenAccount: getAssociatedTokenAddressSync(
         positionMintKeypair.publicKey,
         client.getContext().wallet.publicKey,
+        undefined,
+        TOKEN_2022_PROGRAM_ID,
       ),
-      metadataPda,
+      withTokenMetadataExtension: true,
     }),
   );
 
@@ -446,7 +449,26 @@ export async function openPosition(
     positionMintKeypair,
   ]);
 
-  const positionRent = 0.00203928; // Standard position account rent
+  // Calculate rent by querying the actual SOL balances of position accounts.
+  // This is more accurate than deriving from wallet SOL changes, which can be
+  // skewed by ephemeral wSOL wrapper create/close cycles within the same TX.
+  const LAMPORT_TO_SOL = 1e-9;
+  const positionTokenAccount = getAssociatedTokenAddressSync(
+    positionMintKeypair.publicKey,
+    client.getContext().wallet.publicKey,
+    undefined,
+    TOKEN_2022_PROGRAM_ID,
+  );
+  const [positionMintBalance, positionDataBalance, positionAtaBalance] = await Promise.all([
+    solana.connection.getBalance(positionMintKeypair.publicKey),
+    solana.connection.getBalance(positionPda.publicKey),
+    solana.connection.getBalance(positionTokenAccount),
+  ]);
+  const positionRent = (positionMintBalance + positionDataBalance + positionAtaBalance) * LAMPORT_TO_SOL;
+
+  logger.info(
+    `Position rent: mint=${positionMintBalance}, data=${positionDataBalance}, ata=${positionAtaBalance}, total=${positionRent} SOL`,
+  );
 
   if (shouldAddLiquidity) {
     logger.info(

--- a/test/connectors/orca/clmm-routes/executeSwap.test.ts
+++ b/test/connectors/orca/clmm-routes/executeSwap.test.ts
@@ -18,11 +18,14 @@ jest.mock('@orca-so/whirlpools-sdk', () => ({
     getOracle: jest.fn().mockReturnValue({ publicKey: 'oracle-pubkey' }),
   },
   WhirlpoolIx: {
-    swapIx: jest.fn().mockReturnValue({
+    swapV2Ix: jest.fn().mockReturnValue({
       instructions: [],
       cleanupInstructions: [],
       signers: [],
     }),
+  },
+  TokenExtensionUtil: {
+    getExtraAccountMetasForTransferHook: jest.fn().mockResolvedValue([]),
   },
   IGNORE_CACHE: true,
 }));

--- a/test/connectors/orca/clmm-routes/openPosition.test.ts
+++ b/test/connectors/orca/clmm-routes/openPosition.test.ts
@@ -19,12 +19,12 @@ jest.mock('@orca-so/whirlpools-sdk', () => ({
     priceToTickIndex: jest.fn().mockReturnValue(-28800),
   },
   WhirlpoolIx: {
-    openPositionIx: jest.fn().mockReturnValue({
+    openPositionWithTokenExtensionsIx: jest.fn().mockReturnValue({
       instructions: [],
       cleanupInstructions: [],
       signers: [],
     }),
-    increaseLiquidityIx: jest.fn().mockReturnValue({
+    increaseLiquidityV2Ix: jest.fn().mockReturnValue({
       instructions: [],
       cleanupInstructions: [],
       signers: [],
@@ -42,8 +42,10 @@ jest.mock('@orca-so/whirlpools-sdk', () => ({
   }),
   TokenExtensionUtil: {
     isV2IxRequiredPool: jest.fn().mockReturnValue(false),
+    buildTokenExtensionContext: jest.fn().mockResolvedValue({}),
   },
   ORCA_WHIRLPOOL_PROGRAM_ID: 'whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc',
+  IGNORE_CACHE: true,
 }));
 jest.mock('@orca-so/common-sdk', () => ({
   Percentage: {
@@ -103,6 +105,9 @@ describe('POST /open-position', () => {
         signature: 'test-signature',
         fee: 0.000005,
       }),
+      connection: {
+        getBalance: jest.fn().mockResolvedValue(2039280), // ~0.00204 SOL rent per account
+      },
     };
     (Solana.getInstance as jest.Mock).mockResolvedValue(mockSolana);
 


### PR DESCRIPTION
## Summary

Fixes #584 — Orca CLMM positions now use Token-2022 instructions instead of Metaplex, enabling full rent recovery when positions are closed.

**Problem:** The old Metaplex-based `openPositionWithMetadataIx` creates a mint account that cannot be closed. On position close, only the position data PDA and token ATA rent could be reclaimed (~0.006 SOL), but the mint account rent (~0.004 SOL) was permanently locked. This meant ~$1.89 was spent opening a position but only ~$0.74 was returned on close.

**Solution:** Switch to Token-2022's `openPositionWithTokenExtensionsIx` which creates mints with `MintCloseAuthority` extension, making all 3 position accounts (mint, PDA, ATA) fully reclaimable on close.

## Changes

### `openPosition.ts`
- Replaced `openPositionWithMetadataIx` (Metaplex) with `openPositionWithTokenExtensionsIx` (Token-2022)
- Position token account now derives with `TOKEN_2022_PROGRAM_ID`
- Rent calculation uses direct `getBalance()` queries on the 3 position accounts instead of unreliable wallet SOL change extraction

### `executeSwap.ts`
- Replaced `WhirlpoolIx.swapIx` with `WhirlpoolIx.swapV2Ix` for Token-2022 compatibility

### `closePosition.ts`
- Rent refund calculation uses direct `getBalance()` queries on position accounts before the close TX (while accounts still exist)
- Fee amounts use `collectFeesQuote` from on-chain position data instead of post-TX wallet SOL change extraction
- Already had `closePositionWithTokenExtensionsIx` (backward compatible with legacy via `isToken2022` check)

### Tests
- Updated `openPosition.test.ts`: mock `connection.getBalance` instead of `extractBalanceChangesAndFee`
- Updated `executeSwap.test.ts`: mock `swapV2Ix` instead of `swapIx`
