### PR TITLE
fix/ auto-update default wallet when deleted wallet was the default

### DIFF
--- a/src/wallet/routes/removeWallet.ts
+++ b/src/wallet/routes/removeWallet.ts
@@ -4,6 +4,7 @@ import { FastifyPluginAsync } from 'fastify';
 
 import { Ethereum } from '../../chains/ethereum/ethereum';
 import { Solana } from '../../chains/solana/solana';
+import { ConfigManagerV2 } from '../../services/config-manager-v2';
 import { logger } from '../../services/logger';
 import {
   RemoveWalletRequest,
@@ -11,7 +12,14 @@ import {
   RemoveWalletRequestSchema,
   RemoveWalletResponseSchema,
 } from '../schemas';
-import { removeWallet, validateChainName, isHardwareWallet, getHardwareWallets, saveHardwareWallets } from '../utils';
+import {
+  removeWallet,
+  validateChainName,
+  isHardwareWallet,
+  getHardwareWallets,
+  saveHardwareWallets,
+  getAllWalletAddressesForChain,
+} from '../utils';
 
 export const removeWalletRoute: FastifyPluginAsync = async (fastify) => {
   await fastify.register(sensible);
@@ -50,6 +58,12 @@ export const removeWalletRoute: FastifyPluginAsync = async (fastify) => {
       if (await isHardwareWallet(chain, validatedAddress)) {
         logger.info(`Removing hardware wallet: ${validatedAddress} from chain: ${chain}`);
 
+        // Check if this is the default wallet before removing
+        const chainLower = chain.toLowerCase();
+        const currentDefaultWallet = ConfigManagerV2.getInstance().get(`${chainLower}.defaultWallet`);
+        const isDefaultWallet =
+          currentDefaultWallet && currentDefaultWallet.toLowerCase() === validatedAddress.toLowerCase();
+
         const wallets = await getHardwareWallets(chain);
         const index = wallets.findIndex((w) => w.address === validatedAddress);
         if (index === -1) {
@@ -58,6 +72,23 @@ export const removeWalletRoute: FastifyPluginAsync = async (fastify) => {
 
         wallets.splice(index, 1);
         await saveHardwareWallets(chain, wallets);
+
+        // If the deleted wallet was the default, update the default wallet
+        if (isDefaultWallet) {
+          // Get all remaining wallet addresses (both regular and hardware)
+          const remainingAddresses = await getAllWalletAddressesForChain(chain);
+
+          if (remainingAddresses.length > 0) {
+            // Set the first remaining wallet as the new default
+            const newDefaultWallet = remainingAddresses[0];
+            ConfigManagerV2.getInstance().set(`${chainLower}.defaultWallet`, newDefaultWallet);
+            logger.info(`Set new default wallet for ${chainLower}: ${newDefaultWallet}`);
+          } else {
+            // No wallets remaining, clear the default wallet
+            ConfigManagerV2.getInstance().set(`${chainLower}.defaultWallet`, '');
+            logger.info(`Cleared default wallet for ${chainLower} (no wallets remaining)`);
+          }
+        }
 
         return {
           message: `Hardware wallet ${validatedAddress} removed successfully`,

--- a/src/wallet/utils.ts
+++ b/src/wallet/utils.ts
@@ -16,6 +16,7 @@ import { Ethereum } from '../chains/ethereum/ethereum';
 import { Solana } from '../chains/solana/solana';
 import { updateDefaultWallet } from '../config/utils';
 import { ConfigManagerCertPassphrase } from '../services/config-manager-cert-passphrase';
+import { ConfigManagerV2 } from '../services/config-manager-v2';
 import {
   getInitializedChain,
   UnsupportedChainException,
@@ -177,12 +178,35 @@ export async function removeWallet(fastify: FastifyInstance, req: RemoveWalletRe
       throw new Error(`Unsupported chain: ${req.chain}`);
     }
 
+    // Check if this is the default wallet before removing
+    const chainLower = req.chain.toLowerCase();
+    const currentDefaultWallet = ConfigManagerV2.getInstance().get(`${chainLower}.defaultWallet`);
+    const isDefaultWallet =
+      currentDefaultWallet && currentDefaultWallet.toLowerCase() === validatedAddress.toLowerCase();
+
     // Create safe file path
-    const safeChain = sanitizePathComponent(req.chain.toLowerCase());
+    const safeChain = sanitizePathComponent(chainLower);
     const safeAddress = sanitizePathComponent(validatedAddress);
 
     // Remove file
     await fse.remove(`${walletPath}/${safeChain}/${safeAddress}.json`);
+
+    // If the deleted wallet was the default, update the default wallet
+    if (isDefaultWallet) {
+      // Get all remaining wallet addresses (both regular and hardware)
+      const remainingAddresses = await getAllWalletAddressesForChain(chainLower);
+
+      if (remainingAddresses.length > 0) {
+        // Set the first remaining wallet as the new default
+        const newDefaultWallet = remainingAddresses[0];
+        ConfigManagerV2.getInstance().set(`${chainLower}.defaultWallet`, newDefaultWallet);
+        logger.info(`Set new default wallet for ${chainLower}: ${newDefaultWallet}`);
+      } else {
+        // No wallets remaining, clear the default wallet
+        ConfigManagerV2.getInstance().set(`${chainLower}.defaultWallet`, '');
+        logger.info(`Cleared default wallet for ${chainLower} (no wallets remaining)`);
+      }
+    }
   } catch (error) {
     if (error.message.includes('Invalid') || error.message.includes('Unrecognized')) {
       throw fastify.httpErrors.badRequest(error.message);
@@ -347,6 +371,37 @@ export async function getHardwareWallets(chain: string): Promise<HardwareWalletD
 export async function getHardwareWalletAddresses(chain: string): Promise<string[]> {
   const wallets = await getHardwareWallets(chain);
   return wallets.map((w) => w.address);
+}
+
+/**
+ * Get all wallet addresses for a chain (both regular and hardware wallets)
+ */
+export async function getAllWalletAddressesForChain(chain: string): Promise<string[]> {
+  const chainLower = chain.toLowerCase();
+  const safeChain = sanitizePathComponent(chainLower);
+
+  // Get regular wallet addresses
+  const walletFiles = await getJsonFiles(`${walletPath}/${safeChain}`);
+  const regularAddresses = walletFiles
+    .map((file) => file.replace('.json', ''))
+    .filter((address) => {
+      // Validate addresses based on chain type
+      try {
+        if (chainLower === 'ethereum') {
+          return /^0x[a-fA-F0-9]{40}$/i.test(address);
+        } else if (chainLower === 'solana') {
+          return address.length >= 32 && address.length <= 44;
+        }
+        return false;
+      } catch {
+        return false;
+      }
+    });
+
+  // Get hardware wallet addresses
+  const hardwareAddresses = await getHardwareWalletAddresses(chain);
+
+  return [...regularAddresses, ...hardwareAddresses];
 }
 
 export async function saveHardwareWallets(chain: string, wallets: HardwareWalletData[]): Promise<void> {


### PR DESCRIPTION
## Summary
- When a wallet is deleted that was set as the default for a chain, the system now automatically selects another available wallet as the new default
- If no wallets remain for the chain, the default wallet is cleared (set to empty string)
- This prevents "Wallet not found" errors during balance polling when the default wallet no longer exists

## Test plan
- [x] Delete a non-default wallet → default should remain unchanged
- [x] Delete the default wallet when other wallets exist → another wallet should become the new default
- [x] Delete the default wallet when no other wallets exist → default should be cleared
- [ ] Verify balance polling works after deleting the default wallet

🤖 Generated with [Claude Code](https://claude.com/claude-code)