### PR TITLE
refactor / replace axios with native fetch for HTTP requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "@uniswap/v4-sdk": "^1.21.4",
     "ajv": "^8.17.1",
     "app-root-path": "^3.1.0",
-    "axios": "^1.12.0",
     "bigint-buffer": "1.1.5",
     "bn.js": "5.2.1",
     "brotli": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,9 +178,6 @@ importers:
       app-root-path:
         specifier: ^3.1.0
         version: 3.1.0
-      axios:
-        specifier: ^1.8.4
-        version: 1.12.0(debug@4.4.0)
       bigint-buffer:
         specifier: 1.1.5
         version: 1.1.5

--- a/src/chains/ethereum/etherscan-service.ts
+++ b/src/chains/ethereum/etherscan-service.ts
@@ -1,5 +1,4 @@
-import axios from 'axios';
-
+import { httpGet, HttpClientError } from '../../services/http-client';
 import { logger } from '../../services/logger';
 
 /**
@@ -91,7 +90,7 @@ export class EtherscanService {
         `Request params: ${JSON.stringify({ chainid: this.chainId, module: 'gastracker', action: 'gasoracle', apikey: '***' })}`,
       );
 
-      const response = await axios.get<EtherscanGasOracleResponse>(EtherscanService.BASE_URL, {
+      const response = await httpGet<EtherscanGasOracleResponse>(EtherscanService.BASE_URL, {
         params,
         timeout: 5000,
       });
@@ -119,11 +118,13 @@ export class EtherscanService {
 
       return gasData;
     } catch (error: any) {
-      if (error.response?.status === 401) {
-        throw new Error('Invalid Etherscan API key');
-      }
-      if (error.code === 'ECONNABORTED' || error.code === 'ETIMEDOUT') {
-        throw new Error('Etherscan API request timeout');
+      if (error instanceof HttpClientError) {
+        if (error.response?.status === 401) {
+          throw new Error('Invalid Etherscan API key');
+        }
+        if (error.code === 'ECONNABORTED') {
+          throw new Error('Etherscan API request timeout');
+        }
       }
       throw new Error(`Failed to fetch gas data from Etherscan: ${error.message}`);
     }

--- a/src/connectors/0x/0x.ts
+++ b/src/connectors/0x/0x.ts
@@ -1,8 +1,8 @@
-import axios, { AxiosInstance } from 'axios';
 import { BigNumber } from 'ethers';
 
 import { Ethereum } from '../../chains/ethereum/ethereum';
 import { ConfigManagerV2 } from '../../services/config-manager-v2';
+import { createHttpClient, HttpClient, HttpClientError } from '../../services/http-client';
 import { logger } from '../../services/logger';
 
 import { ZeroXConfig } from './0x.config';
@@ -57,7 +57,7 @@ export interface ZeroXQuoteResponse extends ZeroXPriceResponse {
 
 export class ZeroX {
   private static instances: Map<string, ZeroX> = new Map();
-  private client: AxiosInstance;
+  private client: HttpClient;
   private apiKey: string;
   private _slippagePct: number;
 
@@ -76,7 +76,7 @@ export class ZeroX {
 
     const apiEndpoint = ZeroXConfig.getApiEndpoint(network);
 
-    this.client = axios.create({
+    this.client = createHttpClient({
       baseURL: apiEndpoint,
       timeout: ConfigManagerV2.getInstance().get('0x.requestTimeout') || 30000,
       headers: {
@@ -84,26 +84,8 @@ export class ZeroX {
         '0x-version': 'v2',
         'Content-Type': 'application/json',
       },
+      enableLogging: ConfigManagerV2.getInstance().get('0x.enableLogging'),
     });
-
-    // Add request/response logging if enabled
-    if (ConfigManagerV2.getInstance().get('0x.enableLogging')) {
-      this.client.interceptors.request.use((config) => {
-        logger.debug(`0x API Request: ${config.method} ${config.url}`);
-        return config;
-      });
-
-      this.client.interceptors.response.use(
-        (response) => {
-          logger.debug(`0x API Response: ${response.status}`);
-          return response;
-        },
-        (error) => {
-          logger.error(`0x API Error: ${error.message}`);
-          return Promise.reject(error);
-        },
-      );
-    }
   }
 
   public static async getInstance(network: string): Promise<ZeroX> {
@@ -151,7 +133,7 @@ export class ZeroX {
 
       return response.data;
     } catch (error: any) {
-      if (error.response?.data) {
+      if (error instanceof HttpClientError && error.response?.data) {
         logger.error(`0x API Error Response: ${JSON.stringify(error.response.data)}`);
         throw new Error(
           `0x API Error: ${error.response.data.reason || error.response.data.message || JSON.stringify(error.response.data)}`,
@@ -195,7 +177,7 @@ export class ZeroX {
 
       return response.data;
     } catch (error: any) {
-      if (error.response?.data) {
+      if (error instanceof HttpClientError && error.response?.data) {
         logger.error(`0x API Error Response: ${JSON.stringify(error.response.data)}`);
         throw new Error(
           `0x API Error: ${error.response.data.reason || error.response.data.message || JSON.stringify(error.response.data)}`,

--- a/src/connectors/jupiter/jupiter.ts
+++ b/src/connectors/jupiter/jupiter.ts
@@ -1,9 +1,9 @@
 import { Wallet } from '@coral-xyz/anchor';
 import { VersionedTransaction } from '@solana/web3.js';
-import axios, { AxiosInstance } from 'axios';
 
 import { Solana } from '../../chains/solana/solana';
 import { getSolanaNetworkConfig } from '../../chains/solana/solana.config';
+import { createHttpClient, HttpClient, HttpClientError } from '../../services/http-client';
 import { logger } from '../../services/logger';
 
 import { JupiterConfig } from './jupiter.config';
@@ -37,7 +37,7 @@ export class Jupiter {
   private static _instances: { [name: string]: Jupiter };
   private solana: Solana;
   public config: JupiterConfig.RootConfig;
-  private httpClient: AxiosInstance;
+  private httpClient: HttpClient;
 
   private constructor() {
     this.config = JupiterConfig.config;
@@ -63,7 +63,7 @@ export class Jupiter {
       );
     }
 
-    this.httpClient = axios.create({
+    this.httpClient = createHttpClient({
       baseURL,
       timeout: 30000,
       headers,
@@ -135,7 +135,8 @@ export class Jupiter {
     const quoteAmount = Math.floor(amount * 10 ** tokenDecimals);
 
     // Build query parameters for the REST API
-    const params = new URLSearchParams({
+    // Note: maxAccounts parameter has been deprecated
+    const params = {
       inputMint: inputToken.address,
       outputMint: outputToken.address,
       amount: quoteAmount.toString(),
@@ -143,17 +144,12 @@ export class Jupiter {
       swapMode: swapMode,
       onlyDirectRoutes: onlyDirectRoutes.toString(),
       restrictIntermediateTokens: restrictIntermediateTokens.toString(),
-    });
+    };
 
-    // Note: maxAccounts parameter has been deprecated
-
-    logger.debug(
-      `Getting Jupiter quote for ${inputToken.symbol} to ${outputToken.symbol} with params:`,
-      Object.fromEntries(params),
-    );
+    logger.debug(`Getting Jupiter quote for ${inputToken.symbol} to ${outputToken.symbol} with params:`, params);
 
     try {
-      const response = await this.httpClient.get('/swap/v1/quote', { params });
+      const response = await this.httpClient.get<QuoteResponse>('/swap/v1/quote', { params });
       const quote = response.data;
 
       if (!quote) {
@@ -164,29 +160,30 @@ export class Jupiter {
       logger.debug('Got Jupiter quote:', quote);
       return quote;
     } catch (error) {
-      const axiosError = error as any; // Type assertion for axios error
-      logger.error('Jupiter API error:', axiosError.message);
-      if (axiosError.response?.data) {
-        logger.error('Jupiter API error response:', axiosError.response.data);
+      if (error instanceof HttpClientError) {
+        logger.error('Jupiter API error:', error.message);
+        if (error.response?.data) {
+          logger.error('Jupiter API error response:', error.response.data);
 
-        // Handle specific error messages
-        if (typeof axiosError.response.data === 'string') {
-          if (axiosError.response.data === 'Route not found') {
+          // Handle specific error messages
+          if (typeof error.response.data === 'string') {
+            if (error.response.data === 'Route not found') {
+              if (swapMode === 'ExactOut') {
+                throw new Error('ExactOut not supported for this token pair');
+              } else {
+                throw new Error('No route found for this token pair');
+              }
+            }
+            throw new Error(`Jupiter API error: ${error.response.data}`);
+          } else if (error.response.data.errorCode === 'COULD_NOT_FIND_ANY_ROUTE') {
             if (swapMode === 'ExactOut') {
               throw new Error('ExactOut not supported for this token pair');
             } else {
               throw new Error('No route found for this token pair');
             }
+          } else if (error.response.data.error) {
+            throw new Error(`Jupiter API error: ${error.response.data.error}`);
           }
-          throw new Error(`Jupiter API error: ${axiosError.response.data}`);
-        } else if (axiosError.response.data.errorCode === 'COULD_NOT_FIND_ANY_ROUTE') {
-          if (swapMode === 'ExactOut') {
-            throw new Error('ExactOut not supported for this token pair');
-          } else {
-            throw new Error('No route found for this token pair');
-          }
-        } else if (axiosError.response.data.error) {
-          throw new Error(`Jupiter API error: ${axiosError.response.data.error}`);
         }
       }
       throw error;
@@ -235,22 +232,20 @@ export class Jupiter {
           },
         };
 
-        const response = await this.httpClient.post('/swap/v1/swap', swapRequest);
+        const response = await this.httpClient.post<SwapResponse>('/swap/v1/swap', swapRequest);
         swapObj = response.data;
         break; // Success, exit the retry loop
       } catch (error) {
-        const axiosError = error as any; // Type assertion for axios error
-        lastError = axiosError;
-        logger.error(
-          `Fetching swap object attempt ${attempt}/${retryCount} failed:`,
-          axiosError.response?.status
-            ? {
-                error: axiosError.message,
-                status: axiosError.response.status,
-                data: axiosError.response.data,
-              }
-            : axiosError,
-        );
+        lastError = error instanceof Error ? error : new Error(String(error));
+        if (error instanceof HttpClientError) {
+          logger.error(`Fetching swap object attempt ${attempt}/${retryCount} failed:`, {
+            error: error.message,
+            status: error.response?.status,
+            data: error.response?.data,
+          });
+        } else {
+          logger.error(`Fetching swap object attempt ${attempt}/${retryCount} failed:`, error);
+        }
 
         if (attempt < retryCount) {
           logger.info(`Waiting ${retryInterval}ms before retry...`);
@@ -316,22 +311,20 @@ export class Jupiter {
           },
         };
 
-        const response = await this.httpClient.post('/swap/v1/swap', swapRequest);
+        const response = await this.httpClient.post<SwapResponse>('/swap/v1/swap', swapRequest);
         swapObj = response.data;
         break; // Success, exit the retry loop
       } catch (error) {
-        const axiosError = error as any;
-        lastError = axiosError;
-        logger.error(
-          `Fetching swap object attempt ${attempt}/${retryCount} failed:`,
-          axiosError.response?.status
-            ? {
-                error: axiosError.message,
-                status: axiosError.response.status,
-                data: axiosError.response.data,
-              }
-            : axiosError,
-        );
+        lastError = error instanceof Error ? error : new Error(String(error));
+        if (error instanceof HttpClientError) {
+          logger.error(`Fetching swap object attempt ${attempt}/${retryCount} failed:`, {
+            error: error.message,
+            status: error.response?.status,
+            data: error.response?.data,
+          });
+        } else {
+          logger.error(`Fetching swap object attempt ${attempt}/${retryCount} failed:`, error);
+        }
 
         if (attempt < retryCount) {
           logger.info(`Waiting ${retryInterval}ms before retry...`);

--- a/src/services/coingecko-service.ts
+++ b/src/services/coingecko-service.ts
@@ -1,6 +1,5 @@
-import axios, { AxiosInstance } from 'axios';
-
 import { ConfigManagerV2 } from './config-manager-v2';
+import { createHttpClient, HttpClient, HttpClientError } from './http-client';
 import { logger } from './logger';
 
 /**
@@ -216,7 +215,7 @@ export interface GeckoTerminalTokenInfo {
  */
 export class CoinGeckoService {
   private static instance: CoinGeckoService;
-  private client: AxiosInstance;
+  private client: HttpClient;
   private apiKey: string | undefined;
   private baseURL = 'https://api.geckoterminal.com/api/v2';
 
@@ -224,7 +223,7 @@ export class CoinGeckoService {
     const configManager = ConfigManagerV2.getInstance();
     this.apiKey = configManager.get('apiKeys.coingecko');
 
-    this.client = axios.create({
+    this.client = createHttpClient({
       baseURL: this.baseURL,
       timeout: 30000,
       headers: {
@@ -409,7 +408,7 @@ export class CoinGeckoService {
 
       return pools;
     } catch (error: any) {
-      if (error.response?.status === 404) {
+      if (error instanceof HttpClientError && error.response?.status === 404) {
         logger.warn(`Token ${tokenAddress} not found on ${chainNetwork}`);
         return [];
       }
@@ -484,7 +483,7 @@ export class CoinGeckoService {
 
       return pools;
     } catch (error: any) {
-      if (error.response?.status === 404) {
+      if (error instanceof HttpClientError && error.response?.status === 404) {
         logger.warn(`Network ${chainNetwork} not found`);
         return [];
       }
@@ -568,7 +567,7 @@ export class CoinGeckoService {
           : undefined,
       };
     } catch (error: any) {
-      if (error.response?.status === 404) {
+      if (error instanceof HttpClientError && error.response?.status === 404) {
         throw new Error(`Token ${tokenAddress} not found on ${chainNetwork}`);
       }
 
@@ -674,7 +673,7 @@ export class CoinGeckoService {
         topPools,
       };
     } catch (error: any) {
-      if (error.response?.status === 404) {
+      if (error instanceof HttpClientError && error.response?.status === 404) {
         throw new Error(`Token ${tokenAddress} not found on ${chainNetwork}`);
       }
 
@@ -708,7 +707,7 @@ export class CoinGeckoService {
       const pool = response.data.data;
       return this.transformPool(pool);
     } catch (error: any) {
-      if (error.response?.status === 404) {
+      if (error instanceof HttpClientError && error.response?.status === 404) {
         throw new Error(`Pool ${poolAddress} not found on ${chainNetwork}`);
       }
 

--- a/src/services/http-client.ts
+++ b/src/services/http-client.ts
@@ -1,0 +1,260 @@
+import { logger } from './logger';
+
+/**
+ * HTTP client options for creating a client instance
+ */
+export interface HttpClientOptions {
+  baseURL: string;
+  timeout?: number;
+  headers?: Record<string, string>;
+  enableLogging?: boolean;
+}
+
+/**
+ * Request options for individual requests
+ */
+export interface RequestOptions {
+  params?: Record<string, string | number | boolean>;
+  headers?: Record<string, string>;
+  timeout?: number;
+}
+
+/**
+ * HTTP response wrapper
+ */
+export interface HttpResponse<T> {
+  data: T;
+  status: number;
+  statusText: string;
+}
+
+/**
+ * HTTP error with response details
+ */
+export class HttpClientError extends Error {
+  public status?: number;
+  public statusText?: string;
+  public data?: any;
+  public code?: string;
+
+  constructor(
+    message: string,
+    options?: {
+      status?: number;
+      statusText?: string;
+      data?: any;
+      code?: string;
+    },
+  ) {
+    super(message);
+    this.name = 'HttpClientError';
+    this.status = options?.status;
+    this.statusText = options?.statusText;
+    this.data = options?.data;
+    this.code = options?.code;
+  }
+
+  /**
+   * Get the response object in axios-compatible format
+   */
+  get response() {
+    if (this.status !== undefined) {
+      return {
+        status: this.status,
+        statusText: this.statusText,
+        data: this.data,
+      };
+    }
+    return undefined;
+  }
+}
+
+/**
+ * Lightweight HTTP client using native fetch
+ * Drop-in replacement for axios with similar API
+ */
+export class HttpClient {
+  private baseURL: string;
+  private timeout: number;
+  private defaultHeaders: Record<string, string>;
+  private enableLogging: boolean;
+
+  constructor(options: HttpClientOptions) {
+    this.baseURL = options.baseURL.replace(/\/$/, ''); // Remove trailing slash
+    this.timeout = options.timeout ?? 30000;
+    this.defaultHeaders = options.headers ?? {};
+    this.enableLogging = options.enableLogging ?? false;
+  }
+
+  /**
+   * Build URL with query parameters
+   */
+  private buildUrl(path: string, params?: Record<string, string | number | boolean>): string {
+    const url = new URL(path.startsWith('http') ? path : `${this.baseURL}${path}`);
+    if (params) {
+      Object.entries(params).forEach(([key, value]) => {
+        url.searchParams.append(key, String(value));
+      });
+    }
+    return url.toString();
+  }
+
+  /**
+   * Execute a fetch request with timeout
+   */
+  private async request<T>(
+    method: string,
+    path: string,
+    options?: RequestOptions & { body?: any },
+  ): Promise<HttpResponse<T>> {
+    const url = this.buildUrl(path, options?.params);
+    const timeout = options?.timeout ?? this.timeout;
+
+    const headers = {
+      ...this.defaultHeaders,
+      ...options?.headers,
+    };
+
+    if (this.enableLogging) {
+      logger.debug(`HTTP ${method} ${url}`);
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+    try {
+      const fetchOptions: RequestInit = {
+        method,
+        headers,
+        signal: controller.signal,
+      };
+
+      if (options?.body !== undefined) {
+        fetchOptions.body = JSON.stringify(options.body);
+        if (!headers['Content-Type']) {
+          headers['Content-Type'] = 'application/json';
+        }
+      }
+
+      const response = await fetch(url, fetchOptions);
+
+      if (this.enableLogging) {
+        logger.debug(`HTTP Response: ${response.status}`);
+      }
+
+      // Parse response body
+      const contentType = response.headers.get('content-type');
+      let data: any;
+      if (contentType?.includes('application/json')) {
+        data = await response.json();
+      } else {
+        const text = await response.text();
+        // Try to parse as JSON anyway (some APIs don't set content-type correctly)
+        try {
+          data = JSON.parse(text);
+        } catch {
+          data = text;
+        }
+      }
+
+      // Throw error for non-2xx status codes (matching axios behavior)
+      if (!response.ok) {
+        throw new HttpClientError(`Request failed with status ${response.status}`, {
+          status: response.status,
+          statusText: response.statusText,
+          data,
+        });
+      }
+
+      return {
+        data,
+        status: response.status,
+        statusText: response.statusText,
+      };
+    } catch (error: any) {
+      if (error instanceof HttpClientError) {
+        throw error;
+      }
+
+      if (error.name === 'AbortError') {
+        const timeoutError = new HttpClientError(`Request timeout after ${timeout}ms`);
+        timeoutError.code = 'ECONNABORTED';
+        throw timeoutError;
+      }
+
+      // Network errors
+      const networkError = new HttpClientError(error.message);
+      networkError.code = 'ENETWORK';
+      throw networkError;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * GET request
+   */
+  async get<T>(path: string, options?: RequestOptions): Promise<HttpResponse<T>> {
+    return this.request<T>('GET', path, options);
+  }
+
+  /**
+   * POST request
+   */
+  async post<T>(path: string, data?: any, options?: RequestOptions): Promise<HttpResponse<T>> {
+    return this.request<T>('POST', path, { ...options, body: data });
+  }
+
+  /**
+   * PUT request
+   */
+  async put<T>(path: string, data?: any, options?: RequestOptions): Promise<HttpResponse<T>> {
+    return this.request<T>('PUT', path, { ...options, body: data });
+  }
+
+  /**
+   * DELETE request
+   */
+  async delete<T>(path: string, options?: RequestOptions): Promise<HttpResponse<T>> {
+    return this.request<T>('DELETE', path, options);
+  }
+}
+
+/**
+ * Create a new HTTP client instance
+ * Equivalent to axios.create()
+ */
+export function createHttpClient(options: HttpClientOptions): HttpClient {
+  return new HttpClient(options);
+}
+
+/**
+ * Simple one-off GET request (equivalent to axios.get)
+ */
+export async function httpGet<T>(
+  url: string,
+  options?: RequestOptions & { timeout?: number },
+): Promise<HttpResponse<T>> {
+  const client = new HttpClient({
+    baseURL: '',
+    timeout: options?.timeout,
+    headers: options?.headers,
+  });
+  return client.get<T>(url, options);
+}
+
+/**
+ * Simple one-off POST request (equivalent to axios.post)
+ */
+export async function httpPost<T>(
+  url: string,
+  data?: any,
+  options?: RequestOptions & { timeout?: number },
+): Promise<HttpResponse<T>> {
+  const client = new HttpClient({
+    baseURL: '',
+    timeout: options?.timeout,
+    headers: options?.headers,
+  });
+  return client.post<T>(url, data, options);
+}

--- a/test/chains/ethereum/etherscan-service.test.ts
+++ b/test/chains/ethereum/etherscan-service.test.ts
@@ -1,9 +1,16 @@
-import axios from 'axios';
-
 import { EtherscanService } from '../../../src/chains/ethereum/etherscan-service';
+import { HttpClientError, httpGet } from '../../../src/services/http-client';
 
-jest.mock('axios');
-const mockedAxios = axios as jest.Mocked<typeof axios>;
+// Mock only the httpGet function, keep other exports (like HttpClientError)
+jest.mock('../../../src/services/http-client', () => {
+  const actual = jest.requireActual('../../../src/services/http-client');
+  return {
+    ...actual,
+    httpGet: jest.fn(),
+  };
+});
+
+const mockedHttpGet = httpGet as jest.MockedFunction<typeof httpGet>;
 
 describe('EtherscanService', () => {
   let etherscanService: EtherscanService;
@@ -82,9 +89,11 @@ describe('EtherscanService', () => {
             gasUsedRatio: '0.435419730941365,0.0126618899438999',
           },
         },
+        status: 200,
+        statusText: 'OK',
       };
 
-      mockedAxios.get.mockResolvedValue(mockResponse);
+      mockedHttpGet.mockResolvedValue(mockResponse);
 
       const result = await etherscanService.getGasOracle();
 
@@ -95,7 +104,7 @@ describe('EtherscanService', () => {
         priorityFeeFast: 0.32341308,
       });
 
-      expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect(mockedHttpGet).toHaveBeenCalledWith(
         'https://api.etherscan.io/v2/api',
         expect.objectContaining({
           params: {
@@ -116,9 +125,11 @@ describe('EtherscanService', () => {
           message: 'NOTOK',
           result: 'Error! Invalid API key',
         },
+        status: 200,
+        statusText: 'OK',
       };
 
-      mockedAxios.get.mockResolvedValue(mockResponse);
+      mockedHttpGet.mockResolvedValue(mockResponse);
 
       await expect(etherscanService.getGasOracle()).rejects.toThrow(
         'Failed to fetch gas data from Etherscan: Etherscan API error: NOTOK',
@@ -126,23 +137,21 @@ describe('EtherscanService', () => {
     });
 
     it('should handle 401 unauthorized error', async () => {
-      const mockError = {
-        response: { status: 401 },
-        message: 'Unauthorized',
-      };
+      const mockError = new HttpClientError('Unauthorized', {
+        status: 401,
+        statusText: 'Unauthorized',
+      });
 
-      mockedAxios.get.mockRejectedValue(mockError);
+      mockedHttpGet.mockRejectedValue(mockError);
 
       await expect(etherscanService.getGasOracle()).rejects.toThrow('Invalid Etherscan API key');
     });
 
     it('should handle timeout error', async () => {
-      const mockError = {
-        code: 'ETIMEDOUT',
-        message: 'Timeout',
-      };
+      const mockError = new HttpClientError('Timeout');
+      mockError.code = 'ECONNABORTED';
 
-      mockedAxios.get.mockRejectedValue(mockError);
+      mockedHttpGet.mockRejectedValue(mockError);
 
       await expect(etherscanService.getGasOracle()).rejects.toThrow('Etherscan API request timeout');
     });
@@ -164,13 +173,15 @@ describe('EtherscanService', () => {
             UsdPrice: '0.19475759691524',
           },
         },
+        status: 200,
+        statusText: 'OK',
       };
 
-      mockedAxios.get.mockResolvedValue(mockResponse);
+      mockedHttpGet.mockResolvedValue(mockResponse);
 
       await polygonService.getGasOracle();
 
-      expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect(mockedHttpGet).toHaveBeenCalledWith(
         'https://api.etherscan.io/v2/api',
         expect.objectContaining({
           params: expect.objectContaining({
@@ -198,9 +209,11 @@ describe('EtherscanService', () => {
             gasUsedRatio: '0.5',
           },
         },
+        status: 200,
+        statusText: 'OK',
       };
 
-      mockedAxios.get.mockResolvedValue(mockResponse);
+      mockedHttpGet.mockResolvedValue(mockResponse);
     });
 
     it('should return propose (average) speed prices by default', async () => {

--- a/test/services/http-client.test.ts
+++ b/test/services/http-client.test.ts
@@ -1,0 +1,203 @@
+import { HttpClient, HttpClientError, createHttpClient, httpGet, httpPost } from '../../src/services/http-client';
+
+// Mock the global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe('HttpClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('HttpClientError', () => {
+    it('should create error with message only', () => {
+      const error = new HttpClientError('Test error');
+      expect(error.message).toBe('Test error');
+      expect(error.name).toBe('HttpClientError');
+      expect(error.status).toBeUndefined();
+      expect(error.response).toBeUndefined();
+    });
+
+    it('should create error with status and data', () => {
+      const error = new HttpClientError('Test error', {
+        status: 404,
+        statusText: 'Not Found',
+        data: { error: 'Resource not found' },
+      });
+      expect(error.status).toBe(404);
+      expect(error.statusText).toBe('Not Found');
+      expect(error.data).toEqual({ error: 'Resource not found' });
+      expect(error.response).toEqual({
+        status: 404,
+        statusText: 'Not Found',
+        data: { error: 'Resource not found' },
+      });
+    });
+
+    it('should create error with code', () => {
+      const error = new HttpClientError('Timeout');
+      error.code = 'ECONNABORTED';
+      expect(error.code).toBe('ECONNABORTED');
+    });
+  });
+
+  describe('HttpClient class', () => {
+    let client: HttpClient;
+
+    beforeEach(() => {
+      client = new HttpClient({
+        baseURL: 'https://api.example.com',
+        timeout: 5000,
+        headers: { Authorization: 'Bearer token' },
+      });
+    });
+
+    it('should make GET request with params', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: jest.fn().mockResolvedValue({ data: 'test' }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const result = await client.get('/test', {
+        params: { foo: 'bar', num: 123 },
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.example.com/test?foo=bar&num=123',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer token',
+          }),
+        }),
+      );
+      expect(result.data).toEqual({ data: 'test' });
+      expect(result.status).toBe(200);
+    });
+
+    it('should make POST request with body', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: jest.fn().mockResolvedValue({ id: 1 }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const result = await client.post('/test', { name: 'test' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.example.com/test',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ name: 'test' }),
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
+        }),
+      );
+      expect(result.data).toEqual({ id: 1 });
+    });
+
+    it('should throw HttpClientError for non-2xx responses', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: jest.fn().mockResolvedValue({ error: 'Not found' }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await expect(client.get('/notfound')).rejects.toThrow(HttpClientError);
+      await expect(client.get('/notfound')).rejects.toMatchObject({
+        status: 404,
+        data: { error: 'Not found' },
+      });
+    });
+
+    it('should handle timeout', async () => {
+      // Create abort error
+      const abortError = new Error('Aborted');
+      abortError.name = 'AbortError';
+      mockFetch.mockRejectedValue(abortError);
+
+      await expect(client.get('/slow')).rejects.toThrow('Request timeout');
+      await expect(client.get('/slow')).rejects.toMatchObject({
+        code: 'ECONNABORTED',
+      });
+    });
+
+    it('should handle text responses', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({ 'content-type': 'text/plain' }),
+        text: jest.fn().mockResolvedValue('plain text response'),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const result = await client.get('/text');
+
+      expect(result.data).toBe('plain text response');
+    });
+
+    it('should remove trailing slash from baseURL', () => {
+      const clientWithSlash = new HttpClient({
+        baseURL: 'https://api.example.com/',
+      });
+
+      // The trailing slash should be removed internally
+      expect(clientWithSlash).toBeDefined();
+    });
+  });
+
+  describe('createHttpClient', () => {
+    it('should create HttpClient instance', () => {
+      const client = createHttpClient({
+        baseURL: 'https://api.example.com',
+      });
+      expect(client).toBeInstanceOf(HttpClient);
+    });
+  });
+
+  describe('httpGet', () => {
+    it('should make one-off GET request', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: jest.fn().mockResolvedValue({ data: 'test' }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const result = await httpGet('https://api.example.com/test');
+
+      expect(result.data).toEqual({ data: 'test' });
+    });
+  });
+
+  describe('httpPost', () => {
+    it('should make one-off POST request', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: jest.fn().mockResolvedValue({ id: 1 }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const result = await httpPost('https://api.example.com/test', { name: 'test' });
+
+      expect(result.data).toEqual({ id: 1 });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add lightweight `http-client.ts` using native fetch API (Node 20+)
- Migrate Jupiter, 0x, CoinGecko, and Etherscan services to use fetch
- Remove axios from production dependencies (kept in devDependencies for test scripts)
- Add comprehensive tests for http-client module

## Motivation
Axios has been the target of multiple supply chain attacks. Since Gateway requires Node 20+ where native fetch is available, we can eliminate this dependency from the production bundle without losing functionality.

## Changes
| File | Change |
|------|--------|
| `src/services/http-client.ts` | New lightweight HTTP client using native fetch |
| `src/connectors/jupiter/jupiter.ts` | Migrated from axios to http-client |
| `src/connectors/0x/0x.ts` | Migrated from axios to http-client |
| `src/services/coingecko-service.ts` | Migrated from axios to http-client |
| `src/chains/ethereum/etherscan-service.ts` | Migrated from axios to httpGet |
| `package.json` | Removed axios from production dependencies |

## Test plan
- [x] All existing tests pass
- [x] New http-client tests pass
- [x] Build succeeds
- [x] Manual testing of Jupiter swaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)