### PR TITLE
fix / solana surface InstructionError details in simulation failures

### DIFF
--- a/src/chains/solana/solana-error-parser.ts
+++ b/src/chains/solana/solana-error-parser.ts
@@ -12,6 +12,7 @@ export type SolanaErrorType =
   | 'PRICE_LIMIT_OVERFLOW'
   | 'ACCOUNT_NOT_FOUND'
   | 'MATH_OVERFLOW'
+  | 'INSTRUCTION_ERROR'
   | 'UNKNOWN';
 
 export interface ParsedSolanaError {
@@ -19,6 +20,8 @@ export interface ParsedSolanaError {
   program: string;
   errorCode: number | null;
   errorCodeHex: string | null;
+  /** Index of the failing instruction, when the error is an InstructionError */
+  instructionIndex: number | null;
   message: string;
   rawError: string;
 }
@@ -170,6 +173,61 @@ const GENERIC_ERROR_CODES: Record<number, { type: SolanaErrorType; message: stri
 };
 
 /**
+ * Runtime `InstructionError` variants (non-`Custom`) that Solana returns when a
+ * program rejects an account or fails outside of a custom program error code.
+ * These appear in errors like {"InstructionError":[3,"InvalidAccountData"]} and
+ * carry no numeric error code, so they need to be matched by variant name.
+ */
+const INSTRUCTION_ERROR_VARIANTS: Record<string, { type: SolanaErrorType; message: string }> = {
+  InvalidAccountData: {
+    type: 'INSTRUCTION_ERROR',
+    message:
+      'An account passed to the instruction has invalid or unexpected data. ' +
+      'It may be uninitialized, owned by the wrong program, or hold a different token mint than expected.',
+  },
+  InvalidAccountOwner: {
+    type: 'INSTRUCTION_ERROR',
+    message: 'An account passed to the instruction is owned by an unexpected program.',
+  },
+  IllegalOwner: {
+    type: 'INSTRUCTION_ERROR',
+    message: 'An account passed to the instruction has an illegal owner.',
+  },
+  AccountNotExecutable: {
+    type: 'INSTRUCTION_ERROR',
+    message: 'An account expected to be an executable program is not executable.',
+  },
+  AccountDataTooSmall: {
+    type: 'INSTRUCTION_ERROR',
+    message: 'An account passed to the instruction has insufficient data size.',
+  },
+  NotEnoughAccountKeys: {
+    type: 'INSTRUCTION_ERROR',
+    message: 'The instruction was given fewer account keys than required.',
+  },
+  UninitializedAccount: {
+    type: 'ACCOUNT_NOT_FOUND',
+    message: 'An account passed to the instruction is uninitialized.',
+  },
+  MissingAccount: {
+    type: 'ACCOUNT_NOT_FOUND',
+    message: 'A required account was missing from the instruction.',
+  },
+  InsufficientFunds: {
+    type: 'INSUFFICIENT_BALANCE',
+    message: 'Insufficient funds to complete the instruction.',
+  },
+  ProgramFailedToComplete: {
+    type: 'INSTRUCTION_ERROR',
+    message: 'The program failed to complete execution.',
+  },
+  ComputationalBudgetExceeded: {
+    type: 'INSTRUCTION_ERROR',
+    message: 'The instruction exceeded its computational budget.',
+  },
+};
+
+/**
  * Generic error patterns that apply across programs
  * These are checked when program-specific codes don't match
  */
@@ -227,6 +285,42 @@ function extractErrorCode(errorMessage: string): { code: number | null; hex: str
 }
 
 /**
+ * Extract the failing instruction index and the (non-`Custom`) error variant
+ * from an InstructionError, e.g. {"InstructionError":[3,"InvalidAccountData"]}.
+ * For custom program errors ({"InstructionError":[3,{"Custom":6001}]}) the
+ * variant is returned as null since the numeric code is extracted separately.
+ */
+function extractInstructionError(errorMessage: string): { index: number | null; variant: string | null } {
+  const match = errorMessage.match(/"InstructionError"\s*:\s*\[\s*(\d+)\s*,\s*(.+?)\s*\]/);
+  if (!match) {
+    return { index: null, variant: null };
+  }
+  const index = parseInt(match[1], 10);
+  // The variant is either a quoted string ("InvalidAccountData") or an object ({"Custom":6001}).
+  const variantMatch = match[2].match(/^"([A-Za-z]+)"$/);
+  return { index, variant: variantMatch ? variantMatch[1] : null };
+}
+
+/**
+ * Extract the program log lines from a simulation error message.
+ * `simulateTransaction` appends logs after a `Program Logs:` marker; this
+ * returns the trailing lines (most relevant to the failure) for surfacing.
+ */
+export function extractProgramLogs(errorMessage: string, maxLines = 12): string[] {
+  const marker = 'Program Logs:';
+  const markerIndex = errorMessage.indexOf(marker);
+  if (markerIndex === -1) {
+    return [];
+  }
+  const lines = errorMessage
+    .slice(markerIndex + marker.length)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  return lines.slice(-maxLines);
+}
+
+/**
  * Extract program ID from error message
  */
 function extractProgramId(errorMessage: string): string | null {
@@ -280,6 +374,7 @@ export function parseSolanaError(errorMessage: string): ParsedSolanaError {
   const { code, hex } = extractErrorCode(errorMessage);
   const programId = extractProgramId(errorMessage);
   const programName = getProgramName(programId);
+  const { index: instructionIndex, variant: instructionVariant } = extractInstructionError(errorMessage);
 
   // Try program-specific error code lookup
   if (programId && code !== null && PROGRAM_ERROR_CODES[programId]) {
@@ -290,6 +385,7 @@ export function parseSolanaError(errorMessage: string): ParsedSolanaError {
         program: programName,
         errorCode: code,
         errorCodeHex: hex,
+        instructionIndex,
         message: errorInfo.message,
         rawError: errorMessage,
       };
@@ -304,7 +400,23 @@ export function parseSolanaError(errorMessage: string): ParsedSolanaError {
       program: programName,
       errorCode: code,
       errorCodeHex: hex,
+      instructionIndex,
       message: errorInfo.message,
+      rawError: errorMessage,
+    };
+  }
+
+  // Try non-`Custom` InstructionError variants (e.g. InvalidAccountData), which carry no numeric code
+  if (instructionVariant && INSTRUCTION_ERROR_VARIANTS[instructionVariant]) {
+    const errorInfo = INSTRUCTION_ERROR_VARIANTS[instructionVariant];
+    const indexSuffix = instructionIndex !== null ? ` (failing instruction index ${instructionIndex})` : '';
+    return {
+      type: errorInfo.type,
+      program: programName,
+      errorCode: code,
+      errorCodeHex: hex,
+      instructionIndex,
+      message: `${errorInfo.message}${indexSuffix}`,
       rawError: errorMessage,
     };
   }
@@ -317,6 +429,7 @@ export function parseSolanaError(errorMessage: string): ParsedSolanaError {
         program: programName,
         errorCode: code,
         errorCodeHex: hex,
+        instructionIndex,
         message,
         rawError: errorMessage,
       };
@@ -329,6 +442,7 @@ export function parseSolanaError(errorMessage: string): ParsedSolanaError {
     program: programName,
     errorCode: code,
     errorCodeHex: hex,
+    instructionIndex,
     message: 'Transaction failed with an unknown error.',
     rawError: errorMessage,
   };
@@ -369,6 +483,8 @@ export function getUserFriendlyErrorMessage(errorMessage: string): string {
       return `Transaction failed: ${parsed.message} The pool or token accounts may not be initialized.`;
     case 'MATH_OVERFLOW':
       return `Transaction failed: ${parsed.message} Try reducing the amount or adjusting parameters.`;
+    case 'INSTRUCTION_ERROR':
+      return `Transaction simulation failed: ${parsed.message}`;
     default:
       return `Transaction failed. ${parsed.errorCodeHex ? `Error code: ${parsed.errorCodeHex}` : 'Unknown error.'}`;
   }

--- a/src/chains/solana/solana.ts
+++ b/src/chains/solana/solana.ts
@@ -1886,10 +1886,25 @@ export class Solana {
 
       // Import error helpers and parser
       const { simulationFailed, insufficientBalance, slippageExceeded } = await import('../../services/error-handler');
-      const { parseSolanaError } = await import('./solana-error-parser');
+      const { parseSolanaError, extractProgramLogs } = await import('./solana-error-parser');
 
       // Parse the error using the utility
       const parsedError = parseSolanaError(errorMessage);
+
+      // Compose a detailed message including the failing instruction index and
+      // program logs, so callers can diagnose failures without digging through
+      // Gateway server logs.
+      const buildDetail = (base: string): string => {
+        const parts = [base];
+        if (parsedError.instructionIndex !== null) {
+          parts.push(`Failing instruction index: ${parsedError.instructionIndex}.`);
+        }
+        const logs = extractProgramLogs(errorMessage);
+        if (logs.length > 0) {
+          parts.push(`Program logs:\n${logs.join('\n')}`);
+        }
+        return parts.join('\n');
+      };
 
       // Throw appropriate error based on parsed type
       switch (parsedError.type) {
@@ -1899,19 +1914,23 @@ export class Solana {
         case 'INSUFFICIENT_BALANCE':
           throw insufficientBalance(parsedError.message);
 
+        case 'INSTRUCTION_ERROR':
         case 'INVALID_POSITION':
         case 'PRICE_LIMIT_OVERFLOW':
         case 'ACCOUNT_NOT_FOUND':
         case 'MATH_OVERFLOW':
-          throw simulationFailed(parsedError.message);
+          logger.error('Transaction simulation failed:', simulationError);
+          throw simulationFailed(buildDetail(parsedError.message));
 
         default:
           // Generic simulation failure
           logger.error('Transaction simulation failed:', simulationError);
           throw simulationFailed(
-            parsedError.errorCodeHex
-              ? `Transaction simulation failed. Error code: ${parsedError.errorCodeHex}.`
-              : 'Transaction simulation failed.',
+            buildDetail(
+              parsedError.errorCodeHex
+                ? `Transaction simulation failed. Error code: ${parsedError.errorCodeHex}.`
+                : 'Transaction simulation failed.',
+            ),
           );
       }
     }

--- a/test/chains/solana/solana-error-parser.test.ts
+++ b/test/chains/solana/solana-error-parser.test.ts
@@ -3,6 +3,7 @@ import {
   isSlippageError,
   isInsufficientBalanceError,
   getUserFriendlyErrorMessage,
+  extractProgramLogs,
   PROGRAM_IDS,
 } from '../../../src/chains/solana/solana-error-parser';
 
@@ -212,6 +213,82 @@ describe('Solana Error Parser', () => {
         const result = parseSolanaError(errorMessage);
 
         expect(result.type).toBe('ACCOUNT_NOT_FOUND');
+      });
+    });
+
+    describe('InstructionError variants (non-Custom)', () => {
+      it('should parse InvalidAccountData with the failing instruction index', () => {
+        const errorMessage = `Transaction simulation failed: \nError: {"InstructionError":[3,"InvalidAccountData"]}\nProgram Logs: Program JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4 invoke [1]`;
+        const result = parseSolanaError(errorMessage);
+
+        expect(result.type).toBe('INSTRUCTION_ERROR');
+        expect(result.instructionIndex).toBe(3);
+        expect(result.errorCode).toBeNull();
+        expect(result.message).toContain('invalid or unexpected data');
+        expect(result.message).toContain('failing instruction index 3');
+      });
+
+      it('should parse InvalidAccountOwner', () => {
+        const result = parseSolanaError(`{"InstructionError":[1,"InvalidAccountOwner"]}`);
+
+        expect(result.type).toBe('INSTRUCTION_ERROR');
+        expect(result.instructionIndex).toBe(1);
+      });
+
+      it('should map UninitializedAccount to ACCOUNT_NOT_FOUND', () => {
+        const result = parseSolanaError(`{"InstructionError":[2,"UninitializedAccount"]}`);
+
+        expect(result.type).toBe('ACCOUNT_NOT_FOUND');
+        expect(result.instructionIndex).toBe(2);
+      });
+
+      it('should map InsufficientFunds variant to INSUFFICIENT_BALANCE', () => {
+        const result = parseSolanaError(`{"InstructionError":[0,"InsufficientFunds"]}`);
+
+        expect(result.type).toBe('INSUFFICIENT_BALANCE');
+        expect(result.instructionIndex).toBe(0);
+      });
+
+      it('should still extract custom error code from InstructionError with Custom variant', () => {
+        const result = parseSolanaError(`{"InstructionError":[3,{"Custom":6001}]}`);
+
+        expect(result.type).toBe('SLIPPAGE_EXCEEDED');
+        expect(result.errorCode).toBe(6001);
+        expect(result.instructionIndex).toBe(3);
+      });
+
+      it('should return null instruction index when there is no InstructionError', () => {
+        const result = parseSolanaError(`custom program error: 0x1771`);
+
+        expect(result.instructionIndex).toBeNull();
+      });
+
+      it('should produce a user-friendly message for instruction errors', () => {
+        const message = getUserFriendlyErrorMessage(`{"InstructionError":[3,"InvalidAccountData"]}`);
+        expect(message).toContain('Transaction simulation failed');
+      });
+    });
+
+    describe('extractProgramLogs', () => {
+      it('should extract program log lines from a simulation error message', () => {
+        const errorMessage = `Transaction simulation failed: \nError: {"InstructionError":[3,"InvalidAccountData"]}\nProgram Logs: Program JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4 invoke [1]\nProgram log: Instruction: Route\nProgram JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4 failed: invalid account data`;
+        const logs = extractProgramLogs(errorMessage);
+
+        expect(logs.length).toBe(3);
+        expect(logs[0]).toContain('invoke [1]');
+        expect(logs[2]).toContain('failed: invalid account data');
+      });
+
+      it('should return an empty array when no program logs are present', () => {
+        expect(extractProgramLogs(`custom program error: 0x1771`)).toEqual([]);
+      });
+
+      it('should cap the number of returned lines', () => {
+        const manyLines = Array.from({ length: 30 }, (_, i) => `Program log: line ${i}`).join('\n');
+        const logs = extractProgramLogs(`Program Logs: ${manyLines}`, 5);
+
+        expect(logs.length).toBe(5);
+        expect(logs[4]).toContain('line 29');
       });
     });
 


### PR DESCRIPTION
## Problem

Addresses the diagnostics gap in #636.

When a Solana transaction simulation fails with a non-`Custom` runtime `InstructionError` — e.g. `{"InstructionError":[3,"InvalidAccountData"]}` — Gateway's error parser does not recognize it:

- `extractErrorCode()` only matches 4+ digit numeric codes, so `InvalidAccountData` yields no code.
- No generic pattern matches the variant name.
- Result: `type = 'UNKNOWN'` → `simulateWithErrorHandling` throws the bare `SIMULATION_FAILED: Transaction simulation failed.`

The failing instruction index and the program logs — assembled in `simulateTransaction` but then discarded — never reach the API caller. In #636 the reporter had to dig through Gateway server logs just to see `InvalidAccountData`.

## Changes

- **`solana-error-parser.ts`**
  - Recognize non-`Custom` `InstructionError` variants (`InvalidAccountData`, `InvalidAccountOwner`, `IllegalOwner`, `AccountNotExecutable`, `AccountDataTooSmall`, `NotEnoughAccountKeys`, `UninitializedAccount`, `MissingAccount`, `InsufficientFunds`, `ProgramFailedToComplete`, `ComputationalBudgetExceeded`), each mapped to a descriptive message and error type.
  - Extract the failing instruction index and expose it as `ParsedSolanaError.instructionIndex`.
  - Add `extractProgramLogs()` to pull the program-log tail from a simulation error message.
- **`solana.ts`** — `simulateWithErrorHandling()` now appends the failing instruction index and program logs to the `SIMULATION_FAILED` error message, so callers can diagnose failures without server-log access.

This is a diagnostics/observability fix. It does not change the swap execution path itself; the USDC→SOL transaction in #636 is built by the Jupiter `/swap` API and Gateway passes it through unmodified — with this change a future occurrence reports *which* instruction and program failed directly in the API response.

## Testing

- Added 10 unit tests in `solana-error-parser.test.ts` covering the new variants, instruction-index extraction, `Custom`-variant pass-through, and `extractProgramLogs`.
- Full parser suite: 50/50 passing. `tsc --noEmit` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)