### PR TITLE
Fix / Add sensible to fix throwing generic errors to trading routes

### DIFF
--- a/src/trading/trading.routes.ts
+++ b/src/trading/trading.routes.ts
@@ -1,3 +1,4 @@
+import sensible from '@fastify/sensible';
 import { FastifyPluginAsync } from 'fastify';
 
 import { poolsRoute } from './clmm/pools';
@@ -15,12 +16,16 @@ import {
 } from './trading-clmm-routes';
 
 export const tradingSwapRoutes: FastifyPluginAsync = async (fastify) => {
+  await fastify.register(sensible);
+
   // Register swap routes
   fastify.register(quoteSwapRoute);
   fastify.register(executeSwapRoute);
 };
 
 export const tradingClmmRoutes: FastifyPluginAsync = async (fastify) => {
+  await fastify.register(sensible);
+
   // Register CLMM query routes
   fastify.register(poolsRoute);
   fastify.register(positionsRoute);


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
- Add `sensible` to trading routes `src/trading/trading.routes.ts` to prevent throwing generic errors like the one in this issue https://github.com/hummingbot/gateway/issues/631

**Tests performed by the developer**:
- Call GET /trading/clmm/position-info?connector=orca&chainNetwork=solana-mainnet-beta&positionAddress=<closed_or_missing_position> and see if it got 500 error or 404 error
- Got expected error message
```
{
  "statusCode": 404,
  "error": "NotFoundError",
  "message": "Position not found or closed: xxxxx"
}
```