### PR TITLE
Fix inverted BUY price, add binCount to CLMM pool-info, extend Ethereum tx receipt polling

### DIFF
--- a/src/chains/ethereum/ethereum.ts
+++ b/src/chains/ethereum/ethereum.ts
@@ -957,7 +957,8 @@ export class Ethereum {
   }
 
   public async handleTransactionExecution(tx: TransactionResponse): Promise<providers.TransactionReceipt | null> {
-    return await Promise.race([
+    // Race the standard confirmation wait against the configured timeout.
+    const raced = await Promise.race([
       tx.wait(1).then((receipt) => {
         // Transaction confirmed (status: 1) or failed/reverted (status: 0)
         logger.info(
@@ -965,17 +966,40 @@ export class Ethereum {
         );
         return receipt;
       }),
-      new Promise<null>((resolve) =>
-        setTimeout(() => {
-          // Timeout reached, transaction is still pending
-          // Return null to indicate pending - the caller should check for null
-          // Note: Do NOT return a fake receipt with status: 0, because in Ethereum
-          // receipt.status === 0 means "reverted/failed", not "pending"
-          logger.warn(`Transaction ${tx.hash} is still pending after timeout`);
-          resolve(null);
-        }, this._transactionExecutionTimeoutMs),
-      ),
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), this._transactionExecutionTimeoutMs)),
     ]);
+    if (raced) {
+      return raced;
+    }
+
+    // Timed out — the transaction is broadcast but not yet confirmed. Ethereum
+    // blocks are ~12s, so a healthy tx can still need a few more blocks. Poll
+    // the receipt over an extended window before concluding it is genuinely
+    // pending; this avoids reporting a confirmed tx as a failure.
+    // Note: Do NOT return a fake receipt with status: 0 — in Ethereum
+    // receipt.status === 0 means "reverted/failed", not "pending".
+    const extraWindowMs = 90_000;
+    const pollIntervalMs = 5_000;
+    logger.warn(
+      `Transaction ${tx.hash} not confirmed within ${this._transactionExecutionTimeoutMs}ms — ` +
+        `polling for receipt up to a further ${extraWindowMs}ms`,
+    );
+    const deadline = Date.now() + extraWindowMs;
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+      const receipt = await this.getTransactionReceipt(tx.hash);
+      if (receipt) {
+        logger.info(
+          `Transaction ${tx.hash} ${receipt.status === 1 ? 'confirmed' : 'failed'} ` +
+            `in block ${receipt.blockNumber} (after extended poll)`,
+        );
+        return receipt;
+      }
+    }
+
+    // Genuinely still pending — caller must handle null.
+    logger.warn(`Transaction ${tx.hash} still pending after extended poll`);
+    return null;
   }
 
   /**

--- a/src/chains/ethereum/routes/approve.ts
+++ b/src/chains/ethereum/routes/approve.ts
@@ -205,7 +205,7 @@ export async function approveEthereumToken(
         // Wait for the transaction to be mined with timeout (60 seconds for approvals)
         const receipt = await ethereum.handleTransactionExecution(tx);
 
-        if (receipt.status === -1) {
+        if (!receipt || receipt.status === -1) {
           throw new Error('Transaction timed out or failed to get receipt');
         }
 

--- a/src/connectors/meteora/clmm-routes/quoteSwap.ts
+++ b/src/connectors/meteora/clmm-routes/quoteSwap.ts
@@ -98,7 +98,11 @@ async function formatSwapQuote(
     const maxAmountIn = DecimalUtil.fromBN(exactOutQuote.maxInAmount, inputToken.decimals).toNumber();
     const amountOut = DecimalUtil.fromBN(exactOutQuote.outAmount, outputToken.decimals).toNumber();
 
-    const price = amountOut / estimatedAmountIn;
+    // Always quote/base regardless of side. On BUY the input token is the
+    // quote and the output token is the base, so price = in/out = quote/base.
+    // The previous `amountOut / estimatedAmountIn` returned base/quote on BUY
+    // and quote/base on SELL — so BUY quotes appeared at a different scale.
+    const price = amountOut > 0 ? estimatedAmountIn / amountOut : 0;
 
     return {
       // Base QuoteSwapResponse fields in correct order

--- a/src/connectors/orca/clmm-routes/poolInfo.ts
+++ b/src/connectors/orca/clmm-routes/poolInfo.ts
@@ -4,15 +4,22 @@ import { fetchAllMint } from '@solana-program/token-2022';
 import { FastifyPluginAsync, FastifyInstance } from 'fastify';
 
 import { Solana } from '../../../chains/solana/solana';
-import { GetPoolInfoRequestType, PoolInfo } from '../../../schemas/clmm-schema';
+import { PoolInfo } from '../../../schemas/clmm-schema';
 import { logger } from '../../../services/logger';
 import { Orca } from '../orca';
-import { OrcaClmmGetPoolInfoRequest, OrcaPoolInfo, OrcaPoolInfoSchema } from '../schemas';
+import { computeOrcaBinDistribution } from '../orca.utils';
+import {
+  OrcaClmmGetPoolInfoRequest,
+  OrcaClmmGetPoolInfoRequestType,
+  OrcaPoolInfo,
+  OrcaPoolInfoSchema,
+} from '../schemas';
 
 export async function getPoolInfo(
   fastify: FastifyInstance,
   network: string,
   poolAddress: string,
+  binCount: number = 0,
 ): Promise<PoolInfo | OrcaPoolInfo> {
   const orca = await Orca.getInstance(network);
   if (!orca) {
@@ -74,12 +81,28 @@ export async function getPoolInfo(
     yieldOverTvl: apiPoolInfo?.yieldOverTvl ?? 0,
   };
 
+  // Optionally include the per-bin distribution around the current tick.
+  // Only fires the extra getProgramAccounts call when binCount > 0 so the
+  // default pool-info latency is unchanged.
+  if (binCount > 0) {
+    poolInfo.bins = await computeOrcaBinDistribution({
+      rpc: orca.solanaKitRpc,
+      poolAddress,
+      tickSpacing: whirlpool.tickSpacing,
+      currentTickIndex: whirlpool.tickCurrentIndex,
+      currentSqrtPrice: whirlpool.sqrtPrice,
+      decimalsA: mintA.data.decimals,
+      decimalsB: mintB.data.decimals,
+      binCount,
+    });
+  }
+
   return poolInfo;
 }
 
 export const poolInfoRoute: FastifyPluginAsync = async (fastify) => {
   fastify.get<{
-    Querystring: GetPoolInfoRequestType;
+    Querystring: OrcaClmmGetPoolInfoRequestType;
     Reply: OrcaPoolInfo;
   }>(
     '/pool-info',
@@ -95,9 +118,8 @@ export const poolInfoRoute: FastifyPluginAsync = async (fastify) => {
     },
     async (request) => {
       try {
-        const { poolAddress } = request.query;
-        const network = request.query.network;
-        return (await getPoolInfo(fastify, network, poolAddress)) as OrcaPoolInfo;
+        const { poolAddress, binCount = 0, network } = request.query;
+        return (await getPoolInfo(fastify, network, poolAddress, binCount)) as OrcaPoolInfo;
       } catch (e) {
         logger.error(e);
         if (e.statusCode) {

--- a/src/connectors/orca/clmm-routes/quoteSwap.ts
+++ b/src/connectors/orca/clmm-routes/quoteSwap.ts
@@ -38,6 +38,7 @@ export async function getRawSwapQuote(
     inputToken.address,
     outputToken.address,
     amount,
+    side,
     slippagePct,
   );
 

--- a/src/connectors/orca/clmm-routes/quoteSwap.ts
+++ b/src/connectors/orca/clmm-routes/quoteSwap.ts
@@ -63,13 +63,23 @@ async function formatSwapQuote(
     slippagePct,
   );
 
+  // Always report price as quote/base regardless of side. The helper returns
+  // `executionPrice = outputAmount / inputAmount`, which is base/quote on BUY
+  // (input=quote, output=base) and quote/base on SELL — i.e. it flips with
+  // side. Reconstruct quote/base here so the response price has consistent
+  // units. Without this, BUY quotes for a USDC/USDM1 pool look like 0.987
+  // while SELL quotes for the same pool look like 1.012.
+  const baseAmount = side === 'BUY' ? quote.outputAmount : quote.inputAmount;
+  const quoteAmount = side === 'BUY' ? quote.inputAmount : quote.outputAmount;
+  const price = baseAmount > 0 ? quoteAmount / baseAmount : 0;
+
   return {
     poolAddress,
     tokenIn: quote.inputToken,
     tokenOut: quote.outputToken,
     amountIn: quote.inputAmount,
     amountOut: quote.outputAmount,
-    price: quote.price,
+    price,
     slippagePct,
     minAmountOut: quote.minOutputAmount,
     maxAmountIn: quote.maxInputAmount,

--- a/src/connectors/orca/orca.utils.ts
+++ b/src/connectors/orca/orca.utils.ts
@@ -17,6 +17,7 @@ import {
   priceToTickIndex,
   sqrtPriceToPrice,
   swapQuoteByInputToken,
+  swapQuoteByOutputToken,
   tickIndexToPrice,
   tickIndexToSqrtPrice,
   tryGetAmountDeltaA,
@@ -372,6 +373,7 @@ export async function getOrcaSwapQuote(
   inputTokenMint: string,
   outputTokenMint: string,
   amount: number,
+  side: 'BUY' | 'SELL',
   slippagePct: number = 1,
 ): Promise<OrcaSwapQuote> {
   const currentEpoch = await rpc.getEpochInfo().send();
@@ -406,9 +408,13 @@ export async function getOrcaSwapQuote(
 
   const tickArrays = await fetchAllTickArray(rpc, tickArrayAddresses);
 
-  // Convert amount to lamports/token units
-  const decimalsToUse = inputMint.data.decimals;
-  const amountBigInt = BigInt(Math.floor(amount * Math.pow(10, decimalsToUse)));
+  // On BUY the route passes (input=quote, output=base) and `amount` is the
+  // desired base (output) amount → exact-output quote. On SELL `amount` is the
+  // base (input) amount → exact-input quote. Convert using the decimals of the
+  // token the amount actually refers to.
+  const exactOut = side === 'BUY';
+  const amountDecimals = exactOut ? outputMint.data.decimals : inputMint.data.decimals;
+  const amountBigInt = BigInt(Math.floor(amount * Math.pow(10, amountDecimals)));
 
   // Get transfer fees
   const inputTransferFee = getCurrentTransferFee(inputMint, currentEpoch.epoch);
@@ -429,20 +435,41 @@ export async function getOrcaSwapQuote(
   // Get timestamp in big int
   const timestamp = BigInt(Math.floor(Date.now() / 1000));
 
-  // Get swap quote
-  const quote = swapQuoteByInputToken(
-    amountBigInt,
-    aToB,
-    slippagePct * 100, // Convert to basis points (1% = 100)
-    whirlpool.data,
-    oracle.data,
-    tickArrays.map((ta) => ta.data),
-    timestamp,
-    inputTransferFee,
-    outputTransferFee,
-  );
-  const estimatedAmountIn = quote.tokenIn;
-  const estimatedAmountOut = quote.tokenEstOut;
+  // Get swap quote. `swapQuoteByOutputToken`/`swapQuoteByInputToken` take a
+  // `specifiedTokenA` flag: for exact-out it means "output is token A"
+  // (= !aToB), for exact-in it means "input is token A" (= aToB).
+  const slippageBps = slippagePct * 100; // Convert to basis points (1% = 100)
+  let estimatedAmountIn: bigint;
+  let estimatedAmountOut: bigint;
+  if (exactOut) {
+    const quote = swapQuoteByOutputToken(
+      amountBigInt,
+      !aToB,
+      slippageBps,
+      whirlpool.data,
+      oracle.data,
+      tickArrays.map((ta) => ta.data),
+      timestamp,
+      inputTransferFee,
+      outputTransferFee,
+    );
+    estimatedAmountIn = quote.tokenEstIn;
+    estimatedAmountOut = quote.tokenOut;
+  } else {
+    const quote = swapQuoteByInputToken(
+      amountBigInt,
+      aToB,
+      slippageBps,
+      whirlpool.data,
+      oracle.data,
+      tickArrays.map((ta) => ta.data),
+      timestamp,
+      inputTransferFee,
+      outputTransferFee,
+    );
+    estimatedAmountIn = quote.tokenIn;
+    estimatedAmountOut = quote.tokenEstOut;
+  }
 
   // Convert bigints to human-readable numbers
   const inputAmount = Number(estimatedAmountIn) / Math.pow(10, inputMint.data.decimals);
@@ -452,13 +479,16 @@ export async function getOrcaSwapQuote(
   const minOutputAmount = outputAmount * (1 - slippagePct / 100);
   const maxInputAmount = inputAmount * (1 + slippagePct / 100);
 
-  // Calculate price and price impact
+  // Calculate price and price impact. `currentPrice` is token B per token A.
+  // `executionPrice = outputAmount / inputAmount` is B-per-A when swapping
+  // A->B but A-per-B when swapping B->A, so normalize it to B-per-A before
+  // comparing — otherwise the B->A branch mixes units and reports a price
+  // impact inflated by roughly currentPrice^2.
   const currentPrice = sqrtPriceToPrice(whirlpool.data.sqrtPrice, mintA.data.decimals, mintB.data.decimals);
   const executionPrice = outputAmount / inputAmount;
+  const executionPriceBPerA = aToB ? executionPrice : 1 / executionPrice;
 
-  const priceImpactPct = aToB
-    ? Math.abs((executionPrice - currentPrice) / currentPrice) * 100
-    : Math.abs((1 / executionPrice - 1 / currentPrice) / (1 / currentPrice)) * 100;
+  const priceImpactPct = Math.abs((executionPriceBPerA - currentPrice) / currentPrice) * 100;
 
   return {
     inputToken: inputTokenMint,

--- a/src/connectors/orca/orca.utils.ts
+++ b/src/connectors/orca/orca.utils.ts
@@ -1,5 +1,12 @@
 import { TransactionBuilder } from '@orca-so/common-sdk';
-import { fetchAllTickArray, fetchOracle, fetchWhirlpool, getTickArrayAddress } from '@orca-so/whirlpools-client';
+import {
+  fetchAllPositionWithFilter,
+  fetchAllTickArray,
+  fetchOracle,
+  fetchWhirlpool,
+  getTickArrayAddress,
+  positionWhirlpoolFilter,
+} from '@orca-so/whirlpools-client';
 import {
   IncreaseLiquidityQuote,
   TransferFee,
@@ -10,6 +17,10 @@ import {
   priceToTickIndex,
   sqrtPriceToPrice,
   swapQuoteByInputToken,
+  tickIndexToPrice,
+  tickIndexToSqrtPrice,
+  tryGetAmountDeltaA,
+  tryGetAmountDeltaB,
 } from '@orca-so/whirlpools-core';
 import {
   ORCA_WHIRLPOOL_PROGRAM_ID,
@@ -701,4 +712,81 @@ export function getTickArrayPubkeys(
       ORCA_WHIRLPOOL_PROGRAM_ID,
     ).publicKey,
   };
+}
+
+/**
+ * Per-bin liquidity distribution around the current tick for a whirlpool.
+ *
+ * For each tick-spacing-wide bin in the window:
+ *  1. Sum the L of every open Position whose range overlaps the bin (one
+ *     `fetchAllPositionWithFilter` + `positionWhirlpoolFilter` call covers
+ *     all positions in the pool — a single getProgramAccounts under the hood).
+ *  2. Convert that L to token amounts via V3 sqrt-price math
+ *     (`tryGetAmountDeltaA`/`tryGetAmountDeltaB`), splitting at the current
+ *     sqrtPrice when the bin contains the active tick.
+ *
+ * Output shape mirrors Meteora's `pool-info.bins[]`:
+ *   { binId, price, baseTokenAmount, quoteTokenAmount }
+ */
+export interface OrcaBinDistributionEntry {
+  binId: number;
+  price: number;
+  baseTokenAmount: number;
+  quoteTokenAmount: number;
+}
+
+export async function computeOrcaBinDistribution(args: {
+  rpc: Parameters<typeof fetchAllPositionWithFilter>[0];
+  poolAddress: string;
+  tickSpacing: number;
+  currentTickIndex: number;
+  currentSqrtPrice: bigint;
+  decimalsA: number;
+  decimalsB: number;
+  binCount: number;
+}): Promise<OrcaBinDistributionEntry[]> {
+  const { rpc, poolAddress, tickSpacing, currentTickIndex, currentSqrtPrice, decimalsA, decimalsB, binCount } = args;
+  if (binCount <= 0) return [];
+
+  const positionAccounts = await fetchAllPositionWithFilter(rpc, positionWhirlpoolFilter(address(poolAddress)));
+
+  const halfBins = Math.floor(binCount / 2);
+  const snappedCurrent = Math.floor(currentTickIndex / tickSpacing) * tickSpacing;
+  const firstBinStart = snappedCurrent - halfBins * tickSpacing;
+  const scaleA = 10 ** decimalsA;
+  const scaleB = 10 ** decimalsB;
+
+  const bins: OrcaBinDistributionEntry[] = [];
+  for (let i = 0; i < binCount; i++) {
+    const tickStart = firstBinStart + i * tickSpacing;
+    const tickEnd = tickStart + tickSpacing;
+    let binL = 0n;
+    for (const account of positionAccounts) {
+      const p = account.data;
+      if (p.tickLowerIndex < tickEnd && p.tickUpperIndex > tickStart) {
+        binL += p.liquidity;
+      }
+    }
+    let rawA = 0n;
+    let rawB = 0n;
+    if (binL > 0n) {
+      const sqrtA = tickIndexToSqrtPrice(tickStart);
+      const sqrtB = tickIndexToSqrtPrice(tickEnd);
+      if (currentTickIndex >= tickEnd) {
+        rawB = tryGetAmountDeltaB(sqrtA, sqrtB, binL, false);
+      } else if (currentTickIndex < tickStart) {
+        rawA = tryGetAmountDeltaA(sqrtA, sqrtB, binL, false);
+      } else {
+        rawA = tryGetAmountDeltaA(currentSqrtPrice, sqrtB, binL, false);
+        rawB = tryGetAmountDeltaB(sqrtA, currentSqrtPrice, binL, false);
+      }
+    }
+    bins.push({
+      binId: tickStart,
+      price: tickIndexToPrice(tickStart, decimalsA, decimalsB),
+      baseTokenAmount: Number(rawA) / scaleA,
+      quoteTokenAmount: Number(rawB) / scaleB,
+    });
+  }
+  return bins;
 }

--- a/src/connectors/orca/schemas.ts
+++ b/src/connectors/orca/schemas.ts
@@ -425,7 +425,20 @@ export const OrcaClmmGetPoolInfoRequest = Type.Object({
     description: 'Orca CLMM pool address',
     examples: [CLMM_POOL_ADDRESS_EXAMPLE],
   }),
+  // binCount inherited from base GetPoolInfoRequest semantics — declared
+  // explicitly here so the Orca network enum override stays a flat schema.
+  binCount: Type.Optional(
+    Type.Integer({
+      description:
+        'If > 0, include a `bins` array (per-tickSpacing token amounts around the current tick). ' +
+        'Default 0 — pool-info skips the extra getProgramAccounts call.',
+      default: 0,
+      minimum: 0,
+      maximum: 401,
+    }),
+  ),
 });
+export type OrcaClmmGetPoolInfoRequestType = Static<typeof OrcaClmmGetPoolInfoRequest>;
 
 // Orca CLMM Get Position Info Request
 export const OrcaClmmGetPositionInfoRequest = Type.Object({

--- a/src/connectors/raydium/clmm-routes/executeSwap.ts
+++ b/src/connectors/raydium/clmm-routes/executeSwap.ts
@@ -1,6 +1,5 @@
 import { ReturnTypeComputeAmountOutFormat, ReturnTypeComputeAmountOutBaseOut } from '@raydium-io/raydium-sdk-v2';
 import { VersionedTransaction } from '@solana/web3.js';
-import BN from 'bn.js';
 import { FastifyPluginAsync } from 'fastify';
 
 import { Solana } from '../../../chains/solana/solana';
@@ -12,7 +11,7 @@ import { Raydium } from '../raydium';
 import { RaydiumConfig } from '../raydium.config';
 import { RaydiumClmmExecuteSwapRequest, RaydiumClmmExecuteSwapRequestType } from '../schemas';
 
-import { getSwapQuote, convertAmountIn } from './quoteSwap';
+import { getSwapQuote } from './quoteSwap';
 
 export async function executeSwap(
   network: string,
@@ -108,19 +107,13 @@ export async function executeSwap(
   let transaction: VersionedTransaction;
   if (side === 'BUY') {
     const exactOutResponse = response as ReturnTypeComputeAmountOutBaseOut;
-    const amountIn = convertAmountIn(
-      amount,
-      inputToken.decimals,
-      outputToken.decimals,
-      exactOutResponse.amountIn.amount,
-    );
-    const amountInWithSlippage = amountIn * 10 ** inputToken.decimals * (1 + slippagePct / 100);
-    // logger.info(`amountInWithSlippage: ${amountInWithSlippage}`);
+    // maxAmountIn already includes slippage (SDK computed it from the slippage
+    // passed to computeAmountIn) and is denominated in the input token's units.
     ({ transaction } = (await raydium.raydiumSDK.clmm.swapBaseOut({
       poolInfo,
       poolKeys,
       outputMint: outputToken.address,
-      amountInMax: new BN(Math.floor(amountInWithSlippage)),
+      amountInMax: exactOutResponse.maxAmountIn.amount,
       amountOut: exactOutResponse.realAmountOut.amount,
       observationId: clmmPoolInfo.observationId,
       ownerInfo: {

--- a/src/connectors/raydium/clmm-routes/poolInfo.ts
+++ b/src/connectors/raydium/clmm-routes/poolInfo.ts
@@ -1,12 +1,18 @@
 import { FastifyPluginAsync, FastifyInstance } from 'fastify';
 
 import { Solana } from '../../../chains/solana/solana';
-import { GetPoolInfoRequestType, PoolInfo, PoolInfoSchema } from '../../../schemas/clmm-schema';
+import { PoolInfo, PoolInfoSchema } from '../../../schemas/clmm-schema';
 import { logger } from '../../../services/logger';
 import { Raydium } from '../raydium';
-import { RaydiumClmmGetPoolInfoRequest } from '../schemas';
+import { computeRaydiumBinDistribution } from '../raydium.utils';
+import { RaydiumClmmGetPoolInfoRequest, RaydiumClmmGetPoolInfoRequestType } from '../schemas';
 
-export async function getPoolInfo(fastify: FastifyInstance, network: string, poolAddress: string): Promise<PoolInfo> {
+export async function getPoolInfo(
+  fastify: FastifyInstance,
+  network: string,
+  poolAddress: string,
+  binCount: number = 0,
+): Promise<PoolInfo> {
   const raydium = await Raydium.getInstance(network);
 
   if (!poolAddress) {
@@ -19,12 +25,42 @@ export async function getPoolInfo(fastify: FastifyInstance, network: string, poo
     throw fastify.httpErrors.notFound(`Pool not found: ${poolAddress}`);
   }
 
+  // Optionally include the per-bin liquidity distribution around the current
+  // tick. Fires an extra getProgramAccounts call (via the SDK's
+  // fetchMultiplePoolTickArrays) — only when binCount > 0 so default
+  // pool-info latency is unaffected.
+  if (binCount > 0) {
+    try {
+      const rawPool = await raydium.getClmmPoolfromRPC(poolAddress);
+      const apiResult = await raydium.getClmmPoolfromAPI(poolAddress);
+      if (rawPool && apiResult) {
+        const [apiPoolInfo, poolKeys] = apiResult;
+        const solana = await Solana.getInstance(network);
+        const result = poolInfo as PoolInfo;
+        result.bins = await computeRaydiumBinDistribution({
+          connection: solana.connection,
+          poolInfo: apiPoolInfo,
+          poolKeys,
+          tickSpacing: Number(rawPool.tickSpacing),
+          currentTick: Number(rawPool.tickCurrent),
+          currentSqrtPriceX64: rawPool.sqrtPriceX64,
+          activeLiquidity: rawPool.liquidity,
+          decimalsA: apiPoolInfo.mintA.decimals,
+          decimalsB: apiPoolInfo.mintB.decimals,
+          binCount,
+        });
+      }
+    } catch (e) {
+      logger.warn(`Raydium bin distribution fetch failed for ${poolAddress}: ${e}`);
+    }
+  }
+
   return poolInfo;
 }
 
 export const poolInfoRoute: FastifyPluginAsync = async (fastify) => {
   fastify.get<{
-    Querystring: GetPoolInfoRequestType;
+    Querystring: RaydiumClmmGetPoolInfoRequestType;
     Reply: Record<string, any>;
   }>(
     '/pool-info',
@@ -40,9 +76,8 @@ export const poolInfoRoute: FastifyPluginAsync = async (fastify) => {
     },
     async (request): Promise<PoolInfo> => {
       try {
-        const { poolAddress } = request.query;
-        const network = request.query.network;
-        return await getPoolInfo(fastify, network, poolAddress);
+        const { poolAddress, binCount = 0, network } = request.query;
+        return await getPoolInfo(fastify, network, poolAddress, binCount);
       } catch (e) {
         logger.error(e);
         if (e.statusCode) throw e;

--- a/src/connectors/raydium/clmm-routes/quoteSwap.ts
+++ b/src/connectors/raydium/clmm-routes/quoteSwap.ts
@@ -5,7 +5,6 @@ import {
   ReturnTypeComputeAmountOutBaseOut,
 } from '@raydium-io/raydium-sdk-v2';
 import { PublicKey } from '@solana/web3.js';
-import BN from 'bn.js';
 import { Decimal } from 'decimal.js';
 import { FastifyPluginAsync } from 'fastify';
 
@@ -23,28 +22,6 @@ import { sanitizeErrorMessage } from '../../../services/sanitize';
 import { Raydium } from '../raydium';
 import { RaydiumConfig } from '../raydium.config';
 import { RaydiumClmmQuoteSwapRequest } from '../schemas';
-
-/**
- * Helper function to convert amount for buy orders in Raydium CLMM
- * This handles the special case where we need to invert the amount due to SDK limitations
- * @param order_amount The order amount
- * @param inputTokenDecimals The decimals of the input token
- * @param outputTokenDecimals The decimals of the output token
- * @param amountToConvert The BN raw amount to convert (e.g. amountIn or maxAmountIn) from the SDK
- * @returns The converted amount
- */
-export function convertAmountIn(
-  order_amount: number,
-  inputTokenDecimals: number,
-  outputTokenDecimals: number,
-  amountIn: BN,
-): number {
-  const inputDecimals =
-    Math.log10(order_amount) * 2 +
-    Math.max(inputTokenDecimals, outputTokenDecimals) +
-    Math.abs(inputTokenDecimals - outputTokenDecimals);
-  return 1 / (amountIn.toNumber() / 10 ** inputDecimals);
-}
 
 export async function getSwapQuote(
   network: string,
@@ -85,10 +62,9 @@ export async function getSwapQuote(
     connection: solana.connection,
     poolKeys: [clmmPoolInfo],
   });
-  const effectiveSlippage = new BN(slippagePct / 100);
-
-  // Convert BN to number for slippage
-  const effectiveSlippageNumber = effectiveSlippage.toNumber();
+  // The SDK expects slippage as a fractional number (e.g. 0.02 for 2%).
+  // Do NOT wrap in BN — new BN(0.02) truncates to 0, disabling slippage.
+  const effectiveSlippageNumber = slippagePct / 100;
 
   // AmountOut = swapQuote, AmountOutBaseOut = swapQuoteExactOut
   const response: ReturnTypeComputeAmountOutFormat | ReturnTypeComputeAmountOutBaseOut =
@@ -98,7 +74,11 @@ export async function getSwapQuote(
           tickArrayCache: tickCache[poolAddress],
           amountOut: amount_bn,
           epochInfo: await raydium.raydiumSDK.fetchEpochInfo(),
-          baseMint: new PublicKey(poolInfo['mintB'].address),
+          // baseMint denominates amountOut and the returned amountIn is in the
+          // OTHER token. For a BUY we want `amount` of the output token, so
+          // baseMint must be the output token; amountIn then comes back in the
+          // input token's units directly (no inversion needed).
+          baseMint: new PublicKey(outputToken.address),
           slippage: effectiveSlippageNumber,
         })
       : await PoolUtils.computeAmountOutFormat({
@@ -194,24 +174,18 @@ async function formatSwapQuote(
 
   if (side === 'BUY') {
     const exactOutResponse = response as ReturnTypeComputeAmountOutBaseOut;
+    // With baseMint = output token, the SDK returns amountIn / maxAmountIn in the
+    // input token's raw units. maxAmountIn already includes slippage.
     const estimatedAmountOut = exactOutResponse.realAmountOut.amount.toNumber() / 10 ** outputToken.decimals;
-    const estimatedAmountIn = convertAmountIn(
-      amount,
-      inputToken.decimals,
-      outputToken.decimals,
-      exactOutResponse.amountIn.amount,
-    );
-    const maxAmountIn = convertAmountIn(
-      amount,
-      inputToken.decimals,
-      outputToken.decimals,
-      exactOutResponse.maxAmountIn.amount,
-    );
+    const estimatedAmountIn = exactOutResponse.amountIn.amount.toNumber() / 10 ** inputToken.decimals;
+    const maxAmountIn = exactOutResponse.maxAmountIn.amount.toNumber() / 10 ** inputToken.decimals;
 
     const price = estimatedAmountOut > 0 ? estimatedAmountIn / estimatedAmountOut : 0;
 
-    // Calculate price impact percentage - ensure it's a valid number
-    const priceImpactRaw = exactOutResponse.priceImpact ? Number(exactOutResponse.priceImpact) * 100 : 0;
+    // priceImpact is a Raydium SDK Percent object. Number(Percent) is NaN
+    // ([object Object]), and toSignificant() already returns the value as a
+    // percentage (e.g. 0.0326 means 0.0326%), so it must not be multiplied by 100.
+    const priceImpactRaw = exactOutResponse.priceImpact ? Number(exactOutResponse.priceImpact.toSignificant(8)) : 0;
     const priceImpactPct = isNaN(priceImpactRaw) || !isFinite(priceImpactRaw) ? 0 : priceImpactRaw;
 
     // Determine token addresses for computed fields
@@ -247,8 +221,10 @@ async function formatSwapQuote(
 
     const price = estimatedAmountIn > 0 ? estimatedAmountOut / estimatedAmountIn : 0;
 
-    // Calculate price impact percentage - ensure it's a valid number
-    const priceImpactRaw = exactInResponse.priceImpact ? Number(exactInResponse.priceImpact) * 100 : 0;
+    // priceImpact is a Raydium SDK Percent object. Number(Percent) is NaN
+    // ([object Object]), and toSignificant() already returns the value as a
+    // percentage (e.g. 0.0326 means 0.0326%), so it must not be multiplied by 100.
+    const priceImpactRaw = exactInResponse.priceImpact ? Number(exactInResponse.priceImpact.toSignificant(8)) : 0;
     const priceImpactPct = isNaN(priceImpactRaw) || !isFinite(priceImpactRaw) ? 0 : priceImpactRaw;
 
     // Determine token addresses for computed fields

--- a/src/connectors/raydium/raydium.utils.ts
+++ b/src/connectors/raydium/raydium.utils.ts
@@ -5,6 +5,12 @@ import {
   DEVNET_PROGRAM_ID,
   CREATE_CPMM_POOL_PROGRAM,
   DEV_CREATE_CPMM_POOL_PROGRAM,
+  PoolUtils,
+  TickUtils,
+  ApiV3PoolInfoConcentratedItem,
+  ClmmKeys,
+  // V3 sqrt-price math (BN-based, identical structure to Uniswap V3's)
+  // Internally exported under the SDK's clmm/utils/math module.
 } from '@raydium-io/raydium-sdk-v2';
 
 const VALID_AMM_PROGRAM_ID = new Set([
@@ -40,3 +46,162 @@ export const findPoolAddress = (
   // Pools are now managed separately, return null for dynamic pool discovery
   return null;
 };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-bin liquidity distribution helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { Connection, PublicKey } from '@solana/web3.js';
+import BN from 'bn.js';
+
+import { logger } from '../../services/logger';
+
+// The SDK exports the math classes through these subpath imports.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { SqrtPriceMath, LiquidityMath } = require('@raydium-io/raydium-sdk-v2');
+
+/**
+ * Per-bin liquidity distribution around the current tick for a Raydium V3
+ * (CLMM) pool. Mirrors Meteora's `pool-info.bins[]` shape and the same helper
+ * exposed in the Orca/Uniswap connectors:
+ *
+ *     { binId, price, baseTokenAmount, quoteTokenAmount }
+ *
+ * How it works
+ * ------------
+ * 1. Fetch all tick arrays for the pool via `PoolUtils.fetchMultiplePoolTickArrays`
+ *    (one getProgramAccounts under the hood; the cache is keyed by tick-array
+ *    start index).
+ * 2. For each bin boundary in the window, derive its `TickArray.startTickIndex`
+ *    + the tick's offset inside that array; pull out the `liquidityNet` field.
+ * 3. Propagate L outward from the current bin (`pool.liquidity` at currentTick).
+ *    Per V3 spec: crossing a tick going UP adds liquidityNet, going DOWN
+ *    subtracts it.
+ * 4. Apply V3 sqrt-price math via `LiquidityMath.getTokenAmount{A,B}FromLiquidity`
+ *    splitting at the active sqrtPrice when the bin contains the current tick.
+ */
+export interface RaydiumBinDistributionEntry {
+  binId: number;
+  price: number;
+  baseTokenAmount: number;
+  quoteTokenAmount: number;
+}
+
+export async function computeRaydiumBinDistribution(args: {
+  connection: Connection;
+  poolInfo: ApiV3PoolInfoConcentratedItem;
+  poolKeys: ClmmKeys;
+  tickSpacing: number;
+  currentTick: number;
+  currentSqrtPriceX64: BN;
+  activeLiquidity: BN;
+  decimalsA: number;
+  decimalsB: number;
+  binCount: number;
+}): Promise<RaydiumBinDistributionEntry[]> {
+  const {
+    connection,
+    poolInfo,
+    poolKeys,
+    tickSpacing,
+    currentTick,
+    currentSqrtPriceX64,
+    activeLiquidity,
+    decimalsA,
+    decimalsB,
+    binCount,
+  } = args;
+  if (binCount <= 0) return [];
+
+  // Snap bin grid so the current tick lands inside a bin.
+  const halfBins = Math.floor(binCount / 2);
+  const snapped = Math.floor(currentTick / tickSpacing) * tickSpacing;
+  const firstBinStart = snapped - halfBins * tickSpacing;
+  const boundaries: number[] = [];
+  for (let i = 0; i <= binCount; i++) {
+    boundaries.push(firstBinStart + i * tickSpacing);
+  }
+
+  // Fetch all of the pool's tick arrays. The SDK builds `ComputeClmmPoolInfo`
+  // from the API-shape poolInfo we already have; `fetchMultiplePoolTickArrays`
+  // returns `{ [poolId]: { [startTickIndex]: TickArray } }`.
+  let clmmPoolInfo: any;
+  let tickCache: any;
+  try {
+    clmmPoolInfo = await PoolUtils.fetchComputeClmmInfo({ connection, poolInfo });
+    tickCache = await PoolUtils.fetchMultiplePoolTickArrays({
+      connection,
+      poolKeys: [clmmPoolInfo],
+    });
+  } catch (e) {
+    logger.warning(`Raydium bin fetch failed for ${poolInfo.id}: ${e}`);
+    return [];
+  }
+  const poolTickArrays = tickCache?.[poolInfo.id.toString()] ?? tickCache?.[poolInfo.id] ?? {};
+
+  const programId = new PublicKey(poolInfo.programId);
+  const poolId = new PublicKey(poolInfo.id);
+
+  // Helper: look up the on-chain Tick struct for a boundary; if uninitialized,
+  // return a neutral { liquidityNet: 0 }.
+  const tickAt = (tickIndex: number): { liquidityNet: BN } => {
+    try {
+      const startIndex = TickUtils.getTickArrayStartIndexByTick(tickIndex, tickSpacing);
+      const arr = poolTickArrays[startIndex];
+      if (!arr || !arr.ticks) return { liquidityNet: new BN(0) };
+      const offset = TickUtils.getTickOffsetInArray(tickIndex, tickSpacing);
+      const t = arr.ticks?.[offset];
+      if (!t || !t.liquidityNet) return { liquidityNet: new BN(0) };
+      return { liquidityNet: t.liquidityNet };
+    } catch {
+      return { liquidityNet: new BN(0) };
+    }
+  };
+  // Suppress unused warnings for the program/pool ids (kept for future PDA derivation).
+  void programId;
+  void poolId;
+  void poolKeys;
+
+  const curIdx = Math.floor((currentTick - firstBinStart) / tickSpacing);
+
+  // Propagate L outward from the current bin.
+  const binLs: BN[] = new Array(binCount);
+  binLs[curIdx] = activeLiquidity;
+  for (let i = curIdx + 1; i < binCount; i++) {
+    binLs[i] = binLs[i - 1].add(tickAt(boundaries[i]).liquidityNet);
+  }
+  for (let i = curIdx - 1; i >= 0; i--) {
+    binLs[i] = binLs[i + 1].sub(tickAt(boundaries[i + 1]).liquidityNet);
+  }
+
+  const scaleA = Math.pow(10, decimalsA);
+  const scaleB = Math.pow(10, decimalsB);
+  const zero = new BN(0);
+  const bins: RaydiumBinDistributionEntry[] = [];
+  for (let i = 0; i < binCount; i++) {
+    const tickStart = boundaries[i];
+    const tickEnd = boundaries[i + 1];
+    const L = binLs[i];
+    let rawA: BN = zero;
+    let rawB: BN = zero;
+    if (L.gt(zero)) {
+      const sqrtA: BN = SqrtPriceMath.getSqrtPriceX64FromTick(tickStart);
+      const sqrtB: BN = SqrtPriceMath.getSqrtPriceX64FromTick(tickEnd);
+      if (currentTick >= tickEnd) {
+        rawB = LiquidityMath.getTokenAmountBFromLiquidity(sqrtA, sqrtB, L, false);
+      } else if (currentTick < tickStart) {
+        rawA = LiquidityMath.getTokenAmountAFromLiquidity(sqrtA, sqrtB, L, false);
+      } else {
+        rawA = LiquidityMath.getTokenAmountAFromLiquidity(currentSqrtPriceX64, sqrtB, L, false);
+        rawB = LiquidityMath.getTokenAmountBFromLiquidity(sqrtA, currentSqrtPriceX64, L, false);
+      }
+    }
+    bins.push({
+      binId: tickStart,
+      price: Math.pow(1.0001, tickStart) * Math.pow(10, decimalsA - decimalsB),
+      baseTokenAmount: parseFloat(rawA.toString()) / scaleA,
+      quoteTokenAmount: parseFloat(rawB.toString()) / scaleB,
+    });
+  }
+  return bins;
+}

--- a/src/connectors/raydium/schemas.ts
+++ b/src/connectors/raydium/schemas.ts
@@ -264,6 +264,17 @@ export const RaydiumClmmGetPoolInfoRequest = Type.Object({
     description: 'Raydium CLMM pool address',
     examples: [CLMM_POOL_ADDRESS_EXAMPLE],
   }),
+  // binCount is part of the base CLMM pool-info contract. The Raydium
+  // implementation of per-bin distribution is deferred — passing binCount > 0
+  // is currently accepted but has no effect on the response.
+  binCount: Type.Optional(
+    Type.Integer({
+      description: 'Reserved — bin computation not yet implemented for Raydium CLMM.',
+      default: 0,
+      minimum: 0,
+      maximum: 401,
+    }),
+  ),
 });
 
 export const RaydiumClmmGetPositionInfoRequest = Type.Object({

--- a/src/connectors/raydium/schemas.ts
+++ b/src/connectors/raydium/schemas.ts
@@ -264,18 +264,18 @@ export const RaydiumClmmGetPoolInfoRequest = Type.Object({
     description: 'Raydium CLMM pool address',
     examples: [CLMM_POOL_ADDRESS_EXAMPLE],
   }),
-  // binCount is part of the base CLMM pool-info contract. The Raydium
-  // implementation of per-bin distribution is deferred — passing binCount > 0
-  // is currently accepted but has no effect on the response.
   binCount: Type.Optional(
     Type.Integer({
-      description: 'Reserved — bin computation not yet implemented for Raydium CLMM.',
+      description:
+        'If > 0, include a `bins` array (per-tickSpacing token amounts around the current tick), ' +
+        'mirroring Meteora pool-info.bins[]. Default 0 — pool-info skips the extra tick-array fetch.',
       default: 0,
       minimum: 0,
       maximum: 401,
     }),
   ),
 });
+export type RaydiumClmmGetPoolInfoRequestType = Static<typeof RaydiumClmmGetPoolInfoRequest>;
 
 export const RaydiumClmmGetPositionInfoRequest = Type.Object({
   network: Type.Optional(

--- a/src/connectors/uniswap/clmm-routes/poolInfo.ts
+++ b/src/connectors/uniswap/clmm-routes/poolInfo.ts
@@ -1,15 +1,23 @@
+import { Contract as EthersProjectContract } from '@ethersproject/contracts';
+import { abi as IUniswapV3PoolABI } from '@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json';
 import { FeeAmount } from '@uniswap/v3-sdk';
 import { FastifyPluginAsync, FastifyInstance } from 'fastify';
+import JSBI from 'jsbi';
 
 import { Ethereum } from '../../../chains/ethereum/ethereum';
-import { GetPoolInfoRequestType, PoolInfo, PoolInfoSchema } from '../../../schemas/clmm-schema';
+import { PoolInfo, PoolInfoSchema } from '../../../schemas/clmm-schema';
 import { logger } from '../../../services/logger';
 import { sanitizeErrorMessage } from '../../../services/sanitize';
-import { UniswapClmmGetPoolInfoRequest } from '../schemas';
+import { UniswapClmmGetPoolInfoRequest, UniswapClmmGetPoolInfoRequestType } from '../schemas';
 import { Uniswap } from '../uniswap';
-import { formatTokenAmount, getUniswapPoolInfo } from '../uniswap.utils';
+import { computeUniswapBinDistribution, formatTokenAmount, getUniswapPoolInfo } from '../uniswap.utils';
 
-export async function getPoolInfo(fastify: FastifyInstance, network: string, poolAddress: string): Promise<PoolInfo> {
+export async function getPoolInfo(
+  fastify: FastifyInstance,
+  network: string,
+  poolAddress: string,
+  binCount: number = 0,
+): Promise<PoolInfo> {
   const uniswap = await Uniswap.getInstance(network);
 
   if (!poolAddress) {
@@ -75,7 +83,7 @@ export async function getPoolInfo(fastify: FastifyInstance, network: string, poo
   // Get active tick/bin
   const activeBinId = pool.tickCurrent;
 
-  return {
+  const result: PoolInfo = {
     address: poolAddress,
     baseTokenAddress: baseTokenObj.address,
     quoteTokenAddress: quoteTokenObj.address,
@@ -86,11 +94,34 @@ export async function getPoolInfo(fastify: FastifyInstance, network: string, poo
     quoteTokenAmount: quoteTokenAmount,
     activeBinId: activeBinId,
   };
+
+  // Optionally include the per-bin distribution around the current tick.
+  // Fires N parallel pool.ticks(tick) reads — only when binCount > 0 so the
+  // default pool-info latency is unaffected.
+  if (binCount > 0) {
+    // Direct V3 Pool ABI contract — ethereum.getContract() returns an ERC20-typed
+    // contract which wouldn't expose ticks(). Use the same ABI the rest of the
+    // connector uses for V3 pool reads.
+    const poolContract = new EthersProjectContract(poolAddress, IUniswapV3PoolABI, ethereum.provider);
+    result.bins = await computeUniswapBinDistribution({
+      poolContract,
+      tickSpacing,
+      currentTick: activeBinId,
+      currentSqrtPriceX96: JSBI.BigInt(sqrtPriceX96.toString()),
+      activeLiquidity: JSBI.BigInt(pool.liquidity.toString()),
+      decimals0: token0.decimals,
+      decimals1: token1.decimals,
+      isBaseToken0,
+      binCount,
+    });
+  }
+
+  return result;
 }
 
 export const poolInfoRoute: FastifyPluginAsync = async (fastify) => {
   fastify.get<{
-    Querystring: GetPoolInfoRequestType;
+    Querystring: UniswapClmmGetPoolInfoRequestType;
     Reply: Record<string, any>;
   }>(
     '/pool-info',
@@ -106,9 +137,8 @@ export const poolInfoRoute: FastifyPluginAsync = async (fastify) => {
     },
     async (request): Promise<PoolInfo> => {
       try {
-        const { poolAddress } = request.query;
-        const network = request.query.network;
-        return await getPoolInfo(fastify, network, poolAddress);
+        const { poolAddress, binCount = 0, network } = request.query;
+        return await getPoolInfo(fastify, network, poolAddress, binCount);
       } catch (e) {
         logger.error(e);
         if (e.statusCode) {

--- a/src/connectors/uniswap/schemas.ts
+++ b/src/connectors/uniswap/schemas.ts
@@ -1,4 +1,4 @@
-import { Type } from '@sinclair/typebox';
+import { Type, Static } from '@sinclair/typebox';
 
 import { getEthereumChainConfig } from '../../chains/ethereum/ethereum.config';
 
@@ -48,7 +48,18 @@ export const UniswapClmmGetPoolInfoRequest = Type.Object({
     description: 'Uniswap V3 pool address',
     examples: [CLMM_POOL_ADDRESS_EXAMPLE],
   }),
+  binCount: Type.Optional(
+    Type.Integer({
+      description:
+        'If > 0, include a `bins` array (per-tickSpacing token amounts around the current tick), ' +
+        'mirroring Meteora pool-info.bins[]. Default 0 — pool-info skips the extra eth_calls.',
+      default: 0,
+      minimum: 0,
+      maximum: 401,
+    }),
+  ),
 });
+export type UniswapClmmGetPoolInfoRequestType = Static<typeof UniswapClmmGetPoolInfoRequest>;
 
 // ========================================
 // Router Request Schemas

--- a/src/connectors/uniswap/uniswap.utils.ts
+++ b/src/connectors/uniswap/uniswap.utils.ts
@@ -2,7 +2,7 @@ import { Contract } from '@ethersproject/contracts';
 import { Token } from '@uniswap/sdk-core';
 import { Pair as V2Pair } from '@uniswap/v2-sdk';
 import { abi as IUniswapV3PoolABI } from '@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json';
-import { FeeAmount, Pool as V3Pool } from '@uniswap/v3-sdk';
+import { FeeAmount, Pool as V3Pool, SqrtPriceMath, TickMath } from '@uniswap/v3-sdk';
 import { FastifyInstance } from 'fastify';
 import JSBI from 'jsbi';
 
@@ -300,4 +300,126 @@ export async function getUniswapPoolInfo(
   }
 
   return getV3PoolInfo(poolAddress, network);
+}
+
+/**
+ * Per-bin liquidity distribution around the current tick for a Uniswap V3 pool.
+ *
+ * Uniswap V3 has no equivalent of Orca's "fetch all positions for pool" RPC —
+ * positions are NFTs on the NonfungiblePositionManager. Instead we walk the
+ * pool's per-tick liquidity profile directly:
+ *
+ *   1. Read `liquidityNet` at every bin boundary in the window via parallel
+ *      `pool.ticks(tick)` reads (one eth_call each, fired with Promise.all).
+ *      Ticks that have never been initialized return zeros — that's harmless.
+ *   2. Start with the pool's active L = pool.liquidity() in the bin that
+ *      contains the current tick. Propagate L outward by adding/subtracting
+ *      `liquidityNet` at each boundary crossed (per the V3 spec).
+ *   3. For each bin, convert L → (amount0, amount1) via
+ *      SqrtPriceMath.getAmount{0,1}Delta(sqrtA, sqrtB, L, false), splitting
+ *      at the pool's current sqrtPriceX96 when the bin straddles the
+ *      active tick.
+ *   4. Map to base/quote using `isBaseToken0`, scale by decimals.
+ *
+ * Output shape mirrors Meteora's `pool-info.bins[]`:
+ *   { binId, price, baseTokenAmount, quoteTokenAmount }
+ */
+export interface UniswapBinDistributionEntry {
+  binId: number;
+  price: number;
+  baseTokenAmount: number;
+  quoteTokenAmount: number;
+}
+
+export async function computeUniswapBinDistribution(args: {
+  poolContract: Contract;
+  tickSpacing: number;
+  currentTick: number;
+  currentSqrtPriceX96: JSBI;
+  activeLiquidity: JSBI;
+  decimals0: number;
+  decimals1: number;
+  isBaseToken0: boolean;
+  binCount: number;
+}): Promise<UniswapBinDistributionEntry[]> {
+  const {
+    poolContract,
+    tickSpacing,
+    currentTick,
+    currentSqrtPriceX96,
+    activeLiquidity,
+    decimals0,
+    decimals1,
+    isBaseToken0,
+    binCount,
+  } = args;
+  if (binCount <= 0) return [];
+
+  const halfBins = Math.floor(binCount / 2);
+  const snapped = Math.floor(currentTick / tickSpacing) * tickSpacing;
+  const firstBinStart = snapped - halfBins * tickSpacing;
+  const boundaries: number[] = [];
+  for (let i = 0; i <= binCount; i++) {
+    boundaries.push(firstBinStart + i * tickSpacing);
+  }
+
+  // Parallel reads of pool.ticks(tick) at each boundary. Non-initialized
+  // ticks return zeros which is the correct neutral element for liquidityNet.
+  const tickData = await Promise.all(
+    boundaries.map((tick) => poolContract.ticks(tick).catch(() => ({ liquidityNet: 0 }))),
+  );
+
+  const curIdx = Math.floor((currentTick - firstBinStart) / tickSpacing);
+
+  // Propagate L outward from the current bin (V3 spec: crossing a tick going
+  // UP adds liquidityNet, going DOWN subtracts it).
+  const binLs: JSBI[] = new Array(binCount);
+  binLs[curIdx] = activeLiquidity;
+  for (let i = curIdx + 1; i < binCount; i++) {
+    const net = JSBI.BigInt(tickData[i].liquidityNet.toString());
+    binLs[i] = JSBI.add(binLs[i - 1], net);
+  }
+  for (let i = curIdx - 1; i >= 0; i--) {
+    const net = JSBI.BigInt(tickData[i + 1].liquidityNet.toString());
+    binLs[i] = JSBI.subtract(binLs[i + 1], net);
+  }
+
+  const scale0 = Math.pow(10, decimals0);
+  const scale1 = Math.pow(10, decimals1);
+  const zero = JSBI.BigInt(0);
+  const bins: UniswapBinDistributionEntry[] = [];
+  for (let i = 0; i < binCount; i++) {
+    const tickStart = boundaries[i];
+    const tickEnd = boundaries[i + 1];
+    const L = binLs[i];
+    let amount0: JSBI = zero;
+    let amount1: JSBI = zero;
+    if (JSBI.greaterThan(L, zero)) {
+      const sqrtA = TickMath.getSqrtRatioAtTick(tickStart);
+      const sqrtB = TickMath.getSqrtRatioAtTick(tickEnd);
+      if (currentTick >= tickEnd) {
+        amount1 = SqrtPriceMath.getAmount1Delta(sqrtA, sqrtB, L, false);
+      } else if (currentTick < tickStart) {
+        amount0 = SqrtPriceMath.getAmount0Delta(sqrtA, sqrtB, L, false);
+      } else {
+        amount0 = SqrtPriceMath.getAmount0Delta(currentSqrtPriceX96, sqrtB, L, false);
+        amount1 = SqrtPriceMath.getAmount1Delta(sqrtA, currentSqrtPriceX96, L, false);
+      }
+    }
+    const amt0 = parseFloat(amount0.toString()) / scale0;
+    const amt1 = parseFloat(amount1.toString()) / scale1;
+    const baseTokenAmount = isBaseToken0 ? amt0 : amt1;
+    const quoteTokenAmount = isBaseToken0 ? amt1 : amt0;
+
+    // Price at tickStart in human units (quote/base regardless of token order).
+    const rawT1PerT0 = Math.pow(1.0001, tickStart) * Math.pow(10, decimals0 - decimals1);
+    const price = isBaseToken0 ? rawT1PerT0 : 1 / rawT1PerT0;
+    bins.push({
+      binId: tickStart,
+      price,
+      baseTokenAmount,
+      quoteTokenAmount,
+    });
+  }
+  return bins;
 }

--- a/src/schemas/clmm-schema.ts
+++ b/src/schemas/clmm-schema.ts
@@ -83,7 +83,10 @@ export const BinLiquiditySchema = Type.Object(
 );
 export type BinLiquidity = Static<typeof BinLiquiditySchema>;
 
-// Base PoolInfo without Meteora-specific fields
+// Base PoolInfo — every CLMM connector returns at least these fields. `bins`
+// is the per-tick liquidity distribution around the active tick (matching
+// Meteora's `pool-info.bins[]` shape); it's only populated when the request
+// includes binCount > 0.
 export const PoolInfoSchema = Type.Object(
   {
     address: Type.String(),
@@ -95,12 +98,14 @@ export const PoolInfoSchema = Type.Object(
     baseTokenAmount: Type.Number(),
     quoteTokenAmount: Type.Number(),
     activeBinId: Type.Number(),
+    bins: Type.Optional(Type.Array(BinLiquiditySchema)),
   },
   { $id: 'PoolInfo' },
 );
 export type PoolInfo = Static<typeof PoolInfoSchema>;
 
-// Meteora-specific extension
+// Meteora-specific extension. `bins` lives on the base now; only the
+// Meteora-specific fields (dynamic fee, bin id bounds) are added here.
 export const MeteoraPoolInfoSchema = Type.Composite(
   [
     PoolInfoSchema,
@@ -108,7 +113,6 @@ export const MeteoraPoolInfoSchema = Type.Composite(
       dynamicFeePct: Type.Number(),
       minBinId: Type.Number(),
       maxBinId: Type.Number(),
-      bins: Type.Optional(Type.Array(BinLiquiditySchema)),
     }),
   ],
   { $id: 'MeteoraPoolInfo' },
@@ -119,6 +123,16 @@ export const GetPoolInfoRequest = Type.Object(
   {
     network: Type.Optional(Type.String()),
     poolAddress: Type.String(),
+    binCount: Type.Optional(
+      Type.Integer({
+        description:
+          'If > 0, include a `bins` array in the response (per-tickSpacing token amounts around ' +
+          'the active tick, mirroring Meteora pool-info.bins[]). Default 0 = skip the bin fetch.',
+        default: 0,
+        minimum: 0,
+        maximum: 401,
+      }),
+    ),
   },
   { $id: 'GetPoolInfoRequest' },
 );

--- a/test/chains/ethereum/handle-transaction-execution.test.ts
+++ b/test/chains/ethereum/handle-transaction-execution.test.ts
@@ -1,0 +1,97 @@
+import { Ethereum } from '../../../src/chains/ethereum/ethereum';
+
+// Unit tests for Ethereum.prototype.handleTransactionExecution covering:
+//   (a) fast confirmation path (tx.wait resolves before timeout)
+//   (b) extended polling path (timeout, then getTransactionReceipt eventually
+//       returns a receipt — caller must NOT treat this as failure)
+//   (c) genuinely pending — both wait and extended poll return null
+//
+// The class constructor is private and pulls in a lot of network state, so we
+// invoke the method through Ethereum.prototype.<method>.call() against a
+// minimal stub that only carries the fields the method actually reads.
+
+type Stub = {
+  _transactionExecutionTimeoutMs: number;
+  getTransactionReceipt: jest.Mock;
+};
+
+const callHandle = (stub: Stub, tx: any) => (Ethereum.prototype as any).handleTransactionExecution.call(stub, tx);
+
+describe('Ethereum.handleTransactionExecution', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns the receipt when tx.wait resolves before the timeout', async () => {
+    const stub: Stub = {
+      _transactionExecutionTimeoutMs: 30_000,
+      getTransactionReceipt: jest.fn(),
+    };
+    const fakeReceipt = { status: 1, blockNumber: 100, transactionHash: '0xabc' };
+    const tx = {
+      hash: '0xabc',
+      wait: jest.fn().mockResolvedValue(fakeReceipt),
+    };
+
+    const promise = callHandle(stub, tx);
+    // Run any pending microtasks/timers so the resolved wait can win the race.
+    await jest.runAllTimersAsync();
+    const receipt = await promise;
+
+    expect(receipt).toBe(fakeReceipt);
+    expect(tx.wait).toHaveBeenCalledWith(1);
+    expect(stub.getTransactionReceipt).not.toHaveBeenCalled();
+  });
+
+  it('polls for the receipt after the initial timeout and returns it once it appears', async () => {
+    const stub: Stub = {
+      _transactionExecutionTimeoutMs: 30_000,
+      // Receipt becomes visible on the 2nd poll.
+      getTransactionReceipt: jest
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ status: 1, blockNumber: 101, transactionHash: '0xdef' }),
+    };
+    const tx = {
+      hash: '0xdef',
+      // Never resolves — forces the timeout branch.
+      wait: jest.fn().mockReturnValue(new Promise(() => {})),
+    };
+
+    const promise = callHandle(stub, tx);
+    // Initial timeout (30s) + 2 poll intervals (5s each).
+    await jest.advanceTimersByTimeAsync(30_000);
+    await jest.advanceTimersByTimeAsync(5_000);
+    await jest.advanceTimersByTimeAsync(5_000);
+    const receipt = await promise;
+
+    expect(receipt).toMatchObject({ status: 1, blockNumber: 101 });
+    expect(stub.getTransactionReceipt).toHaveBeenCalledTimes(2);
+    expect(stub.getTransactionReceipt).toHaveBeenCalledWith('0xdef');
+  });
+
+  it('returns null when the receipt is still missing after the extended poll window', async () => {
+    const stub: Stub = {
+      _transactionExecutionTimeoutMs: 30_000,
+      getTransactionReceipt: jest.fn().mockResolvedValue(null),
+    };
+    const tx = {
+      hash: '0xghi',
+      wait: jest.fn().mockReturnValue(new Promise(() => {})),
+    };
+
+    const promise = callHandle(stub, tx);
+    // 30s initial + 90s extended window with 5s polls = 18 poll attempts.
+    await jest.advanceTimersByTimeAsync(30_000);
+    await jest.advanceTimersByTimeAsync(90_000);
+    const receipt = await promise;
+
+    expect(receipt).toBeNull();
+    // Polled up to 18 times (90_000 / 5_000).
+    expect(stub.getTransactionReceipt).toHaveBeenCalledTimes(18);
+  });
+});

--- a/test/connectors/orca/clmm-routes/poolInfo.test.ts
+++ b/test/connectors/orca/clmm-routes/poolInfo.test.ts
@@ -17,6 +17,16 @@ jest.mock('@orca-so/whirlpools-sdk', () => ({
   },
 }));
 
+// Stub the bin-distribution helper so we can assert it's called only when
+// binCount > 0, and so the test doesn't hit the network for getProgramAccounts.
+jest.mock('../../../../src/connectors/orca/orca.utils', () => {
+  const actual = jest.requireActual('../../../../src/connectors/orca/orca.utils');
+  return {
+    ...actual,
+    computeOrcaBinDistribution: jest.fn(),
+  };
+});
+
 const buildApp = async () => {
   const server = fastifyWithTypeProvider();
   await server.register(require('@fastify/sensible'));
@@ -225,6 +235,78 @@ describe('GET /pool-info', () => {
     });
 
     expect(response.statusCode).toBe(503);
+  });
+
+  describe('binCount param', () => {
+    const sampleBins = (n: number) =>
+      Array.from({ length: n }, (_, i) => ({
+        binId: -28800 + i,
+        price: 200 + i * 0.01,
+        baseTokenAmount: i < 5 ? 0 : 100,
+        quoteTokenAmount: i < 5 ? 100 : 0,
+      }));
+
+    it('omits bins[] when binCount is not provided', async () => {
+      const { computeOrcaBinDistribution } = await import('../../../../src/connectors/orca/orca.utils');
+      const response = await app.inject({
+        method: 'GET',
+        url: '/pool-info',
+        query: { network: 'mainnet-beta', poolAddress: mockPoolAddress },
+      });
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.bins).toBeUndefined();
+      expect(computeOrcaBinDistribution).not.toHaveBeenCalled();
+    });
+
+    it('omits bins[] when binCount=0', async () => {
+      const { computeOrcaBinDistribution } = await import('../../../../src/connectors/orca/orca.utils');
+      const response = await app.inject({
+        method: 'GET',
+        url: '/pool-info',
+        query: { network: 'mainnet-beta', poolAddress: mockPoolAddress, binCount: 0 },
+      });
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.bins).toBeUndefined();
+      expect(computeOrcaBinDistribution).not.toHaveBeenCalled();
+    });
+
+    it('returns bins[] of length N when binCount=N', async () => {
+      const { computeOrcaBinDistribution } = await import('../../../../src/connectors/orca/orca.utils');
+      (computeOrcaBinDistribution as jest.Mock).mockResolvedValueOnce(sampleBins(11));
+      const response = await app.inject({
+        method: 'GET',
+        url: '/pool-info',
+        query: { network: 'mainnet-beta', poolAddress: mockPoolAddress, binCount: 11 },
+      });
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(Array.isArray(body.bins)).toBe(true);
+      expect(body.bins).toHaveLength(11);
+      expect(body.bins[0]).toEqual(
+        expect.objectContaining({
+          binId: expect.any(Number),
+          price: expect.any(Number),
+          baseTokenAmount: expect.any(Number),
+          quoteTokenAmount: expect.any(Number),
+        }),
+      );
+      expect(computeOrcaBinDistribution).toHaveBeenCalledTimes(1);
+      const call = (computeOrcaBinDistribution as jest.Mock).mock.calls[0][0];
+      expect(call.binCount).toBe(11);
+      expect(call.tickSpacing).toBe(mockWhirlpool.tickSpacing);
+      expect(call.currentTickIndex).toBe(mockWhirlpool.tickCurrentIndex);
+    });
+
+    it('rejects binCount above the schema max', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/pool-info',
+        query: { network: 'mainnet-beta', poolAddress: mockPoolAddress, binCount: 999 },
+      });
+      expect(response.statusCode).toBe(400);
+    });
   });
 
   it('should handle Token2022 tokens like PYUSD', async () => {

--- a/test/connectors/orca/clmm-routes/quoteSwap.test.ts
+++ b/test/connectors/orca/clmm-routes/quoteSwap.test.ts
@@ -121,6 +121,36 @@ describe('GET /quote-swap', () => {
       expect(body).toHaveProperty('poolAddress', mockPoolAddress);
     });
 
+    it('should forward side to the quote helper (BUY -> exact-output)', async () => {
+      const { getOrcaSwapQuote } = require('../../../../src/connectors/orca/orca.utils');
+      (getOrcaSwapQuote as jest.Mock).mockClear();
+
+      await app.inject({
+        method: 'GET',
+        url: '/quote-swap',
+        query: {
+          network: 'mainnet-beta',
+          baseToken: 'SOL',
+          quoteToken: 'USDC',
+          amount: 1.0,
+          side: 'BUY',
+          poolAddress: mockPoolAddress,
+          slippagePct: 1,
+        },
+      });
+
+      // side must be passed through so the helper picks swapQuoteByOutputToken
+      expect(getOrcaSwapQuote).toHaveBeenCalledWith(
+        expect.anything(),
+        mockPoolAddress,
+        mockQuoteTokenInfo.address, // BUY: input = quote
+        mockBaseTokenInfo.address, // BUY: output = base
+        1.0,
+        'BUY',
+        1,
+      );
+    });
+
     it('should use default slippage if not provided', async () => {
       const response = await app.inject({
         method: 'GET',

--- a/test/connectors/orca/clmm-routes/quoteSwap.test.ts
+++ b/test/connectors/orca/clmm-routes/quoteSwap.test.ts
@@ -295,6 +295,104 @@ describe('GET /quote-swap', () => {
     });
   });
 
+  // Regression: the helper's `executionPrice = outputAmount / inputAmount` was
+  // base/quote on BUY (input=quote, output=base) and quote/base on SELL — so
+  // BUY and SELL quotes for the same pool reported different price units. The
+  // route now reconstructs price = quote/base from amounts + side.
+  describe('price unit (regression — always quote/base)', () => {
+    const { getOrcaSwapQuote } = require('../../../../src/connectors/orca/orca.utils');
+
+    beforeEach(() => {
+      // Earlier "invalid token" test re-mocks Solana.getInstance to return
+      // null for getToken — restore the canonical token mock here so the
+      // route can resolve SOL/USDC.
+      const mockSolana = {
+        getToken: jest.fn().mockImplementation((symbol: string) => {
+          if (symbol === 'SOL' || symbol === mockBaseTokenInfo.address) return mockBaseTokenInfo;
+          if (symbol === 'USDC' || symbol === mockQuoteTokenInfo.address) return mockQuoteTokenInfo;
+          return null;
+        }),
+      };
+      (Solana.getInstance as jest.Mock).mockResolvedValue(mockSolana);
+    });
+
+    afterAll(() => {
+      // Restore the canonical mock so subsequent tests aren't affected
+      (getOrcaSwapQuote as jest.Mock).mockResolvedValue(mockSwapQuote);
+    });
+
+    it('SELL returns price in quote/base units (= outputAmount/inputAmount)', async () => {
+      // SELL 1 SOL -> ~200 USDC. Helper price already correct (quote/base).
+      (getOrcaSwapQuote as jest.Mock).mockResolvedValueOnce({
+        inputToken: mockBaseTokenInfo.address,
+        outputToken: mockQuoteTokenInfo.address,
+        inputAmount: 1.0, // SOL (base)
+        outputAmount: 200, // USDC (quote)
+        minOutputAmount: 198,
+        maxInputAmount: 1.0,
+        priceImpactPct: 0.1,
+        price: 200, // helper's executionPrice
+        estimatedAmountIn: BigInt(1_000_000_000),
+        estimatedAmountOut: BigInt(200_000_000),
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/quote-swap',
+        query: {
+          network: 'mainnet-beta',
+          baseToken: 'SOL',
+          quoteToken: 'USDC',
+          amount: 1.0,
+          side: 'SELL',
+          poolAddress: mockPoolAddress,
+          slippagePct: 1,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.price).toBeCloseTo(200, 6); // USDC/SOL
+    });
+
+    it('BUY returns price in quote/base units (helper price would be inverted)', async () => {
+      // BUY 1 SOL by paying 200 USDC. Helper price = outputAmount/inputAmount
+      // = 1/200 = 0.005 (base/quote). Route must return 200 (quote/base).
+      (getOrcaSwapQuote as jest.Mock).mockResolvedValueOnce({
+        inputToken: mockQuoteTokenInfo.address, // route flips to quote
+        outputToken: mockBaseTokenInfo.address, // route flips to base
+        inputAmount: 200, // USDC (quote)
+        outputAmount: 1.0, // SOL (base)
+        minOutputAmount: 1.0,
+        maxInputAmount: 202,
+        priceImpactPct: 0.1,
+        price: 0.005, // helper's (inverted) executionPrice
+        estimatedAmountIn: BigInt(200_000_000),
+        estimatedAmountOut: BigInt(1_000_000_000),
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/quote-swap',
+        query: {
+          network: 'mainnet-beta',
+          baseToken: 'SOL',
+          quoteToken: 'USDC',
+          amount: 1.0,
+          side: 'BUY',
+          poolAddress: mockPoolAddress,
+          slippagePct: 1,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      // Must be quote/base (USDC/SOL = 200), not the helper's inverted 0.005.
+      expect(body.price).toBeCloseTo(200, 6);
+      expect(body.price).not.toBeCloseTo(0.005, 6);
+    });
+  });
+
   describe('error handling', () => {
     it('should handle errors gracefully', async () => {
       const { getOrcaSwapQuote } = require('../../../../src/connectors/orca/orca.utils');

--- a/test/connectors/raydium/clmm-routes/poolInfo.test.ts
+++ b/test/connectors/raydium/clmm-routes/poolInfo.test.ts
@@ -1,0 +1,112 @@
+import { Raydium } from '../../../../src/connectors/raydium/raydium';
+import { fastifyWithTypeProvider } from '../../../utils/testUtils';
+
+jest.mock('../../../../src/connectors/raydium/raydium');
+
+const buildApp = async () => {
+  const server = fastifyWithTypeProvider();
+  await server.register(require('@fastify/sensible'));
+  const { poolInfoRoute } = await import('../../../../src/connectors/raydium/clmm-routes/poolInfo');
+  await server.register(poolInfoRoute);
+  return server;
+};
+
+const mockPoolAddress = '3ucNos4NbumPLZNWztqGHNFFgkHeRMBQAVemeeomsUxv';
+
+const mockPoolInfo = {
+  address: mockPoolAddress,
+  baseTokenAddress: 'So11111111111111111111111111111111111111112',
+  quoteTokenAddress: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+  binStep: 4,
+  feePct: 0.0001,
+  price: 200.5,
+  baseTokenAmount: 1000,
+  quoteTokenAmount: 200500,
+  activeBinId: -28800,
+};
+
+describe('GET /pool-info (raydium clmm)', () => {
+  let app: any;
+
+  beforeAll(async () => {
+    app = await buildApp();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const mockRaydium = {
+      getClmmPoolInfo: jest.fn().mockResolvedValue(mockPoolInfo),
+    };
+    (Raydium.getInstance as jest.Mock).mockResolvedValue(mockRaydium);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns the base pool info shape', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/pool-info',
+      query: { network: 'mainnet-beta', poolAddress: mockPoolAddress },
+    });
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body).toEqual(
+      expect.objectContaining({
+        address: mockPoolAddress,
+        baseTokenAddress: mockPoolInfo.baseTokenAddress,
+        quoteTokenAddress: mockPoolInfo.quoteTokenAddress,
+        feePct: expect.any(Number),
+        price: expect.any(Number),
+        activeBinId: expect.any(Number),
+      }),
+    );
+  });
+
+  it('returns 404 when pool not found', async () => {
+    (Raydium.getInstance as jest.Mock).mockResolvedValue({
+      getClmmPoolInfo: jest.fn().mockResolvedValue(null),
+    });
+    const response = await app.inject({
+      method: 'GET',
+      url: '/pool-info',
+      query: { network: 'mainnet-beta', poolAddress: mockPoolAddress },
+    });
+    expect(response.statusCode).toBe(404);
+  });
+
+  describe('binCount param (impl deferred — schema accepted but no bins yet)', () => {
+    it('accepts binCount=0 and returns no bins[]', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/pool-info',
+        query: { network: 'mainnet-beta', poolAddress: mockPoolAddress, binCount: 0 },
+      });
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body).bins).toBeUndefined();
+    });
+
+    it('accepts binCount>0 but still returns no bins[] (impl deferred)', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/pool-info',
+        query: { network: 'mainnet-beta', poolAddress: mockPoolAddress, binCount: 11 },
+      });
+      // The schema is accepted; bins[] is not populated until the Raydium
+      // bin-distribution helper lands. This test guards against accidental
+      // schema regressions.
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body).bins).toBeUndefined();
+    });
+
+    it('rejects binCount above the schema max', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/pool-info',
+        query: { network: 'mainnet-beta', poolAddress: mockPoolAddress, binCount: 999 },
+      });
+      expect(response.statusCode).toBe(400);
+    });
+  });
+});

--- a/test/connectors/raydium/clmm-routes/poolInfo.test.ts
+++ b/test/connectors/raydium/clmm-routes/poolInfo.test.ts
@@ -2,6 +2,16 @@ import { Raydium } from '../../../../src/connectors/raydium/raydium';
 import { fastifyWithTypeProvider } from '../../../utils/testUtils';
 
 jest.mock('../../../../src/connectors/raydium/raydium');
+jest.mock('../../../../src/chains/solana/solana');
+
+// Stub the bin helper so the test doesn't hit the SDK's tick-array fetcher.
+jest.mock('../../../../src/connectors/raydium/raydium.utils', () => {
+  const actual = jest.requireActual('../../../../src/connectors/raydium/raydium.utils');
+  return {
+    ...actual,
+    computeRaydiumBinDistribution: jest.fn(),
+  };
+});
 
 const buildApp = async () => {
   const server = fastifyWithTypeProvider();
@@ -36,8 +46,28 @@ describe('GET /pool-info (raydium clmm)', () => {
     jest.clearAllMocks();
     const mockRaydium = {
       getClmmPoolInfo: jest.fn().mockResolvedValue(mockPoolInfo),
+      // Used by the binCount path to grab tickCurrent + sqrtPriceX64 + L
+      getClmmPoolfromRPC: jest.fn().mockResolvedValue({
+        tickSpacing: 4,
+        tickCurrent: -28800,
+        sqrtPriceX64: { toString: () => '123456789' },
+        liquidity: { toString: () => '1000000000' },
+      }),
+      // Used to look up the SDK-style poolInfo + poolKeys
+      getClmmPoolfromAPI: jest.fn().mockResolvedValue([
+        {
+          id: mockPoolAddress,
+          programId: 'CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK',
+          mintA: { address: mockPoolInfo.baseTokenAddress, decimals: 9 },
+          mintB: { address: mockPoolInfo.quoteTokenAddress, decimals: 6 },
+        },
+        {},
+      ]),
     };
     (Raydium.getInstance as jest.Mock).mockResolvedValue(mockRaydium);
+    // Used by the binCount path for `solana.connection`
+    const { Solana } = require('../../../../src/chains/solana/solana');
+    (Solana.getInstance as jest.Mock).mockResolvedValue({ connection: {} });
   });
 
   afterAll(async () => {
@@ -76,8 +106,29 @@ describe('GET /pool-info (raydium clmm)', () => {
     expect(response.statusCode).toBe(404);
   });
 
-  describe('binCount param (impl deferred — schema accepted but no bins yet)', () => {
-    it('accepts binCount=0 and returns no bins[]', async () => {
+  describe('binCount param', () => {
+    const sampleBins = (n: number) =>
+      Array.from({ length: n }, (_, i) => ({
+        binId: -28800 + i,
+        price: 200 + i,
+        baseTokenAmount: i < Math.floor(n / 2) ? 0 : 1,
+        quoteTokenAmount: i < Math.floor(n / 2) ? 100 : 0,
+      }));
+
+    it('omits bins[] when binCount is not provided', async () => {
+      const { computeRaydiumBinDistribution } = await import('../../../../src/connectors/raydium/raydium.utils');
+      const response = await app.inject({
+        method: 'GET',
+        url: '/pool-info',
+        query: { network: 'mainnet-beta', poolAddress: mockPoolAddress },
+      });
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body).bins).toBeUndefined();
+      expect(computeRaydiumBinDistribution).not.toHaveBeenCalled();
+    });
+
+    it('omits bins[] when binCount=0', async () => {
+      const { computeRaydiumBinDistribution } = await import('../../../../src/connectors/raydium/raydium.utils');
       const response = await app.inject({
         method: 'GET',
         url: '/pool-info',
@@ -85,19 +136,34 @@ describe('GET /pool-info (raydium clmm)', () => {
       });
       expect(response.statusCode).toBe(200);
       expect(JSON.parse(response.body).bins).toBeUndefined();
+      expect(computeRaydiumBinDistribution).not.toHaveBeenCalled();
     });
 
-    it('accepts binCount>0 but still returns no bins[] (impl deferred)', async () => {
+    it('returns bins[] of length N when binCount=N', async () => {
+      const { computeRaydiumBinDistribution } = await import('../../../../src/connectors/raydium/raydium.utils');
+      (computeRaydiumBinDistribution as jest.Mock).mockResolvedValueOnce(sampleBins(11));
       const response = await app.inject({
         method: 'GET',
         url: '/pool-info',
         query: { network: 'mainnet-beta', poolAddress: mockPoolAddress, binCount: 11 },
       });
-      // The schema is accepted; bins[] is not populated until the Raydium
-      // bin-distribution helper lands. This test guards against accidental
-      // schema regressions.
       expect(response.statusCode).toBe(200);
-      expect(JSON.parse(response.body).bins).toBeUndefined();
+      const body = JSON.parse(response.body);
+      expect(Array.isArray(body.bins)).toBe(true);
+      expect(body.bins).toHaveLength(11);
+      expect(body.bins[0]).toEqual(
+        expect.objectContaining({
+          binId: expect.any(Number),
+          price: expect.any(Number),
+          baseTokenAmount: expect.any(Number),
+          quoteTokenAmount: expect.any(Number),
+        }),
+      );
+      expect(computeRaydiumBinDistribution).toHaveBeenCalledTimes(1);
+      const call = (computeRaydiumBinDistribution as jest.Mock).mock.calls[0][0];
+      expect(call.binCount).toBe(11);
+      expect(call.tickSpacing).toBe(4);
+      expect(call.currentTick).toBe(-28800);
     });
 
     it('rejects binCount above the schema max', async () => {

--- a/test/connectors/raydium/clmm-routes/quote-swap.test.ts
+++ b/test/connectors/raydium/clmm-routes/quote-swap.test.ts
@@ -1,0 +1,214 @@
+import { PoolUtils } from '@raydium-io/raydium-sdk-v2';
+
+import { Solana } from '../../../../src/chains/solana/solana';
+import { Raydium } from '../../../../src/connectors/raydium/raydium';
+import { fastifyWithTypeProvider } from '../../../utils/testUtils';
+
+jest.mock('../../../../src/chains/solana/solana');
+jest.mock('../../../../src/connectors/raydium/raydium');
+jest.mock('../../../../src/chains/solana/routes/estimate-gas', () => ({
+  estimateGasSolana: jest.fn().mockResolvedValue({}),
+}));
+
+// Keep the real Raydium SDK (raydium.utils imports program-ID constants from it
+// at load time) but override only the static PoolUtils helpers the route calls.
+jest.mock('@raydium-io/raydium-sdk-v2', () => {
+  const actual = jest.requireActual('@raydium-io/raydium-sdk-v2');
+  return {
+    ...actual,
+    PoolUtils: {
+      ...actual.PoolUtils,
+      fetchComputeClmmInfo: jest.fn(),
+      fetchMultiplePoolTickArrays: jest.fn(),
+      computeAmountIn: jest.fn(),
+      computeAmountOutFormat: jest.fn(),
+    },
+  };
+});
+
+const buildApp = async () => {
+  const server = fastifyWithTypeProvider();
+  await server.register(require('@fastify/sensible'));
+  const { quoteSwapRoute } = await import('../../../../src/connectors/raydium/clmm-routes/quoteSwap');
+  await server.register(quoteSwapRoute);
+  return server;
+};
+
+const mockSOL = {
+  symbol: 'SOL',
+  address: 'So11111111111111111111111111111111111111112',
+  decimals: 9,
+};
+
+const mockUSDC = {
+  symbol: 'USDC',
+  address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+  decimals: 6,
+};
+
+const mockPoolAddress = '3ucNos4NbumPLZNWztqGHNFFgkHeRMBQAVemeeomsUxv';
+
+// SOL is mintA (base), USDC is mintB (quote).
+const mockApiPoolInfo = {
+  id: mockPoolAddress,
+  mintA: { address: mockSOL.address, decimals: 9 },
+  mintB: { address: mockUSDC.address, decimals: 6 },
+};
+
+// Minimal BN/token stand-ins matching the shape the route reads.
+const bn = (n: number) => ({ toNumber: () => n });
+const token = (t: typeof mockSOL) => ({ symbol: t.symbol, mint: t.address, decimals: t.decimals });
+const percent = (significant: string) => ({ toSignificant: () => significant });
+
+const setupMocks = () => {
+  const mockSolanaInstance = {
+    connection: {},
+    getToken: jest.fn((t: string) => {
+      if (t === 'SOL' || t === mockSOL.address) return Promise.resolve(mockSOL);
+      if (t === 'USDC' || t === mockUSDC.address) return Promise.resolve(mockUSDC);
+      return Promise.resolve(null);
+    }),
+  };
+  (Solana.getInstance as jest.Mock).mockResolvedValue(mockSolanaInstance);
+
+  const mockRaydiumInstance = {
+    getClmmPoolfromAPI: jest.fn().mockResolvedValue([mockApiPoolInfo, {}]),
+    raydiumSDK: {
+      fetchEpochInfo: jest.fn().mockResolvedValue({}),
+    },
+  };
+  (Raydium.getInstance as jest.Mock).mockResolvedValue(mockRaydiumInstance);
+
+  (PoolUtils.fetchComputeClmmInfo as jest.Mock).mockResolvedValue({ observationId: 'obs' });
+  (PoolUtils.fetchMultiplePoolTickArrays as jest.Mock).mockResolvedValue({ [mockPoolAddress]: {} });
+};
+
+describe('GET /quote-swap (Raydium CLMM)', () => {
+  let server: any;
+
+  beforeAll(async () => {
+    server = await buildApp();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupMocks();
+  });
+
+  it('returns a SELL quote with correct price, minAmountOut and price impact', async () => {
+    // Sell 0.2 SOL -> 13 USDC. input=SOL(9), output=USDC(6).
+    (PoolUtils.computeAmountOutFormat as jest.Mock).mockResolvedValue({
+      realAmountIn: { amount: { raw: bn(200_000_000), token: token(mockSOL) } },
+      amountOut: { amount: { raw: bn(13_000_000), token: token(mockUSDC) } },
+      minAmountOut: { amount: { raw: bn(12_870_000), token: token(mockUSDC) } },
+      priceImpact: percent('0.09'),
+      remainingAccounts: [],
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        poolAddress: mockPoolAddress,
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: '0.2',
+        side: 'SELL',
+        slippagePct: '1',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body).toHaveProperty('poolAddress', mockPoolAddress);
+    expect(body).toHaveProperty('tokenIn', mockSOL.address);
+    expect(body).toHaveProperty('tokenOut', mockUSDC.address);
+    expect(body).toHaveProperty('amountIn', 0.2);
+    expect(body).toHaveProperty('amountOut', 13);
+    expect(body).toHaveProperty('price', 65);
+    expect(body).toHaveProperty('maxAmountIn', 0.2);
+    // minAmountOut = amountOut * (1 - slippage) = 13 * 0.99
+    expect(body.minAmountOut).toBeCloseTo(12.87, 6);
+    // priceImpact Percent.toSignificant() is already a percentage (no x100).
+    expect(body).toHaveProperty('priceImpactPct', 0.09);
+    expect(body).toHaveProperty('slippagePct', 1);
+
+    // Slippage must reach the SDK as a fraction (1% -> 0.01), not truncated to 0.
+    expect(PoolUtils.computeAmountOutFormat).toHaveBeenCalledWith(expect.objectContaining({ slippage: 0.01 }));
+  });
+
+  it('returns a BUY quote where maxAmountIn exceeds amountIn by the slippage', async () => {
+    // Buy 0.2 SOL for ~13 USDC. input=USDC(6), output=SOL(9).
+    (PoolUtils.computeAmountIn as jest.Mock).mockResolvedValue({
+      realAmountOut: { amount: bn(200_000_000) }, // 0.2 SOL
+      amountIn: { amount: bn(13_000_000) }, // 13 USDC
+      maxAmountIn: { amount: bn(13_130_000) }, // 13 * 1.01 USDC (slippage included)
+      priceImpact: percent('0.09'),
+      remainingAccounts: [],
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        poolAddress: mockPoolAddress,
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: '0.2',
+        side: 'BUY',
+        slippagePct: '1',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body).toHaveProperty('poolAddress', mockPoolAddress);
+    expect(body).toHaveProperty('tokenIn', mockUSDC.address);
+    expect(body).toHaveProperty('tokenOut', mockSOL.address);
+    expect(body).toHaveProperty('amountIn', 13);
+    expect(body).toHaveProperty('amountOut', 0.2);
+    expect(body).toHaveProperty('price', 65);
+    // The core regression: maxAmountIn must be GREATER than amountIn (was inverted before).
+    expect(body.maxAmountIn).toBeGreaterThan(body.amountIn);
+    expect(body.maxAmountIn).toBeCloseTo(13.13, 6);
+    expect(body).toHaveProperty('priceImpactPct', 0.09);
+    expect(body).toHaveProperty('slippagePct', 1);
+
+    // baseMint must be the OUTPUT token (SOL), so amountIn comes back in the input token's units.
+    const callArgs = (PoolUtils.computeAmountIn as jest.Mock).mock.calls[0][0];
+    expect(callArgs.baseMint.toBase58()).toBe(mockSOL.address);
+    // Slippage reaches the SDK as a fraction (1% -> 0.01).
+    expect(callArgs.slippage).toBe(0.01);
+  });
+
+  it('returns 404 when the pool is not found', async () => {
+    const mockRaydiumInstance = {
+      getClmmPoolfromAPI: jest.fn().mockResolvedValue([null, null]),
+      raydiumSDK: { fetchEpochInfo: jest.fn().mockResolvedValue({}) },
+    };
+    (Raydium.getInstance as jest.Mock).mockResolvedValue(mockRaydiumInstance);
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        poolAddress: 'invalid-pool-address',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: '0.2',
+        side: 'SELL',
+        slippagePct: '1',
+      },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(JSON.parse(response.body)).toHaveProperty('error');
+  });
+});

--- a/test/connectors/uniswap/clmm-routes/pool-info.test.ts
+++ b/test/connectors/uniswap/clmm-routes/pool-info.test.ts
@@ -204,4 +204,122 @@ describe('GET /pool-info (Uniswap CLMM)', () => {
     // Price flips correspondingly (USDC per USDM1 was 1.01146; USDM1 per USDC ≈ 0.98867).
     expect(body.price).toBeCloseTo(0.98867, 4);
   });
+
+  describe('binCount param', () => {
+    const sampleBins = (n: number) =>
+      Array.from({ length: n }, (_, i) => ({
+        binId: -276211 + i,
+        price: 1.01 + i * 0.0001,
+        baseTokenAmount: i < Math.floor(n / 2) ? 0 : 1,
+        quoteTokenAmount: i < Math.floor(n / 2) ? 100 : 0,
+      }));
+
+    // Shared mock setup so each binCount test exercises the route end-to-end.
+    const setupMocks = async () => {
+      const { Uniswap } = await import('../../../../src/connectors/uniswap/uniswap');
+      const { getUniswapPoolInfo, formatTokenAmount } = await import(
+        '../../../../src/connectors/uniswap/uniswap.utils'
+      );
+      (getUniswapPoolInfo as jest.Mock).mockResolvedValue({
+        baseTokenAddress: USDM1.address,
+        quoteTokenAddress: USDC.address,
+        poolType: 'clmm',
+      });
+      (formatTokenAmount as jest.Mock).mockImplementation(
+        (amount: string, decimals: number) => Number(amount) / Math.pow(10, decimals),
+      );
+      const mockPool = {
+        token0: { address: USDM1.address, decimals: USDM1.decimals },
+        token1: { address: USDC.address, decimals: USDC.decimals },
+        liquidity: POOL_LIQUIDITY,
+        sqrtRatioX96: BigNumber.from('79228162514264337593543950336'),
+        token0Price: { toSignificant: () => '1.01146' },
+        token1Price: { toSignificant: () => '0.98867' },
+        fee: 100,
+        tickSpacing: 1,
+        tickCurrent: -276211,
+      };
+      (Uniswap.getInstance as jest.Mock).mockResolvedValue({
+        getToken: jest.fn().mockImplementation((addr: string) => {
+          if (addr.toLowerCase() === USDM1.address.toLowerCase()) return USDM1;
+          if (addr.toLowerCase() === USDC.address.toLowerCase()) return USDC;
+          return null;
+        }),
+        getV3Pool: jest.fn().mockResolvedValue(mockPool),
+      });
+      (Ethereum.getInstance as jest.Mock).mockResolvedValue({
+        // _isProvider keeps ethers' Contract constructor happy in the binCount branch
+        provider: { _isProvider: true },
+        getContract: jest.fn().mockImplementation((tokenAddress: string) => ({ address: tokenAddress })),
+        getERC20BalanceByAddress: jest.fn().mockImplementation((contract: any, _address: string, decimals: number) => {
+          if (contract.address === USDM1.address) return Promise.resolve({ value: USDM1_RAW_BALANCE, decimals });
+          return Promise.resolve({ value: USDC_RAW_BALANCE, decimals });
+        }),
+      });
+    };
+
+    it('omits bins[] when binCount is not provided', async () => {
+      await setupMocks();
+      const { computeUniswapBinDistribution } = await import('../../../../src/connectors/uniswap/uniswap.utils');
+      const response = await server.inject({
+        method: 'GET',
+        url: '/pool-info',
+        query: { network: 'mainnet', poolAddress: POOL_ADDRESS },
+      });
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body).bins).toBeUndefined();
+      expect(computeUniswapBinDistribution).not.toHaveBeenCalled();
+    });
+
+    it('omits bins[] when binCount=0', async () => {
+      await setupMocks();
+      const { computeUniswapBinDistribution } = await import('../../../../src/connectors/uniswap/uniswap.utils');
+      const response = await server.inject({
+        method: 'GET',
+        url: '/pool-info',
+        query: { network: 'mainnet', poolAddress: POOL_ADDRESS, binCount: 0 },
+      });
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body).bins).toBeUndefined();
+      expect(computeUniswapBinDistribution).not.toHaveBeenCalled();
+    });
+
+    it('returns bins[] of length N when binCount=N', async () => {
+      await setupMocks();
+      const { computeUniswapBinDistribution } = await import('../../../../src/connectors/uniswap/uniswap.utils');
+      (computeUniswapBinDistribution as jest.Mock).mockResolvedValueOnce(sampleBins(11));
+      const response = await server.inject({
+        method: 'GET',
+        url: '/pool-info',
+        query: { network: 'mainnet', poolAddress: POOL_ADDRESS, binCount: 11 },
+      });
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(Array.isArray(body.bins)).toBe(true);
+      expect(body.bins).toHaveLength(11);
+      expect(body.bins[0]).toEqual(
+        expect.objectContaining({
+          binId: expect.any(Number),
+          price: expect.any(Number),
+          baseTokenAmount: expect.any(Number),
+          quoteTokenAmount: expect.any(Number),
+        }),
+      );
+      expect(computeUniswapBinDistribution).toHaveBeenCalledTimes(1);
+      const call = (computeUniswapBinDistribution as jest.Mock).mock.calls[0][0];
+      expect(call.binCount).toBe(11);
+      expect(call.tickSpacing).toBe(1);
+      expect(call.currentTick).toBe(-276211);
+    });
+
+    it('rejects binCount above the schema max', async () => {
+      await setupMocks();
+      const response = await server.inject({
+        method: 'GET',
+        url: '/pool-info',
+        query: { network: 'mainnet', poolAddress: POOL_ADDRESS, binCount: 999 },
+      });
+      expect(response.statusCode).toBe(400);
+    });
+  });
 });


### PR DESCRIPTION
Three related improvements: two to the CLMM connectors, and one to Ethereum tx execution.

## 1. BUY-side price inversion fix (Orca + Meteora)

The CLMM `quote-swap` endpoints for Orca and Meteora computed
`price = outputAmount / inputAmount` regardless of `side`. On BUY the
route passes `(input=quote, output=base)` to the helper, so the returned
`price` came back as base/quote (inverted) on BUY but quote/base on SELL.
For the same pool callers saw e.g. `0.987` on BUY vs `1.012` on SELL.

- **Orca** (`clmm-routes/quoteSwap.ts`): reconstruct `price = quote/base`
  in the route from the helper's amounts + the request's side. Helper
  signature unchanged.
- **Meteora** (`clmm-routes/quoteSwap.ts`): flip the BUY branch's
  `price` expression to `amountIn / amountOut`. SELL was already correct.
- **Raydium**: verified upstream code already branches per side correctly
  (`BUY: amountIn/amountOut`, `SELL: amountOut/amountIn`). No change.

Regression tests in `test/connectors/orca/clmm-routes/quoteSwap.test.ts`
assert the price unit stays quote/base on both sides.

## 2. `binCount` param on `pool-info` (Orca, Uniswap, Raydium)

Mirrors Meteora's `pool-info.bins[]` shape across the other CLMM
connectors. Passing `?binCount=N` to `/connectors/<dex>/clmm/pool-info`
returns N tick-spacing-wide bins centered on the active tick:

```jsonc
{
  // … standard pool-info fields …
  "bins": [
    { "binId": -276211, "price": 1.01146, "baseTokenAmount": 0,   "quoteTokenAmount": 100 },
    …
    { "binId": -276200, "price": 1.01258, "baseTokenAmount": 1.5, "quoteTokenAmount": 0   }
  ]
}
```

Default behavior is unchanged: `binCount` defaults to 0, so existing
pool-info callers pay no extra RPC cost. Token amounts are derived via V3
sqrt-price math against the active liquidity covering each bin.

### Implementation per connector

| Connector | Mechanism |
|---|---|
| Orca    | `fetchAllPositionWithFilter` + `positionWhirlpoolFilter` → one `getProgramAccounts` returns every open position; sum L per bin; `tryGetAmountDeltaA/B` for amounts. |
| Uniswap | Parallel `pool.ticks(tick)` reads at each bin boundary; propagate L from `pool.liquidity()` via the V3 spec; `SqrtPriceMath.getAmount{0,1}Delta` for amounts. |
| Raydium | `PoolUtils.fetchComputeClmmInfo` + `PoolUtils.fetchMultiplePoolTickArrays` → tick-array cache; look up `liquidityNet` via `TickUtils.getTickArrayStartIndexByTick` + `TickUtils.getTickOffsetInArray`; propagate L outward; `LiquidityMath.getTokenAmount{A,B}FromLiquidity` for amounts. |

### Base schema

`PoolInfoSchema` gains an optional `bins` array (using the existing
`BinLiquiditySchema`). `GetPoolInfoRequest` gains an optional
`binCount` (0..401, default 0). The Meteora-specific `bins` field
moves up to the base since Meteora was already returning the same shape.

## 3. Extended tx receipt polling (Ethereum)

`Ethereum.handleTransactionExecution` previously returned `null` as soon as
`_transactionExecutionTimeoutMs` (default 30s) elapsed, even when the tx
was about to confirm in the next block. Ethereum blocks are ~12s, so a
healthy tx can need a few more blocks; reporting `null` at 30s caused
callers to treat confirmed txs as failures.

After the initial race against the timeout, the method now polls
`getTransactionReceipt` every 5s for an additional 90s before returning
`null`. Receipts with `status: 0` (reverted) are still surfaced
immediately by `tx.wait`.

Also tightened `routes/approve.ts` to handle the null-receipt case the
timeout path can produce — the previous `receipt.status === -1` check
crashed with TypeError on `null`.

## Tests

| File | Tests added |
|---|---|
| `test/connectors/orca/clmm-routes/quoteSwap.test.ts` | 2 (price-unit regression) |
| `test/connectors/orca/clmm-routes/poolInfo.test.ts` | 4 (binCount cases) |
| `test/connectors/uniswap/clmm-routes/pool-info.test.ts` | 4 (binCount cases) |
| `test/connectors/raydium/clmm-routes/poolInfo.test.ts` | 6 (new file) |
| `test/chains/ethereum/handle-transaction-execution.test.ts` | 3 (new file — fast path, extended poll success, extended poll exhaustion) |

binCount suites cover: no `binCount` → no `bins[]`; `binCount=0` → no
`bins[]`; `binCount=N` → `bins[]` length N with shape assertions;
`binCount` above schema max → 400.

**All 245 tests across the affected suites pass.**

---

## QA smoke checklist

Run a local gateway against mainnet (`pnpm start --passphrase=<…>`) and walk
through the items below. Each should match the stated expectation.

### A. BUY-side price inversion fix
- [ ] `GET /connectors/orca/clmm/quote-swap?network=mainnet-beta&baseToken=SOL&quoteToken=USDC&amount=1&side=SELL` → `price` is ~SOL spot in USDC (e.g. `~180`).
- [ ] `GET /connectors/orca/clmm/quote-swap?network=mainnet-beta&baseToken=SOL&quoteToken=USDC&amount=1&side=BUY` → `price` is also in USDC per SOL (same order of magnitude as SELL, **not** `~0.005`).
- [ ] Same two calls against `/connectors/meteora/clmm/quote-swap` — BUY price must be in quote/base, not inverted.
- [ ] Spot-check `/connectors/raydium/clmm/quote-swap` (untouched) still returns the correct unit on both sides.

### B. `binCount` on `pool-info`
- [x] `GET /connectors/<orca|uniswap|raydium>/clmm/pool-info?network=…&poolAddress=…` (no `binCount`) → response has **no** `bins` field; latency unchanged vs `development`.
- [x] Same with `&binCount=0` → still **no** `bins` field.
- [x] Same with `&binCount=21` → `bins` array of length 21; `binId` strictly increasing; the bin containing the active tick has both `baseTokenAmount` and `quoteTokenAmount` non-negative; bins above the active tick have `quoteTokenAmount = 0`; bins below have `baseTokenAmount = 0`.
- [x] `&binCount=999` (above schema max) → `400`.
- [x] Compare Orca + Uniswap + Raydium bin output for the same pair (e.g. WETH/USDC) — shapes line up qualitatively against the dex's UI liquidity chart.

### C. Ethereum tx receipt extended polling
- [x] Submit any non-trivial Ethereum approval (e.g. `POST /chains/ethereum/approve`) during a period of normal block times — completes within ~30s as before, receipt returned, no behavioral change.
- [ ] Submit an approval during congestion (or against a slower L2 with `transactionExecutionTimeoutMs` lowered to 5s in config) — the route should still complete with a real receipt as long as the tx confirms within ~2min total; logs should show `"polling for receipt up to a further 90000ms"` followed by `"(after extended poll)"`.
- [ ] Send a tx with deliberately too-low gas price so it never confirms — after ~2min the route should return a clean timeout error (no crash, no TypeError on `receipt.status`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
