### PR TITLE
feat: add DFlow, OKX, and Titan Solana router connectors

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -17,12 +17,15 @@ import { ethereumRoutes } from './chains/ethereum/ethereum.routes';
 import { solanaRoutes } from './chains/solana/solana.routes';
 import { configRoutes } from './config/config.routes';
 import { register0xRoutes } from './connectors/0x/0x.routes';
+import { dflowRoutes } from './connectors/dflow/dflow.routes';
 import { jupiterRoutes } from './connectors/jupiter/jupiter.routes';
 import { meteoraRoutes } from './connectors/meteora/meteora.routes';
+import { okxRoutes } from './connectors/okx/okx.routes';
 import { orcaRoutes } from './connectors/orca/orca.routes';
 import { pancakeswapRoutes } from './connectors/pancakeswap/pancakeswap.routes';
 import { pancakeswapSolRoutes } from './connectors/pancakeswap-sol/pancakeswap-sol.routes';
 import { raydiumRoutes } from './connectors/raydium/raydium.routes';
+import { titanRoutes } from './connectors/titan/titan.routes';
 import { uniswapRoutes } from './connectors/uniswap/uniswap.routes';
 import { getHttpsOptions } from './https';
 import { rootPath } from './paths';
@@ -118,6 +121,18 @@ const swaggerOptions = {
       {
         name: '/connector/pancakeswap',
         description: 'PancakeSwap EVM connector endpoints',
+      },
+      {
+        name: '/connector/dflow',
+        description: 'DFlow connector endpoints',
+      },
+      {
+        name: '/connector/okx',
+        description: 'OKX DEX aggregator connector endpoints',
+      },
+      {
+        name: '/connector/titan',
+        description: 'Titan connector endpoints',
       },
     ],
     components: {
@@ -290,6 +305,21 @@ const configureGatewayServer = () => {
     // Jupiter routes
     app.register(jupiterRoutes.router, {
       prefix: '/connectors/jupiter/router',
+    });
+
+    // DFlow routes
+    app.register(dflowRoutes.router, {
+      prefix: '/connectors/dflow/router',
+    });
+
+    // OKX DEX aggregator routes
+    app.register(okxRoutes.router, {
+      prefix: '/connectors/okx/router',
+    });
+
+    // Titan routes
+    app.register(titanRoutes.router, {
+      prefix: '/connectors/titan/router',
     });
 
     // Meteora routes

--- a/src/chains/solana/solana.ts
+++ b/src/chains/solana/solana.ts
@@ -1492,7 +1492,7 @@ export class Solana {
       const priorityFeeMicroLamports = Math.floor(currentPriorityFee * 1_000_000);
       tx.feePayer = wallet as PublicKey;
       tx.instructions = [
-        ...tx.instructions.filter((inst) => !inst.programId.equals(ComputeBudgetProgram.programId)),
+        ...tx.instructions.filter((inst) => !Solana.isReplacedComputeBudgetInstruction(inst.programId, inst.data)),
         ComputeBudgetProgram.setComputeUnitPrice({ microLamports: priorityFeeMicroLamports }),
         ComputeBudgetProgram.setComputeUnitLimit({ units: computeUnitsToUse }),
       ];
@@ -1525,6 +1525,16 @@ export class Solana {
     throw this.confirmationTimeoutError(signature);
   }
 
+  /**
+   * True for ComputeBudget instructions Gateway manages itself (SetComputeUnitLimit,
+   * SetComputeUnitPrice — discriminators 2 and 3). Other ComputeBudget instruction types
+   * (e.g. RequestHeapFrame, SetLoadedAccountsDataSizeLimit) must be preserved: some
+   * aggregator programs (Titan) require a larger heap frame and crash without it.
+   */
+  private static isReplacedComputeBudgetInstruction(programId: PublicKey, data: Uint8Array | Buffer): boolean {
+    return programId.equals(ComputeBudgetProgram.programId) && (data[0] === 2 || data[0] === 3);
+  }
+
   private async prepareTx(
     tx: Transaction,
     currentPriorityFee: number,
@@ -1536,9 +1546,10 @@ export class Solana {
       microLamports: priorityFeeMicroLamports,
     });
 
-    // Remove any existing priority fee instructions and add the new one
+    // Remove any existing CU-price/limit instructions (preserving other ComputeBudget
+    // types like RequestHeapFrame) and add the new one
     tx.instructions = [
-      ...tx.instructions.filter((inst) => !inst.programId.equals(ComputeBudgetProgram.programId)),
+      ...tx.instructions.filter((inst) => !Solana.isReplacedComputeBudgetInstruction(inst.programId, inst.data)),
       priorityFeeInstruction,
     ];
 
@@ -1622,9 +1633,11 @@ export class Solana {
         }),
       );
     } else {
-      // Remove compute budget instructions from original instructions
+      // Remove existing CU-price/limit instructions, preserving other ComputeBudget
+      // instruction types (e.g. RequestHeapFrame, which some aggregator programs require)
       const nonComputeBudgetInstructions = originalMessage.compiledInstructions.filter(
-        (ix) => !originalMessage.staticAccountKeys[ix.programIdIndex].equals(ComputeBudgetProgram.programId),
+        (ix) =>
+          !Solana.isReplacedComputeBudgetInstruction(originalMessage.staticAccountKeys[ix.programIdIndex], ix.data),
       );
 
       // Create modified instructions

--- a/src/config/routes/getConnectors.ts
+++ b/src/config/routes/getConnectors.ts
@@ -4,11 +4,14 @@ import { FastifyPluginAsync } from 'fastify';
 import { PancakeswapConfig } from '#src/connectors/pancakeswap/pancakeswap.config';
 
 import { ZeroXConfig } from '../../connectors/0x/0x.config';
+import { DFlowConfig } from '../../connectors/dflow/dflow.config';
 import { JupiterConfig } from '../../connectors/jupiter/jupiter.config';
 import { MeteoraConfig } from '../../connectors/meteora/meteora.config';
+import { OkxConfig } from '../../connectors/okx/okx.config';
 import { OrcaConfig } from '../../connectors/orca/orca.config';
 import { PancakeswapSolConfig } from '../../connectors/pancakeswap-sol/pancakeswap-sol.config';
 import { RaydiumConfig } from '../../connectors/raydium/raydium.config';
+import { TitanConfig } from '../../connectors/titan/titan.config';
 import { UniswapConfig } from '../../connectors/uniswap/uniswap.config';
 import { logger } from '../../services/logger';
 
@@ -76,6 +79,24 @@ export const connectorsConfig = [
     trading_types: [...OrcaConfig.tradingTypes],
     chain: OrcaConfig.chain,
     networks: [...OrcaConfig.networks],
+  },
+  {
+    name: 'dflow',
+    trading_types: [...DFlowConfig.tradingTypes],
+    chain: DFlowConfig.chain,
+    networks: [...DFlowConfig.networks],
+  },
+  {
+    name: 'okx',
+    trading_types: [...OkxConfig.tradingTypes],
+    chain: OkxConfig.chain,
+    networks: [...OkxConfig.networks],
+  },
+  {
+    name: 'titan',
+    trading_types: [...TitanConfig.tradingTypes],
+    chain: TitanConfig.chain,
+    networks: [...TitanConfig.networks],
   },
 ];
 

--- a/src/connectors/dflow/README.md
+++ b/src/connectors/dflow/README.md
@@ -1,0 +1,63 @@
+# DFlow Router Connector
+
+[DFlow](https://dflow.net) is a low-latency DEX aggregator built for Solana. This connector
+exposes DFlow through Gateway's standard router endpoints:
+
+- `GET  /connectors/dflow/router/quote-swap`
+- `POST /connectors/dflow/router/execute-quote`
+- `POST /connectors/dflow/router/execute-swap`
+
+Network support: `mainnet-beta` only.
+
+## Getting API credentials
+
+DFlow authenticates with a single API key sent via the `x-api-key` header.
+
+**Development (no key required):** without an API key configured, this connector uses the
+public dev endpoint `https://dev-quote-api.dflow.net`. It is rate-limited and not suitable
+for production or bot trading.
+
+**Production:**
+
+1. Go to the API key page: https://pond.dflow.net/build/api-key
+2. Fill out the application form (or contact `hello@dflow.net` directly).
+3. DFlow typically responds within 2–5 days with an API key that has higher rate limits.
+4. Add the key to `conf/connectors/dflow.yml`:
+
+```yaml
+apiKey: 'your-dflow-api-key'
+```
+
+With a key configured, the connector switches to the production endpoint
+`https://quote-api.dflow.net`.
+
+Treat the key as a credential: keep it out of version control (`conf/` is gitignored) and
+rotate it if it is ever exposed.
+
+## Configuration (`conf/connectors/dflow.yml`)
+
+| Field | Description |
+|---|---|
+| `slippagePct` | Default slippage percentage for swaps (e.g., `1` = 1%) |
+| `apiKey` | DFlow API key; empty = keyless dev endpoint |
+| `computeUnitPriceMicroLamports` | Priority fee in micro-lamports; `0` = let DFlow choose (`prioritizationFeeLamports: auto`) |
+| `dynamicComputeUnitLimit` | Let DFlow simulate to set the compute unit limit |
+
+## Behavior notes
+
+- **Flow:** `quote-swap` calls DFlow's `GET /quote` and caches the quote response under a
+  `quoteId`; `execute-quote` posts it to `POST /swap` with the executing wallet, receives a
+  base64 transaction, and sends it unsigned through Gateway's wallet-aware signer (local
+  keypair or Ledger).
+- **BUY orders:** DFlow is ExactIn-only (the API silently ignores a `swapMode` parameter and
+  quotes ExactIn — verified against the live API). With `approximateIfNoExactOut` true
+  (default), the required input is approximated from a sell-leg ExactIn quote and the
+  response is flagged `approximation: true` (the base amount received is an estimate, not
+  exact); with it false, BUY requests fail with a clear error.
+
+## References
+
+- Trading API introduction: https://pond.dflow.net/resources/trading-api/introduction
+- Quote endpoint reference: https://pond.dflow.net/resources/trading-api/imperative/quote
+- Swap endpoint reference: https://pond.dflow.net/resources/trading-api/imperative/swap
+- API key guide: https://pond.dflow.net/build/recipes/api-keys

--- a/src/connectors/dflow/dflow.config.ts
+++ b/src/connectors/dflow/dflow.config.ts
@@ -1,0 +1,36 @@
+import { AvailableNetworks } from '../../services/base';
+import { ConfigManagerV2 } from '../../services/config-manager-v2';
+
+export namespace DFlowConfig {
+  // DFlow's aggregator API serves Solana mainnet only
+  export const chain = 'solana';
+  export const networks = ['mainnet-beta'];
+  export type Network = string;
+
+  // Supported trading types
+  export const tradingTypes = ['router'] as const;
+
+  export interface RootConfig {
+    slippagePct: number;
+    apiKey?: string;
+    computeUnitPriceMicroLamports: number;
+    dynamicComputeUnitLimit: boolean;
+
+    // Available networks
+    availableNetworks: Array<AvailableNetworks>;
+  }
+
+  export const config: RootConfig = {
+    slippagePct: ConfigManagerV2.getInstance().get('dflow.slippagePct'),
+    apiKey: ConfigManagerV2.getInstance().get('dflow.apiKey'),
+    computeUnitPriceMicroLamports: ConfigManagerV2.getInstance().get('dflow.computeUnitPriceMicroLamports'),
+    dynamicComputeUnitLimit: ConfigManagerV2.getInstance().get('dflow.dynamicComputeUnitLimit'),
+
+    availableNetworks: [
+      {
+        chain,
+        networks: networks,
+      },
+    ],
+  };
+}

--- a/src/connectors/dflow/dflow.routes.ts
+++ b/src/connectors/dflow/dflow.routes.ts
@@ -1,0 +1,26 @@
+import sensible from '@fastify/sensible';
+import type { FastifyPluginAsync } from 'fastify';
+
+// Import routes
+import { dflowRouterRoutes } from './router-routes';
+
+// DFlow routes with 3 endpoints
+const dflowRouterRoutesWrapper: FastifyPluginAsync = async (fastify) => {
+  await fastify.register(sensible);
+
+  await fastify.register(async (instance) => {
+    // Decorate the instance with a hook to modify route options
+    instance.addHook('onRoute', (routeOptions) => {
+      if (routeOptions.schema && routeOptions.schema.tags) {
+        routeOptions.schema.tags = ['/connector/dflow'];
+      }
+    });
+
+    await instance.register(dflowRouterRoutes);
+  });
+};
+
+// Export routes in the same pattern as Jupiter
+export const dflowRoutes = {
+  router: dflowRouterRoutesWrapper,
+};

--- a/src/connectors/dflow/dflow.ts
+++ b/src/connectors/dflow/dflow.ts
@@ -1,0 +1,204 @@
+import { VersionedTransaction } from '@solana/web3.js';
+
+import { Solana } from '../../chains/solana/solana';
+import { getSolanaNetworkConfig } from '../../chains/solana/solana.config';
+import { createHttpClient, HttpClient, HttpClientError } from '../../services/http-client';
+import { logger } from '../../services/logger';
+
+import { DFlowConfig } from './dflow.config';
+
+// DFlow Swap API base URLs (https://pond.dflow.net/resources/trading-api/introduction)
+// Production requires an x-api-key; the dev endpoint is keyless but rate-limited and
+// not suitable for production use.
+const DFLOW_API_BASE = 'https://quote-api.dflow.net';
+const DFLOW_API_BASE_DEV = 'https://dev-quote-api.dflow.net';
+
+// Type definitions for DFlow API responses (Jupiter-compatible quote shape)
+export interface DFlowQuoteResponse {
+  inputMint: string;
+  inAmount: string;
+  outputMint: string;
+  outAmount: string;
+  otherAmountThreshold: string;
+  minOutAmount?: string;
+  slippageBps: number;
+  priceImpactPct: string;
+  routePlan: any[];
+  contextSlot?: number;
+  requestId?: string;
+}
+
+interface DFlowSwapResponse {
+  swapTransaction: string;
+  lastValidBlockHeight: number;
+  prioritizationFeeLamports?: number;
+  computeUnitLimit?: number;
+}
+
+export class DFlow {
+  private static _instances: { [name: string]: DFlow };
+  private solana: Solana;
+  public config: DFlowConfig.RootConfig;
+  private httpClient: HttpClient;
+
+  private constructor() {
+    this.config = DFlowConfig.config;
+    this.solana = null;
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    let baseURL: string;
+
+    // Use the production API with an x-api-key, or the keyless dev endpoint without one
+    if (this.config.apiKey && this.config.apiKey.length > 0) {
+      headers['x-api-key'] = this.config.apiKey;
+      baseURL = DFLOW_API_BASE;
+      logger.info('Using DFlow API with key');
+    } else {
+      baseURL = DFLOW_API_BASE_DEV;
+      logger.warn(
+        'No DFlow API key configured. Using dev-quote-api.dflow.net, which is rate-limited and ' +
+          'not suitable for production. Apply for a key at https://pond.dflow.net/build/api-key ' +
+          'and set dflow.apiKey in your config.',
+      );
+    }
+
+    this.httpClient = createHttpClient({
+      baseURL,
+      timeout: 30000,
+      headers,
+    });
+  }
+
+  /**
+   * Gets or creates a singleton instance of DFlow for the specified network
+   */
+  public static async getInstance(network: string): Promise<DFlow> {
+    if (!DFlow._instances) {
+      DFlow._instances = {};
+    }
+    if (!DFlow._instances[network]) {
+      const instance = new DFlow();
+      await instance.init(network);
+      DFlow._instances[network] = instance;
+    }
+    return DFlow._instances[network];
+  }
+
+  private async init(network: string): Promise<void> {
+    try {
+      this.solana = await Solana.getInstance(network);
+      logger.info('Initialized DFlow for network:', network);
+    } catch (error) {
+      logger.error('Failed to initialize DFlow:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Gets an ExactIn swap quote from the DFlow API.
+   * NOTE: DFlow is ExactIn-only. It silently ignores an unknown swapMode parameter and
+   * quotes ExactIn anyway (verified against the live API), so no ExactOut mode is exposed —
+   * BUY orders must go through the sell-leg approximation in quoteSwap.
+   * @param inputMint Input token mint address
+   * @param outputMint Output token mint address
+   * @param amountRaw Input amount in smallest units
+   * @param slippageBps Slippage tolerance in basis points
+   */
+  async getQuote(
+    inputMint: string,
+    outputMint: string,
+    amountRaw: string,
+    slippageBps: number,
+  ): Promise<DFlowQuoteResponse> {
+    const params: Record<string, string> = {
+      inputMint,
+      outputMint,
+      amount: amountRaw,
+      slippageBps: slippageBps.toString(),
+    };
+
+    logger.info(`DFlow quote: ${inputMint} -> ${outputMint}, amountRaw=${amountRaw}, slippageBps=${slippageBps}`);
+
+    try {
+      const response = await this.httpClient.get<DFlowQuoteResponse>('/quote', { params });
+      if (!response.data) {
+        throw new Error('Unable to get quote - empty response');
+      }
+      return response.data;
+    } catch (error) {
+      if (error instanceof HttpClientError) {
+        logger.error('DFlow API error:', error.message);
+        const data = error.response?.data;
+        if (data) {
+          logger.error('DFlow API error response:', data);
+          const apiMessage = typeof data === 'string' ? data : data.error || data.message || JSON.stringify(data);
+          throw new Error(`DFlow API error: ${apiMessage}`);
+        }
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Builds an UNSIGNED swap transaction from a DFlow quote. Signing and sending are handled
+   * by the wallet-type-aware chokepoint (Solana.sendAndConfirmTransactionForWallet).
+   */
+  public async buildSwapTransactionUnsigned(
+    walletAddress: string,
+    quoteResponse: DFlowQuoteResponse,
+  ): Promise<VersionedTransaction> {
+    const swapRequest: Record<string, any> = {
+      userPublicKey: walletAddress,
+      quoteResponse,
+      dynamicComputeUnitLimit: this.config.dynamicComputeUnitLimit,
+    };
+    if (this.config.computeUnitPriceMicroLamports > 0) {
+      swapRequest.computeUnitPriceMicroLamports = Math.floor(this.config.computeUnitPriceMicroLamports);
+    } else {
+      swapRequest.prioritizationFeeLamports = 'auto';
+    }
+
+    const solanaConfig = getSolanaNetworkConfig(this.solana.network);
+    const retryCount = solanaConfig.confirmRetryCount;
+    const retryInterval = solanaConfig.confirmRetryInterval;
+
+    let lastError: Error | null = null;
+    let swapObj: DFlowSwapResponse;
+
+    for (let attempt = 1; attempt <= retryCount; attempt++) {
+      try {
+        const response = await this.httpClient.post<DFlowSwapResponse>('/swap', swapRequest);
+        swapObj = response.data;
+        break;
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+        if (error instanceof HttpClientError) {
+          logger.error(`Fetching DFlow swap object attempt ${attempt}/${retryCount} failed:`, {
+            error: error.message,
+            status: error.response?.status,
+            data: error.response?.data,
+          });
+        } else {
+          logger.error(`Fetching DFlow swap object attempt ${attempt}/${retryCount} failed:`, error);
+        }
+
+        if (attempt < retryCount) {
+          logger.info(`Waiting ${retryInterval}ms before retry...`);
+          await new Promise((resolve) => setTimeout(resolve, retryInterval));
+        }
+      }
+    }
+
+    if (!swapObj) {
+      throw new Error(
+        `Failed to fetch DFlow swap transaction after ${retryCount} attempts. Last error: ${lastError?.message}`,
+      );
+    }
+
+    const swapTransactionBuf = Buffer.from(swapObj.swapTransaction, 'base64');
+    return VersionedTransaction.deserialize(new Uint8Array(swapTransactionBuf));
+  }
+}

--- a/src/connectors/dflow/router-routes/executeQuote.ts
+++ b/src/connectors/dflow/router-routes/executeQuote.ts
@@ -1,0 +1,88 @@
+import { FastifyPluginAsync } from 'fastify';
+
+import { Solana } from '../../../chains/solana/solana';
+import { ExecuteQuoteRequestType, SwapExecuteResponseType, SwapExecuteResponse } from '../../../schemas/router-schema';
+import { httpErrors } from '../../../services/error-handler';
+import { logger } from '../../../services/logger';
+import { quoteCache } from '../../../services/quote-cache';
+import { DFlow } from '../dflow';
+import { DFlowExecuteQuoteRequest } from '../schemas';
+
+export async function executeQuote(
+  walletAddress: string,
+  network: string,
+  quoteId: string,
+): Promise<SwapExecuteResponseType> {
+  // Retrieve cached quote
+  const cached = quoteCache.get(quoteId);
+  if (!cached || cached.connector !== 'dflow') {
+    throw httpErrors.badRequest('Quote not found or expired');
+  }
+
+  const solana = await Solana.getInstance(network);
+  const dflow = await DFlow.getInstance(network);
+
+  const { inputToken, outputToken, quoteResponse } = cached;
+
+  // Build the swap UNSIGNED with the wallet as authority, then sign + send via the
+  // wallet-type-aware chokepoint (local keypair / Ledger) — no per-wallet-type branching here.
+  logger.info(
+    `Executing DFlow quote ${quoteId} for ${inputToken.symbol} -> ${outputToken.symbol}, slippageBps=${quoteResponse.slippageBps}`,
+  );
+  const transaction = await dflow.buildSwapTransactionUnsigned(walletAddress, quoteResponse);
+
+  const { signature } = await solana.sendAndConfirmTransactionForWallet(transaction, walletAddress);
+  const txData = await solana.connection.getTransaction(signature, {
+    commitment: 'confirmed',
+    maxSupportedTransactionVersion: 0,
+  });
+
+  const result = await solana.handleConfirmation(
+    signature,
+    txData !== null,
+    txData,
+    inputToken.address,
+    outputToken.address,
+    walletAddress,
+  );
+
+  // Remove quote from cache only after successful execution (confirmed)
+  if (result.status === 1) {
+    quoteCache.delete(quoteId);
+    logger.info(
+      `Swap executed successfully: ${result.data?.amountIn.toFixed(4)} ${inputToken.symbol} -> ${result.data?.amountOut.toFixed(4)} ${outputToken.symbol}`,
+    );
+  }
+
+  return result as SwapExecuteResponseType;
+}
+
+export const executeQuoteRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.post<{
+    Body: ExecuteQuoteRequestType;
+    Reply: SwapExecuteResponseType;
+  }>(
+    '/execute-quote',
+    {
+      schema: {
+        description: 'Execute a previously fetched quote from DFlow',
+        tags: ['/connector/dflow'],
+        body: DFlowExecuteQuoteRequest,
+        response: { 200: SwapExecuteResponse },
+      },
+    },
+    async (request) => {
+      try {
+        const { walletAddress, network, quoteId } = request.body as typeof DFlowExecuteQuoteRequest._type;
+
+        return await executeQuote(walletAddress, network, quoteId);
+      } catch (e) {
+        if (e.statusCode) throw e;
+        logger.error('Error executing DFlow quote:', e);
+        throw httpErrors.internalServerError(e.message || 'Internal server error');
+      }
+    },
+  );
+};
+
+export default executeQuoteRoute;

--- a/src/connectors/dflow/router-routes/executeSwap.ts
+++ b/src/connectors/dflow/router-routes/executeSwap.ts
@@ -1,0 +1,77 @@
+import { FastifyPluginAsync } from 'fastify';
+
+import { ExecuteSwapRequestType, SwapExecuteResponseType, SwapExecuteResponse } from '../../../schemas/router-schema';
+import { httpErrors } from '../../../services/error-handler';
+import { logger } from '../../../services/logger';
+import { DFlowConfig } from '../dflow.config';
+import { DFlowExecuteSwapRequest } from '../schemas';
+
+import { executeQuote } from './executeQuote';
+import { quoteSwap } from './quoteSwap';
+
+async function executeSwap(
+  walletAddress: string,
+  network: string,
+  baseToken: string,
+  quoteToken: string,
+  amount: number,
+  side: 'BUY' | 'SELL',
+  slippagePct: number = DFlowConfig.config.slippagePct,
+  approximateIfNoExactOut: boolean = true,
+): Promise<SwapExecuteResponseType> {
+  // Step 1: Get a fresh quote
+  const quoteResult = await quoteSwap(
+    network,
+    baseToken,
+    quoteToken,
+    amount,
+    side,
+    slippagePct,
+    approximateIfNoExactOut,
+  );
+
+  // Step 2: Execute the quote immediately
+  return await executeQuote(walletAddress, network, quoteResult.quoteId);
+}
+
+export { executeSwap };
+
+export const executeSwapRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.post<{
+    Body: ExecuteSwapRequestType;
+    Reply: SwapExecuteResponseType;
+  }>(
+    '/execute-swap',
+    {
+      schema: {
+        description: 'Quote and execute a token swap on DFlow in one step',
+        tags: ['/connector/dflow'],
+        body: DFlowExecuteSwapRequest,
+        response: { 200: SwapExecuteResponse },
+      },
+    },
+    async (request) => {
+      try {
+        const { walletAddress, network, baseToken, quoteToken, amount, side, slippagePct, approximateIfNoExactOut } =
+          request.body as typeof DFlowExecuteSwapRequest._type;
+
+        return await executeSwap(
+          walletAddress,
+          network,
+          baseToken,
+          quoteToken,
+          amount,
+          side as 'BUY' | 'SELL',
+          slippagePct,
+          approximateIfNoExactOut,
+        );
+      } catch (e) {
+        if (e.statusCode) throw e;
+        logger.error('Error executing DFlow swap:', e);
+        throw httpErrors.internalServerError(e.message || 'Internal server error');
+      }
+    },
+  );
+};
+
+export default executeSwapRoute;

--- a/src/connectors/dflow/router-routes/index.ts
+++ b/src/connectors/dflow/router-routes/index.ts
@@ -1,0 +1,13 @@
+import { FastifyPluginAsync } from 'fastify';
+
+import executeQuoteRoute from './executeQuote';
+import executeSwapRoute from './executeSwap';
+import quoteSwapRoute from './quoteSwap';
+
+export const dflowRouterRoutes: FastifyPluginAsync = async (fastify) => {
+  await fastify.register(quoteSwapRoute);
+  await fastify.register(executeQuoteRoute);
+  await fastify.register(executeSwapRoute);
+};
+
+export default dflowRouterRoutes;

--- a/src/connectors/dflow/router-routes/quoteSwap.ts
+++ b/src/connectors/dflow/router-routes/quoteSwap.ts
@@ -1,0 +1,154 @@
+import { Static } from '@sinclair/typebox';
+import { FastifyPluginAsync } from 'fastify';
+import { v4 as uuidv4 } from 'uuid';
+
+import { Solana } from '../../../chains/solana/solana';
+import { QuoteSwapRequestType } from '../../../schemas/router-schema';
+import { httpErrors } from '../../../services/error-handler';
+import { logger } from '../../../services/logger';
+import { quoteCache } from '../../../services/quote-cache';
+import { sanitizeErrorMessage, sanitizeString } from '../../../services/sanitize';
+import { approximateBuyViaSellLeg } from '../../router-utils';
+import { DFlow, DFlowQuoteResponse } from '../dflow';
+import { DFlowConfig } from '../dflow.config';
+import { DFlowQuoteSwapRequest, DFlowQuoteSwapResponse } from '../schemas';
+
+export async function quoteSwap(
+  network: string,
+  baseToken: string,
+  quoteToken: string,
+  amount: number,
+  side: 'BUY' | 'SELL',
+  slippagePct: number = DFlowConfig.config.slippagePct,
+  approximateIfNoExactOut: boolean = true,
+): Promise<Static<typeof DFlowQuoteSwapResponse>> {
+  const solana = await Solana.getInstance(network);
+  const dflow = await DFlow.getInstance(network);
+
+  // Resolve token symbols to addresses
+  const baseTokenInfo = await solana.getToken(baseToken);
+  const quoteTokenInfo = await solana.getToken(quoteToken);
+
+  if (!baseTokenInfo || !quoteTokenInfo) {
+    throw httpErrors.badRequest(sanitizeErrorMessage('Token not found: {}', !baseTokenInfo ? baseToken : quoteToken));
+  }
+
+  // Determine input/output based on side
+  const inputToken = side === 'SELL' ? baseTokenInfo : quoteTokenInfo;
+  const outputToken = side === 'SELL' ? quoteTokenInfo : baseTokenInfo;
+  const slippageBps = Math.round(slippagePct * 100);
+
+  logger.info(`Getting DFlow quote for ${amount} ${inputToken.symbol} -> ${outputToken.symbol} (${side})`);
+
+  let quoteResponse: DFlowQuoteResponse;
+  let isApproximation = false;
+
+  if (side === 'SELL') {
+    const amountRaw = Math.floor(amount * Math.pow(10, baseTokenInfo.decimals)).toString();
+    try {
+      quoteResponse = await dflow.getQuote(inputToken.address, outputToken.address, amountRaw, slippageBps);
+    } catch (error) {
+      const tokenPair = `${sanitizeString(baseToken)} -> ${sanitizeString(quoteToken)}`;
+      throw httpErrors.noRouteFound(`No route found for ${tokenPair} (ExactIn). ${error?.message || error}`);
+    }
+  } else {
+    // DFlow is ExactIn-only (it silently ignores swapMode and quotes ExactIn, verified
+    // against the live API), so BUY orders are served via the shared sell-leg approximation
+    if (!approximateIfNoExactOut) {
+      throw httpErrors.badRequest(
+        'DFlow supports ExactIn only: BUY orders require approximateIfNoExactOut=true (approximated via a sell-leg quote) or use side=SELL',
+      );
+    }
+    const approximated = await approximateBuyViaSellLeg<DFlowQuoteResponse>({
+      getExactInQuote: async (inputTokenInfo, outputTokenInfo, legAmountRaw) => {
+        const quote = await dflow.getQuote(inputTokenInfo.address, outputTokenInfo.address, legAmountRaw, slippageBps);
+        return { inAmount: quote.inAmount, outAmount: quote.outAmount, quote };
+      },
+      baseToken: baseTokenInfo,
+      quoteToken: quoteTokenInfo,
+      baseAmount: amount,
+    });
+    quoteResponse = approximated.forwardQuote.quote;
+    isApproximation = true;
+  }
+
+  if (!quoteResponse) {
+    throw httpErrors.noRouteFound('No routes found for this swap');
+  }
+
+  const estimatedAmountIn = Number(quoteResponse.inAmount) / Math.pow(10, inputToken.decimals);
+  const estimatedAmountOut = Number(quoteResponse.outAmount) / Math.pow(10, outputToken.decimals);
+
+  // SELL and approximated BUY are both ExactIn: input fixed, slippage applies to output
+  const minAmountOut = estimatedAmountOut * (1 - slippagePct / 100);
+  const maxAmountIn = estimatedAmountIn;
+
+  const price = side === 'SELL' ? estimatedAmountOut / estimatedAmountIn : estimatedAmountIn / estimatedAmountOut;
+
+  // Generate quote ID and cache a self-contained quote object (quoteCache returns only
+  // the cached value at execute time, so everything needed must live in it)
+  const quoteId = uuidv4();
+  quoteCache.set(quoteId, {
+    connector: 'dflow',
+    network,
+    inputToken,
+    outputToken,
+    side,
+    slippagePct,
+    quoteResponse,
+    isApproximation,
+  });
+
+  return {
+    quoteId,
+    tokenIn: inputToken.address,
+    tokenOut: outputToken.address,
+    amountIn: side === 'SELL' ? amount : estimatedAmountIn,
+    amountOut: estimatedAmountOut,
+    price,
+    priceImpactPct: parseFloat(quoteResponse.priceImpactPct || '0'),
+    minAmountOut,
+    maxAmountIn,
+    ...(isApproximation ? { approximation: true } : {}),
+    quoteResponse,
+  };
+}
+
+export const quoteSwapRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.get<{
+    Querystring: QuoteSwapRequestType;
+    Reply: Static<typeof DFlowQuoteSwapResponse>;
+  }>(
+    '/quote-swap',
+    {
+      schema: {
+        description: 'Get an executable swap quote from DFlow',
+        tags: ['/connector/dflow'],
+        querystring: DFlowQuoteSwapRequest,
+        response: { 200: DFlowQuoteSwapResponse },
+      },
+    },
+    async (request) => {
+      try {
+        const { network, baseToken, quoteToken, amount, side, slippagePct, approximateIfNoExactOut } =
+          request.query as typeof DFlowQuoteSwapRequest._type;
+
+        return await quoteSwap(
+          network,
+          baseToken,
+          quoteToken,
+          amount,
+          side as 'BUY' | 'SELL',
+          slippagePct,
+          approximateIfNoExactOut,
+        );
+      } catch (e) {
+        if (e.statusCode) throw e;
+        logger.error('Error getting DFlow quote:', e);
+        throw httpErrors.internalServerError(e.message || 'Internal server error');
+      }
+    },
+  );
+};
+
+export default quoteSwapRoute;

--- a/src/connectors/dflow/schemas.ts
+++ b/src/connectors/dflow/schemas.ts
@@ -1,0 +1,168 @@
+import { Type } from '@sinclair/typebox';
+
+import { getSolanaChainConfig } from '../../chains/solana/solana.config';
+
+import { DFlowConfig } from './dflow.config';
+
+// Get chain config for defaults
+const solanaChainConfig = getSolanaChainConfig();
+
+// Constants for examples
+const BASE_TOKEN = 'SOL';
+const QUOTE_TOKEN = 'USDC';
+const SWAP_AMOUNT = 0.1;
+
+// DFlow-specific quote-swap request (superset of base QuoteSwapRequest)
+export const DFlowQuoteSwapRequest = Type.Object({
+  network: Type.Optional(
+    Type.String({
+      description: 'Solana network to use',
+      default: solanaChainConfig.defaultNetwork,
+      enum: [...DFlowConfig.networks],
+    }),
+  ),
+  baseToken: Type.String({
+    description: 'Solana token symbol or address to determine swap direction',
+    examples: [BASE_TOKEN],
+  }),
+  quoteToken: Type.String({
+    description: 'The other Solana token symbol or address in the pair',
+    examples: [QUOTE_TOKEN],
+  }),
+  amount: Type.Number({
+    description: 'Amount of base token to trade',
+    examples: [SWAP_AMOUNT],
+  }),
+  side: Type.String({
+    description:
+      'Trade direction - BUY means buying base token with quote token, SELL means selling base token for quote token',
+    enum: ['BUY', 'SELL'],
+    default: 'SELL',
+  }),
+  slippagePct: Type.Optional(
+    Type.Number({
+      minimum: 0,
+      maximum: 100,
+      description: 'Maximum acceptable slippage percentage',
+      default: DFlowConfig.config.slippagePct,
+    }),
+  ),
+  approximateIfNoExactOut: Type.Optional(
+    Type.Boolean({
+      description:
+        'For BUY orders: DFlow is ExactIn-only, so BUYs are approximated via a sell-leg ExactIn quote. If false, BUY requests fail with a clear error.',
+      default: true,
+    }),
+  ),
+});
+
+// DFlow-specific quote-swap response (superset of base QuoteSwapResponse)
+export const DFlowQuoteSwapResponse = Type.Object({
+  quoteId: Type.String({
+    description: 'Unique identifier for this quote',
+  }),
+  tokenIn: Type.String({
+    description: 'Address of the token being swapped from',
+  }),
+  tokenOut: Type.String({
+    description: 'Address of the token being swapped to',
+  }),
+  amountIn: Type.Number({
+    description: 'Amount of tokenIn to be swapped',
+  }),
+  amountOut: Type.Number({
+    description: 'Expected amount of tokenOut to receive',
+  }),
+  price: Type.Number({
+    description: 'Exchange rate between tokenIn and tokenOut',
+  }),
+  priceImpactPct: Type.Number({
+    description: 'Estimated price impact percentage (0-100)',
+  }),
+  minAmountOut: Type.Number({
+    description: 'Minimum amount of tokenOut that will be accepted',
+  }),
+  maxAmountIn: Type.Number({
+    description: 'Maximum amount of tokenIn that will be spent',
+  }),
+  approximation: Type.Optional(
+    Type.Boolean({
+      description:
+        'True when a BUY was approximated via a sell-leg ExactIn quote (DFlow is ExactIn-only); amountOut is an estimate',
+    }),
+  ),
+  quoteResponse: Type.Any({
+    description: "DFlow's native quote response, used to build the swap transaction at execution time",
+  }),
+});
+
+// DFlow-specific execute-quote request (superset of base ExecuteQuoteRequest)
+export const DFlowExecuteQuoteRequest = Type.Object({
+  walletAddress: Type.Optional(
+    Type.String({
+      description: 'Solana wallet address that will execute the swap',
+      default: solanaChainConfig.defaultWallet,
+    }),
+  ),
+  network: Type.Optional(
+    Type.String({
+      description: 'Solana network to use',
+      default: solanaChainConfig.defaultNetwork,
+      enum: [...DFlowConfig.networks],
+    }),
+  ),
+  quoteId: Type.String({
+    description: 'ID of the DFlow quote to execute',
+    examples: ['123e4567-e89b-12d3-a456-426614174000'],
+  }),
+});
+
+// DFlow-specific execute-swap request (superset of base ExecuteSwapRequest)
+export const DFlowExecuteSwapRequest = Type.Object({
+  walletAddress: Type.Optional(
+    Type.String({
+      description: 'Solana wallet address that will execute the swap',
+      default: solanaChainConfig.defaultWallet,
+    }),
+  ),
+  network: Type.Optional(
+    Type.String({
+      description: 'Solana network to use',
+      default: solanaChainConfig.defaultNetwork,
+      enum: [...DFlowConfig.networks],
+    }),
+  ),
+  baseToken: Type.String({
+    description: 'Solana token symbol or address to determine swap direction',
+    examples: [BASE_TOKEN],
+  }),
+  quoteToken: Type.String({
+    description: 'The other Solana token symbol or address in the pair',
+    examples: [QUOTE_TOKEN],
+  }),
+  amount: Type.Number({
+    description: 'Amount of base token to trade',
+    examples: [SWAP_AMOUNT],
+  }),
+  side: Type.String({
+    description:
+      'Trade direction - BUY means buying base token with quote token, SELL means selling base token for quote token',
+    enum: ['BUY', 'SELL'],
+    default: 'SELL',
+  }),
+  slippagePct: Type.Optional(
+    Type.Number({
+      minimum: 0,
+      maximum: 100,
+      description: 'Maximum acceptable slippage percentage',
+      default: DFlowConfig.config.slippagePct,
+    }),
+  ),
+  approximateIfNoExactOut: Type.Optional(
+    Type.Boolean({
+      description:
+        'For BUY orders: DFlow is ExactIn-only, so BUYs are approximated via a sell-leg ExactIn quote. If false, BUY requests fail with a clear error.',
+      default: true,
+    }),
+  ),
+});

--- a/src/connectors/jupiter/router-routes/executeSwap.ts
+++ b/src/connectors/jupiter/router-routes/executeSwap.ts
@@ -19,9 +19,20 @@ async function executeSwap(
   slippagePct: number = JupiterConfig.config.slippagePct,
   priorityLevel?: string,
   maxLamports?: number,
+  approximateIfNoExactOut: boolean = true,
 ): Promise<SwapExecuteResponseType> {
   // Step 1: Get a fresh quote using the quoteSwap function
-  const quoteResult = await quoteSwap(network, baseToken, quoteToken, amount, side, slippagePct);
+  const quoteResult = await quoteSwap(
+    network,
+    baseToken,
+    quoteToken,
+    amount,
+    side,
+    slippagePct,
+    undefined,
+    undefined,
+    approximateIfNoExactOut,
+  );
 
   // Step 2: Execute the quote immediately using executeQuote function
   const executeResult = await executeQuote(
@@ -53,8 +64,18 @@ export const executeSwapRoute: FastifyPluginAsync = async (fastify) => {
     },
     async (request) => {
       try {
-        const { walletAddress, network, baseToken, quoteToken, amount, side, slippagePct, priorityLevel, maxLamports } =
-          request.body as typeof JupiterExecuteSwapRequest._type;
+        const {
+          walletAddress,
+          network,
+          baseToken,
+          quoteToken,
+          amount,
+          side,
+          slippagePct,
+          priorityLevel,
+          maxLamports,
+          approximateIfNoExactOut,
+        } = request.body as typeof JupiterExecuteSwapRequest._type;
 
         return await executeSwap(
           walletAddress,
@@ -66,6 +87,7 @@ export const executeSwapRoute: FastifyPluginAsync = async (fastify) => {
           slippagePct,
           priorityLevel,
           maxLamports,
+          approximateIfNoExactOut,
         );
       } catch (e) {
         if (e.statusCode) throw e;

--- a/src/connectors/jupiter/router-routes/quoteSwap.ts
+++ b/src/connectors/jupiter/router-routes/quoteSwap.ts
@@ -8,6 +8,7 @@ import { httpErrors } from '../../../services/error-handler';
 import { logger } from '../../../services/logger';
 import { quoteCache } from '../../../services/quote-cache';
 import { sanitizeErrorMessage, sanitizeString } from '../../../services/sanitize';
+import { approximateBuyViaSellLeg } from '../../router-utils';
 import { Jupiter } from '../jupiter';
 import { JupiterConfig } from '../jupiter.config';
 import { JupiterQuoteSwapRequest, JupiterQuoteSwapResponse } from '../schemas';
@@ -21,6 +22,7 @@ export async function quoteSwap(
   slippagePct: number = JupiterConfig.config.slippagePct,
   onlyDirectRoutes?: boolean,
   restrictIntermediateTokens?: boolean,
+  approximateIfNoExactOut: boolean = true,
 ): Promise<Static<typeof JupiterQuoteSwapResponse>> {
   const solana = await Solana.getInstance(network);
   const jupiter = await Jupiter.getInstance(network);
@@ -41,6 +43,10 @@ export async function quoteSwap(
 
   logger.info(`Getting quote for ${amount} ${inputToken.symbol} -> ${outputToken.symbol}`);
 
+  const effectiveOnlyDirectRoutes = onlyDirectRoutes ?? JupiterConfig.config.onlyDirectRoutes;
+  const effectiveRestrictIntermediateTokens =
+    restrictIntermediateTokens ?? JupiterConfig.config.restrictIntermediateTokens;
+
   let quoteResponse;
   let approximation = false;
 
@@ -51,42 +57,38 @@ export async function quoteSwap(
       outputToken.address,
       inputAmount / Math.pow(10, inputToken.decimals),
       slippagePct,
-      onlyDirectRoutes ?? JupiterConfig.config.onlyDirectRoutes,
-      restrictIntermediateTokens ?? JupiterConfig.config.restrictIntermediateTokens,
+      effectiveOnlyDirectRoutes,
+      effectiveRestrictIntermediateTokens,
       side === 'BUY' ? 'ExactOut' : 'ExactIn',
     );
   } catch (error) {
+    const errorMessage = error?.message || String(error);
+
     // A BUY is quoted as ExactOut (exact base-token output). Many thin tokens
     // (e.g. pump.fun launches) have no ExactOut route on Jupiter even though
-    // ExactIn routes fine. Fall back to an ExactIn approximation: price the
-    // requested base amount via the reverse (base -> quote) ExactIn quote, then
-    // fetch an executable ExactIn quote that spends that much quote token.
-    if (side === 'BUY') {
+    // ExactIn routes fine. Approximate via a sell-leg ExactIn quote (shared router
+    // behavior, controlled by approximateIfNoExactOut).
+    if (side === 'BUY' && approximateIfNoExactOut) {
       try {
-        const reverseQuote = await jupiter.getQuote(
-          outputToken.address, // base token in
-          inputToken.address, // quote token out
-          amount,
-          slippagePct,
-          onlyDirectRoutes ?? JupiterConfig.config.onlyDirectRoutes,
-          restrictIntermediateTokens ?? JupiterConfig.config.restrictIntermediateTokens,
-          'ExactIn',
-        );
-        const quoteInEstimate = Number(reverseQuote.outAmount) / Math.pow(10, inputToken.decimals);
-        quoteResponse = await jupiter.getQuote(
-          inputToken.address, // quote token in
-          outputToken.address, // base token out
-          quoteInEstimate,
-          slippagePct,
-          onlyDirectRoutes ?? JupiterConfig.config.onlyDirectRoutes,
-          restrictIntermediateTokens ?? JupiterConfig.config.restrictIntermediateTokens,
-          'ExactIn',
-        );
+        const approximated = await approximateBuyViaSellLeg({
+          getExactInQuote: async (inputTokenInfo, outputTokenInfo, amountRaw) => {
+            const quote = await jupiter.getQuote(
+              inputTokenInfo.address,
+              outputTokenInfo.address,
+              Number(amountRaw) / Math.pow(10, inputTokenInfo.decimals),
+              slippagePct,
+              effectiveOnlyDirectRoutes,
+              effectiveRestrictIntermediateTokens,
+              'ExactIn',
+            );
+            return { inAmount: quote.inAmount, outAmount: quote.outAmount, quote };
+          },
+          baseToken: baseTokenInfo,
+          quoteToken: quoteTokenInfo,
+          baseAmount: amount,
+        });
+        quoteResponse = approximated.forwardQuote.quote;
         approximation = true;
-        logger.info(
-          `ExactOut route unavailable for ${outputToken.symbol}; used ExactIn approximation ` +
-            `(~${quoteInEstimate} ${inputToken.symbol} in).`,
-        );
       } catch (fallbackError) {
         const tokenPair = `${sanitizeString(baseToken)} -> ${sanitizeString(quoteToken)}`;
         const msg = fallbackError?.message || String(fallbackError);
@@ -94,9 +96,9 @@ export async function quoteSwap(
       }
     } else {
       // Pass through Jupiter's error with context
-      const errorMessage = error?.message || String(error);
       const tokenPair = `${sanitizeString(baseToken)} -> ${sanitizeString(quoteToken)}`;
-      throw httpErrors.noRouteFound(`No route found for ${tokenPair} (ExactIn). ${errorMessage}`);
+      const swapMode = side === 'BUY' ? 'ExactOut' : 'ExactIn';
+      throw httpErrors.noRouteFound(`No route found for ${tokenPair} (${swapMode}). ${errorMessage}`);
     }
   }
 
@@ -187,6 +189,7 @@ export const quoteSwapRoute: FastifyPluginAsync = async (fastify) => {
           slippagePct,
           onlyDirectRoutes,
           restrictIntermediateTokens,
+          approximateIfNoExactOut,
         } = request.query as typeof JupiterQuoteSwapRequest._type;
 
         return await quoteSwap(
@@ -198,6 +201,7 @@ export const quoteSwapRoute: FastifyPluginAsync = async (fastify) => {
           slippagePct,
           onlyDirectRoutes,
           restrictIntermediateTokens,
+          approximateIfNoExactOut,
         );
       } catch (e) {
         if (e.statusCode) throw e;

--- a/src/connectors/jupiter/schemas.ts
+++ b/src/connectors/jupiter/schemas.ts
@@ -59,6 +59,13 @@ export const JupiterQuoteSwapRequest = Type.Object({
       default: JupiterConfig.config.onlyDirectRoutes,
     }),
   ),
+  approximateIfNoExactOut: Type.Optional(
+    Type.Boolean({
+      description:
+        'For BUY orders when the pair has no ExactOut route: approximate via a sell-leg ExactIn quote instead of failing',
+      default: true,
+    }),
+  ),
 });
 
 // Jupiter-specific quote-swap response (superset of base QuoteSwapResponse)
@@ -226,6 +233,13 @@ export const JupiterExecuteSwapRequest = Type.Object({
     Type.Boolean({
       description: 'Restrict routing to only go through 1 market',
       default: JupiterConfig.config.onlyDirectRoutes,
+    }),
+  ),
+  approximateIfNoExactOut: Type.Optional(
+    Type.Boolean({
+      description:
+        'For BUY orders when the pair has no ExactOut route: approximate via a sell-leg ExactIn quote instead of failing',
+      default: true,
     }),
   ),
   priorityLevel: Type.Optional(

--- a/src/connectors/okx/README.md
+++ b/src/connectors/okx/README.md
@@ -1,0 +1,73 @@
+# OKX DEX Aggregator Router Connector
+
+The [OKX DEX aggregator](https://web3.okx.com/dex-swap) (part of OKX OnchainOS) routes swaps
+across Solana DEX liquidity. This connector exposes it through Gateway's standard router
+endpoints:
+
+- `GET  /connectors/okx/router/quote-swap`
+- `POST /connectors/okx/router/execute-quote`
+- `POST /connectors/okx/router/execute-swap`
+
+Network support: `mainnet-beta` only (OKX `chainIndex` 501).
+
+## Getting API credentials
+
+OKX requires **three credentials** — an API key, a secret key, and a passphrase — used to
+HMAC-sign every request. All three are created in the OKX developer portal:
+
+1. Create an OKX account and sign in to the developer portal:
+   https://web3.okx.com/build/dev-portal
+2. Create a **project** (up to three projects per account).
+3. In the project, open the **API keys** page and click **Create API key** (up to three keys
+   per project). Enter a name and choose a **passphrase**.
+4. Save all three values — the **API key**, the system-generated **secret key**, and your
+   **passphrase**. OKX cannot recover the passphrase; without it the key is unusable.
+5. Add them to `conf/connectors/okx.yml`:
+
+```yaml
+apiKey: 'your-okx-api-key'
+secretKey: 'your-okx-secret-key'
+passphrase: 'your-okx-passphrase'
+```
+
+The connector fails fast with a clear error if any of the three is missing. Treat them as
+credentials: keep them out of version control (`conf/` is gitignored) and rotate them if
+exposed.
+
+## How requests are signed
+
+Every request sends the headers `OK-ACCESS-KEY`, `OK-ACCESS-PASSPHRASE`,
+`OK-ACCESS-TIMESTAMP` (ISO 8601), and `OK-ACCESS-SIGN`, where the signature is:
+
+```
+base64(HMAC-SHA256(timestamp + method + requestPathWithQuery, secretKey))
+```
+
+The connector serializes the query string itself so the signed string is byte-identical to
+the request path (see `okx.ts:signedHeaders`).
+
+## Configuration (`conf/connectors/okx.yml`)
+
+| Field | Description |
+|---|---|
+| `slippagePct` | Default slippage percentage for swaps (e.g., `1` = 1%) |
+| `apiKey` / `secretKey` / `passphrase` | OKX developer portal credentials (all required) |
+| `computeUnitPrice` | Solana priority fee in micro-lamports; `0` = let OKX choose |
+
+## Behavior notes
+
+- **Flow:** `quote-swap` calls the wallet-free `GET /api/v6/dex/aggregator/quote` and caches
+  the request parameters under a `quoteId`. Because OKX's executable transaction is
+  wallet-bound, `execute-quote` re-fetches `GET /api/v6/dex/aggregator/swap` with the
+  executing wallet (fresh route at execution, bounded by `slippagePercent`), then sends the
+  returned transaction unsigned through Gateway's wallet-aware signer.
+- **BUY orders:** served natively with `swapMode=exactOut` where OKX supports it; otherwise,
+  with `approximateIfNoExactOut` true (default), the input is approximated from a sell-leg
+  exactIn quote and the response is flagged `approximation: true`.
+
+## References
+
+- DEX API reference: https://web3.okx.com/onchainos/dev-docs/trade/dex-api-reference
+- Developer portal guide: https://web3.okx.com/onchainos/dev-docs/home/developer-portal
+- Quote endpoint: https://web3.okx.com/build/dev-docs/wallet-api/dex-get-quote
+- Swap endpoint: https://web3.okx.com/build/dev-docs/wallet-api/dex-swap

--- a/src/connectors/okx/okx.config.ts
+++ b/src/connectors/okx/okx.config.ts
@@ -1,0 +1,38 @@
+import { AvailableNetworks } from '../../services/base';
+import { ConfigManagerV2 } from '../../services/config-manager-v2';
+
+export namespace OkxConfig {
+  // The OKX DEX aggregator connector targets Solana mainnet (chainIndex 501)
+  export const chain = 'solana';
+  export const networks = ['mainnet-beta'];
+  export type Network = string;
+
+  // Supported trading types
+  export const tradingTypes = ['router'] as const;
+
+  export interface RootConfig {
+    slippagePct: number;
+    apiKey?: string;
+    secretKey?: string;
+    passphrase?: string;
+    computeUnitPrice: number;
+
+    // Available networks
+    availableNetworks: Array<AvailableNetworks>;
+  }
+
+  export const config: RootConfig = {
+    slippagePct: ConfigManagerV2.getInstance().get('okx.slippagePct'),
+    apiKey: ConfigManagerV2.getInstance().get('okx.apiKey'),
+    secretKey: ConfigManagerV2.getInstance().get('okx.secretKey'),
+    passphrase: ConfigManagerV2.getInstance().get('okx.passphrase'),
+    computeUnitPrice: ConfigManagerV2.getInstance().get('okx.computeUnitPrice'),
+
+    availableNetworks: [
+      {
+        chain,
+        networks: networks,
+      },
+    ],
+  };
+}

--- a/src/connectors/okx/okx.routes.ts
+++ b/src/connectors/okx/okx.routes.ts
@@ -1,0 +1,26 @@
+import sensible from '@fastify/sensible';
+import type { FastifyPluginAsync } from 'fastify';
+
+// Import routes
+import { okxRouterRoutes } from './router-routes';
+
+// OKX routes with 3 endpoints
+const okxRouterRoutesWrapper: FastifyPluginAsync = async (fastify) => {
+  await fastify.register(sensible);
+
+  await fastify.register(async (instance) => {
+    // Decorate the instance with a hook to modify route options
+    instance.addHook('onRoute', (routeOptions) => {
+      if (routeOptions.schema && routeOptions.schema.tags) {
+        routeOptions.schema.tags = ['/connector/okx'];
+      }
+    });
+
+    await instance.register(okxRouterRoutes);
+  });
+};
+
+// Export routes in the same pattern as Jupiter
+export const okxRoutes = {
+  router: okxRouterRoutesWrapper,
+};

--- a/src/connectors/okx/okx.ts
+++ b/src/connectors/okx/okx.ts
@@ -1,0 +1,235 @@
+import * as crypto from 'crypto';
+
+import { VersionedTransaction } from '@solana/web3.js';
+import bs58 from 'bs58';
+
+import { Solana } from '../../chains/solana/solana';
+import { createHttpClient, HttpClient, HttpClientError } from '../../services/http-client';
+import { logger } from '../../services/logger';
+
+import { OkxConfig } from './okx.config';
+
+// OKX DEX aggregator API (https://web3.okx.com/build/dev-docs)
+const OKX_API_BASE = 'https://web3.okx.com';
+const OKX_AGGREGATOR_PATH = '/api/v6/dex/aggregator';
+
+// OKX chainIndex for Solana
+const SOLANA_CHAIN_INDEX = '501';
+
+// Type definitions for OKX API responses
+export interface OkxRouterResult {
+  fromTokenAmount: string;
+  toTokenAmount: string;
+  priceImpactPercent?: string;
+  priceImpactPercentage?: string;
+  dexRouterList?: any[];
+  estimateGasFee?: string;
+  [key: string]: any;
+}
+
+export interface OkxSwapResult {
+  routerResult: OkxRouterResult;
+  tx: {
+    data: string;
+    from?: string;
+    minReceiveAmount?: string;
+    [key: string]: any;
+  };
+}
+
+interface OkxEnvelope<T> {
+  code: string;
+  msg: string;
+  data: T[];
+}
+
+export class Okx {
+  private static _instances: { [name: string]: Okx };
+  private solana: Solana;
+  public config: OkxConfig.RootConfig;
+  private httpClient: HttpClient;
+
+  private constructor() {
+    this.config = OkxConfig.config;
+    this.solana = null;
+
+    if (!this.config.apiKey || !this.config.secretKey || !this.config.passphrase) {
+      throw new Error(
+        'OKX DEX API credentials are not configured. Set okx.apiKey, okx.secretKey and okx.passphrase ' +
+          'in conf/connectors/okx.yml (create them at https://web3.okx.com/build/dev-portal).',
+      );
+    }
+
+    this.httpClient = createHttpClient({
+      baseURL: OKX_API_BASE,
+      timeout: 30000,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  /**
+   * Gets or creates a singleton instance of Okx for the specified network
+   */
+  public static async getInstance(network: string): Promise<Okx> {
+    if (!Okx._instances) {
+      Okx._instances = {};
+    }
+    if (!Okx._instances[network]) {
+      const instance = new Okx();
+      await instance.init(network);
+      Okx._instances[network] = instance;
+    }
+    return Okx._instances[network];
+  }
+
+  private async init(network: string): Promise<void> {
+    try {
+      this.solana = await Solana.getInstance(network);
+      logger.info('Initialized OKX DEX aggregator for network:', network);
+    } catch (error) {
+      logger.error('Failed to initialize OKX DEX aggregator:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Builds the OKX authentication headers for a request.
+   * OK-ACCESS-SIGN = base64(HMAC-SHA256(timestamp + method + requestPathWithQuery, secretKey))
+   * The signed string must match the request path + query EXACTLY as sent.
+   */
+  public signedHeaders(
+    method: 'GET' | 'POST',
+    requestPathWithQuery: string,
+    timestamp?: string,
+  ): Record<string, string> {
+    const ts = timestamp ?? new Date().toISOString();
+    const sign = crypto
+      .createHmac('sha256', this.config.secretKey)
+      .update(ts + method + requestPathWithQuery)
+      .digest('base64');
+    return {
+      'OK-ACCESS-KEY': this.config.apiKey,
+      'OK-ACCESS-SIGN': sign,
+      'OK-ACCESS-PASSPHRASE': this.config.passphrase,
+      'OK-ACCESS-TIMESTAMP': ts,
+    };
+  }
+
+  /**
+   * Performs a signed GET request. The query string is serialized here (never via the
+   * HttpClient params option) so the signed string is byte-identical to the request path.
+   * Unwraps the OKX `{code, msg, data[]}` envelope and throws on non-zero codes.
+   */
+  private async signedGet<T>(path: string, params: Record<string, string>): Promise<T> {
+    const queryString = new URLSearchParams(params).toString();
+    const pathWithQuery = `${path}?${queryString}`;
+    const headers = this.signedHeaders('GET', pathWithQuery);
+
+    let envelope: OkxEnvelope<T>;
+    try {
+      const response = await this.httpClient.get<OkxEnvelope<T>>(pathWithQuery, { headers });
+      envelope = response.data;
+    } catch (error) {
+      if (error instanceof HttpClientError) {
+        logger.error('OKX API error:', error.message);
+        const data = error.response?.data;
+        if (data) {
+          logger.error('OKX API error response:', data);
+          const apiMessage = typeof data === 'string' ? data : data.msg || data.error || JSON.stringify(data);
+          throw new Error(`OKX API error: ${apiMessage}`);
+        }
+      }
+      throw error;
+    }
+
+    if (!envelope || envelope.code !== '0') {
+      throw new Error(`OKX API error (code ${envelope?.code}): ${envelope?.msg || 'unknown error'}`);
+    }
+    if (!envelope.data || envelope.data.length === 0) {
+      throw new Error('OKX API returned an empty data array');
+    }
+    return envelope.data[0];
+  }
+
+  /**
+   * Gets a wallet-free quote from the OKX DEX aggregator
+   * @param fromMint Input token mint address
+   * @param toMint Output token mint address
+   * @param amountRaw Amount in smallest units (input for exactIn, output for exactOut)
+   * @param swapMode 'exactIn' (default) or 'exactOut'
+   */
+  async getQuote(
+    fromMint: string,
+    toMint: string,
+    amountRaw: string,
+    swapMode: 'exactIn' | 'exactOut' = 'exactIn',
+  ): Promise<OkxRouterResult> {
+    logger.info(`OKX quote: ${fromMint} -> ${toMint}, amountRaw=${amountRaw}, swapMode=${swapMode}`);
+    return await this.signedGet<OkxRouterResult>(`${OKX_AGGREGATOR_PATH}/quote`, {
+      chainIndex: SOLANA_CHAIN_INDEX,
+      fromTokenAddress: fromMint,
+      toTokenAddress: toMint,
+      amount: amountRaw,
+      swapMode,
+    });
+  }
+
+  /**
+   * Gets an executable swap (route + serialized transaction) bound to a wallet
+   */
+  async getSwapTransaction(
+    walletAddress: string,
+    fromMint: string,
+    toMint: string,
+    amountRaw: string,
+    swapMode: 'exactIn' | 'exactOut',
+    slippagePct: number,
+  ): Promise<{ routerResult: OkxRouterResult; transaction: VersionedTransaction }> {
+    const params: Record<string, string> = {
+      chainIndex: SOLANA_CHAIN_INDEX,
+      fromTokenAddress: fromMint,
+      toTokenAddress: toMint,
+      amount: amountRaw,
+      swapMode,
+      slippagePercent: slippagePct.toString(),
+      userWalletAddress: walletAddress,
+    };
+    if (this.config.computeUnitPrice > 0) {
+      params.computeUnitPrice = Math.floor(this.config.computeUnitPrice).toString();
+    }
+
+    logger.info(`OKX swap: ${fromMint} -> ${toMint}, amountRaw=${amountRaw}, wallet=${walletAddress}`);
+    const swapResult = await this.signedGet<OkxSwapResult>(`${OKX_AGGREGATOR_PATH}/swap`, params);
+
+    if (!swapResult.tx?.data) {
+      throw new Error('OKX swap response did not include transaction data');
+    }
+
+    return {
+      routerResult: swapResult.routerResult,
+      transaction: this.deserializeTransaction(swapResult.tx.data),
+    };
+  }
+
+  /**
+   * Deserializes OKX Solana transaction data. OKX has served both base58- and
+   * base64-encoded serialized transactions across API versions, so both encodings
+   * are attempted before failing with a clear error.
+   */
+  private deserializeTransaction(txData: string): VersionedTransaction {
+    const errors: string[] = [];
+    for (const [encoding, decode] of [
+      ['base58', () => bs58.decode(txData)],
+      ['base64', () => Buffer.from(txData, 'base64')],
+    ] as const) {
+      try {
+        return VersionedTransaction.deserialize(new Uint8Array(decode()));
+      } catch (error) {
+        errors.push(`${encoding}: ${error.message}`);
+      }
+    }
+    throw new Error(`Unable to deserialize OKX transaction data (${errors.join('; ')})`);
+  }
+}

--- a/src/connectors/okx/router-routes/executeQuote.ts
+++ b/src/connectors/okx/router-routes/executeQuote.ts
@@ -1,0 +1,97 @@
+import { FastifyPluginAsync } from 'fastify';
+
+import { Solana } from '../../../chains/solana/solana';
+import { ExecuteQuoteRequestType, SwapExecuteResponseType, SwapExecuteResponse } from '../../../schemas/router-schema';
+import { httpErrors } from '../../../services/error-handler';
+import { logger } from '../../../services/logger';
+import { quoteCache } from '../../../services/quote-cache';
+import { Okx } from '../okx';
+import { OkxExecuteQuoteRequest } from '../schemas';
+
+export async function executeQuote(
+  walletAddress: string,
+  network: string,
+  quoteId: string,
+): Promise<SwapExecuteResponseType> {
+  // Retrieve cached quote
+  const cached = quoteCache.get(quoteId);
+  if (!cached || cached.connector !== 'okx') {
+    throw httpErrors.badRequest('Quote not found or expired');
+  }
+
+  const solana = await Solana.getInstance(network);
+  const okx = await Okx.getInstance(network);
+
+  const { inputToken, outputToken, amountRaw, swapMode, slippagePct } = cached;
+
+  // OKX's executable transaction is wallet-bound, so the route is re-fetched here with the
+  // executing wallet (fresh route at execution, bounded by slippagePercent). The returned
+  // transaction is UNSIGNED and goes through the wallet-type-aware chokepoint (local keypair /
+  // Ledger) — no per-wallet-type branching here.
+  logger.info(
+    `Executing OKX quote ${quoteId} for ${inputToken.symbol} -> ${outputToken.symbol}, slippagePct=${slippagePct}`,
+  );
+  const { transaction } = await okx.getSwapTransaction(
+    walletAddress,
+    inputToken.address,
+    outputToken.address,
+    amountRaw,
+    swapMode,
+    slippagePct,
+  );
+
+  const { signature } = await solana.sendAndConfirmTransactionForWallet(transaction, walletAddress);
+  const txData = await solana.connection.getTransaction(signature, {
+    commitment: 'confirmed',
+    maxSupportedTransactionVersion: 0,
+  });
+
+  const result = await solana.handleConfirmation(
+    signature,
+    txData !== null,
+    txData,
+    inputToken.address,
+    outputToken.address,
+    walletAddress,
+  );
+
+  // Remove quote from cache only after successful execution (confirmed)
+  if (result.status === 1) {
+    quoteCache.delete(quoteId);
+    logger.info(
+      `Swap executed successfully: ${result.data?.amountIn.toFixed(4)} ${inputToken.symbol} -> ${result.data?.amountOut.toFixed(4)} ${outputToken.symbol}`,
+    );
+  }
+
+  return result as SwapExecuteResponseType;
+}
+
+export const executeQuoteRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.post<{
+    Body: ExecuteQuoteRequestType;
+    Reply: SwapExecuteResponseType;
+  }>(
+    '/execute-quote',
+    {
+      schema: {
+        description: 'Execute a previously fetched quote from the OKX DEX aggregator',
+        tags: ['/connector/okx'],
+        body: OkxExecuteQuoteRequest,
+        response: { 200: SwapExecuteResponse },
+      },
+    },
+    async (request) => {
+      try {
+        const { walletAddress, network, quoteId } = request.body as typeof OkxExecuteQuoteRequest._type;
+
+        return await executeQuote(walletAddress, network, quoteId);
+      } catch (e) {
+        if (e.statusCode) throw e;
+        logger.error('Error executing OKX quote:', e);
+        throw httpErrors.internalServerError(e.message || 'Internal server error');
+      }
+    },
+  );
+};
+
+export default executeQuoteRoute;

--- a/src/connectors/okx/router-routes/executeSwap.ts
+++ b/src/connectors/okx/router-routes/executeSwap.ts
@@ -1,0 +1,77 @@
+import { FastifyPluginAsync } from 'fastify';
+
+import { ExecuteSwapRequestType, SwapExecuteResponseType, SwapExecuteResponse } from '../../../schemas/router-schema';
+import { httpErrors } from '../../../services/error-handler';
+import { logger } from '../../../services/logger';
+import { OkxConfig } from '../okx.config';
+import { OkxExecuteSwapRequest } from '../schemas';
+
+import { executeQuote } from './executeQuote';
+import { quoteSwap } from './quoteSwap';
+
+async function executeSwap(
+  walletAddress: string,
+  network: string,
+  baseToken: string,
+  quoteToken: string,
+  amount: number,
+  side: 'BUY' | 'SELL',
+  slippagePct: number = OkxConfig.config.slippagePct,
+  approximateIfNoExactOut: boolean = true,
+): Promise<SwapExecuteResponseType> {
+  // Step 1: Get a fresh quote
+  const quoteResult = await quoteSwap(
+    network,
+    baseToken,
+    quoteToken,
+    amount,
+    side,
+    slippagePct,
+    approximateIfNoExactOut,
+  );
+
+  // Step 2: Execute the quote immediately
+  return await executeQuote(walletAddress, network, quoteResult.quoteId);
+}
+
+export { executeSwap };
+
+export const executeSwapRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.post<{
+    Body: ExecuteSwapRequestType;
+    Reply: SwapExecuteResponseType;
+  }>(
+    '/execute-swap',
+    {
+      schema: {
+        description: 'Quote and execute a token swap on the OKX DEX aggregator in one step',
+        tags: ['/connector/okx'],
+        body: OkxExecuteSwapRequest,
+        response: { 200: SwapExecuteResponse },
+      },
+    },
+    async (request) => {
+      try {
+        const { walletAddress, network, baseToken, quoteToken, amount, side, slippagePct, approximateIfNoExactOut } =
+          request.body as typeof OkxExecuteSwapRequest._type;
+
+        return await executeSwap(
+          walletAddress,
+          network,
+          baseToken,
+          quoteToken,
+          amount,
+          side as 'BUY' | 'SELL',
+          slippagePct,
+          approximateIfNoExactOut,
+        );
+      } catch (e) {
+        if (e.statusCode) throw e;
+        logger.error('Error executing OKX swap:', e);
+        throw httpErrors.internalServerError(e.message || 'Internal server error');
+      }
+    },
+  );
+};
+
+export default executeSwapRoute;

--- a/src/connectors/okx/router-routes/index.ts
+++ b/src/connectors/okx/router-routes/index.ts
@@ -1,0 +1,13 @@
+import { FastifyPluginAsync } from 'fastify';
+
+import executeQuoteRoute from './executeQuote';
+import executeSwapRoute from './executeSwap';
+import quoteSwapRoute from './quoteSwap';
+
+export const okxRouterRoutes: FastifyPluginAsync = async (fastify) => {
+  await fastify.register(quoteSwapRoute);
+  await fastify.register(executeQuoteRoute);
+  await fastify.register(executeSwapRoute);
+};
+
+export default okxRouterRoutes;

--- a/src/connectors/okx/router-routes/quoteSwap.ts
+++ b/src/connectors/okx/router-routes/quoteSwap.ts
@@ -1,0 +1,169 @@
+import { Static } from '@sinclair/typebox';
+import { FastifyPluginAsync } from 'fastify';
+import { v4 as uuidv4 } from 'uuid';
+
+import { Solana } from '../../../chains/solana/solana';
+import { QuoteSwapRequestType } from '../../../schemas/router-schema';
+import { httpErrors } from '../../../services/error-handler';
+import { logger } from '../../../services/logger';
+import { quoteCache } from '../../../services/quote-cache';
+import { sanitizeErrorMessage, sanitizeString } from '../../../services/sanitize';
+import { approximateBuyViaSellLeg } from '../../router-utils';
+import { Okx, OkxRouterResult } from '../okx';
+import { OkxConfig } from '../okx.config';
+import { OkxQuoteSwapRequest, OkxQuoteSwapResponse } from '../schemas';
+
+function priceImpactPct(routerResult: OkxRouterResult): number {
+  return parseFloat(routerResult.priceImpactPercent ?? routerResult.priceImpactPercentage ?? '0');
+}
+
+export async function quoteSwap(
+  network: string,
+  baseToken: string,
+  quoteToken: string,
+  amount: number,
+  side: 'BUY' | 'SELL',
+  slippagePct: number = OkxConfig.config.slippagePct,
+  approximateIfNoExactOut: boolean = true,
+): Promise<Static<typeof OkxQuoteSwapResponse>> {
+  const solana = await Solana.getInstance(network);
+  const okx = await Okx.getInstance(network);
+
+  // Resolve token symbols to addresses
+  const baseTokenInfo = await solana.getToken(baseToken);
+  const quoteTokenInfo = await solana.getToken(quoteToken);
+
+  if (!baseTokenInfo || !quoteTokenInfo) {
+    throw httpErrors.badRequest(sanitizeErrorMessage('Token not found: {}', !baseTokenInfo ? baseToken : quoteToken));
+  }
+
+  // Determine input/output based on side
+  const inputToken = side === 'SELL' ? baseTokenInfo : quoteTokenInfo;
+  const outputToken = side === 'SELL' ? quoteTokenInfo : baseTokenInfo;
+
+  logger.info(`Getting OKX quote for ${amount} ${inputToken.symbol} -> ${outputToken.symbol} (${side})`);
+
+  // The amount is denominated in base token for both sides
+  const baseAmountRaw = Math.floor(amount * Math.pow(10, baseTokenInfo.decimals)).toString();
+
+  let routerResult: OkxRouterResult;
+  let isApproximation = false;
+  // The executable leg cached for execute-quote (re-fetched with the wallet at execution)
+  let executableAmountRaw = baseAmountRaw;
+  let executableSwapMode: 'exactIn' | 'exactOut' = side === 'BUY' ? 'exactOut' : 'exactIn';
+
+  try {
+    routerResult = await okx.getQuote(inputToken.address, outputToken.address, baseAmountRaw, executableSwapMode);
+  } catch (error) {
+    const errorMessage = error?.message || String(error);
+
+    // BUY orders OKX cannot serve as exactOut on Solana: approximate via a sell-leg exactIn quote
+    if (side === 'BUY' && approximateIfNoExactOut) {
+      logger.info(`OKX exactOut quote failed (${errorMessage}); approximating BUY via sell leg`);
+      const approximated = await approximateBuyViaSellLeg<OkxRouterResult>({
+        getExactInQuote: async (inputTokenInfo, outputTokenInfo, legAmountRaw) => {
+          const quote = await okx.getQuote(inputTokenInfo.address, outputTokenInfo.address, legAmountRaw, 'exactIn');
+          return { inAmount: quote.fromTokenAmount, outAmount: quote.toTokenAmount, quote };
+        },
+        baseToken: baseTokenInfo,
+        quoteToken: quoteTokenInfo,
+        baseAmount: amount,
+      });
+      routerResult = approximated.forwardQuote.quote;
+      executableAmountRaw = approximated.quoteAmountInRaw;
+      executableSwapMode = 'exactIn';
+      isApproximation = true;
+    } else {
+      const tokenPair = `${sanitizeString(baseToken)} -> ${sanitizeString(quoteToken)}`;
+      throw httpErrors.noRouteFound(`No route found for ${tokenPair} (${executableSwapMode}). ${errorMessage}`);
+    }
+  }
+
+  if (!routerResult) {
+    throw httpErrors.noRouteFound('No routes found for this swap');
+  }
+
+  const estimatedAmountIn = Number(routerResult.fromTokenAmount) / Math.pow(10, inputToken.decimals);
+  const estimatedAmountOut = Number(routerResult.toTokenAmount) / Math.pow(10, outputToken.decimals);
+
+  // Approximated BUY quotes are exactIn (input fixed, output estimated), so slippage
+  // applies to the output rather than the input.
+  const minAmountOut = side === 'SELL' || isApproximation ? estimatedAmountOut * (1 - slippagePct / 100) : amount;
+  const maxAmountIn = isApproximation
+    ? estimatedAmountIn
+    : side === 'BUY'
+      ? estimatedAmountIn * (1 + slippagePct / 100)
+      : amount;
+
+  const price = side === 'SELL' ? estimatedAmountOut / estimatedAmountIn : estimatedAmountIn / estimatedAmountOut;
+
+  // Generate quote ID and cache a self-contained quote object. OKX's executable
+  // transaction is wallet-bound, so execute-quote re-fetches the route with the
+  // executing wallet using these cached parameters.
+  const quoteId = uuidv4();
+  quoteCache.set(quoteId, {
+    connector: 'okx',
+    network,
+    inputToken,
+    outputToken,
+    side,
+    slippagePct,
+    amountRaw: executableAmountRaw,
+    swapMode: executableSwapMode,
+    routerResult,
+    isApproximation,
+  });
+
+  return {
+    quoteId,
+    tokenIn: inputToken.address,
+    tokenOut: outputToken.address,
+    amountIn: side === 'SELL' ? amount : estimatedAmountIn,
+    amountOut: side === 'SELL' || isApproximation ? estimatedAmountOut : amount,
+    price,
+    priceImpactPct: priceImpactPct(routerResult),
+    minAmountOut,
+    maxAmountIn,
+    ...(isApproximation ? { approximation: true } : {}),
+    routerResult,
+  };
+}
+
+export const quoteSwapRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.get<{
+    Querystring: QuoteSwapRequestType;
+    Reply: Static<typeof OkxQuoteSwapResponse>;
+  }>(
+    '/quote-swap',
+    {
+      schema: {
+        description: 'Get an executable swap quote from the OKX DEX aggregator',
+        tags: ['/connector/okx'],
+        querystring: OkxQuoteSwapRequest,
+        response: { 200: OkxQuoteSwapResponse },
+      },
+    },
+    async (request) => {
+      try {
+        const { network, baseToken, quoteToken, amount, side, slippagePct, approximateIfNoExactOut } =
+          request.query as typeof OkxQuoteSwapRequest._type;
+
+        return await quoteSwap(
+          network,
+          baseToken,
+          quoteToken,
+          amount,
+          side as 'BUY' | 'SELL',
+          slippagePct,
+          approximateIfNoExactOut,
+        );
+      } catch (e) {
+        if (e.statusCode) throw e;
+        logger.error('Error getting OKX quote:', e);
+        throw httpErrors.internalServerError(e.message || 'Internal server error');
+      }
+    },
+  );
+};
+
+export default quoteSwapRoute;

--- a/src/connectors/okx/schemas.ts
+++ b/src/connectors/okx/schemas.ts
@@ -1,0 +1,168 @@
+import { Type } from '@sinclair/typebox';
+
+import { getSolanaChainConfig } from '../../chains/solana/solana.config';
+
+import { OkxConfig } from './okx.config';
+
+// Get chain config for defaults
+const solanaChainConfig = getSolanaChainConfig();
+
+// Constants for examples
+const BASE_TOKEN = 'SOL';
+const QUOTE_TOKEN = 'USDC';
+const SWAP_AMOUNT = 0.1;
+
+// OKX-specific quote-swap request (superset of base QuoteSwapRequest)
+export const OkxQuoteSwapRequest = Type.Object({
+  network: Type.Optional(
+    Type.String({
+      description: 'Solana network to use',
+      default: solanaChainConfig.defaultNetwork,
+      enum: [...OkxConfig.networks],
+    }),
+  ),
+  baseToken: Type.String({
+    description: 'Solana token symbol or address to determine swap direction',
+    examples: [BASE_TOKEN],
+  }),
+  quoteToken: Type.String({
+    description: 'The other Solana token symbol or address in the pair',
+    examples: [QUOTE_TOKEN],
+  }),
+  amount: Type.Number({
+    description: 'Amount of base token to trade',
+    examples: [SWAP_AMOUNT],
+  }),
+  side: Type.String({
+    description:
+      'Trade direction - BUY means buying base token with quote token, SELL means selling base token for quote token',
+    enum: ['BUY', 'SELL'],
+    default: 'SELL',
+  }),
+  slippagePct: Type.Optional(
+    Type.Number({
+      minimum: 0,
+      maximum: 100,
+      description: 'Maximum acceptable slippage percentage',
+      default: OkxConfig.config.slippagePct,
+    }),
+  ),
+  approximateIfNoExactOut: Type.Optional(
+    Type.Boolean({
+      description:
+        'For BUY orders when OKX cannot serve an exactOut quote: approximate via a sell-leg exactIn quote instead of failing',
+      default: true,
+    }),
+  ),
+});
+
+// OKX-specific quote-swap response (superset of base QuoteSwapResponse)
+export const OkxQuoteSwapResponse = Type.Object({
+  quoteId: Type.String({
+    description: 'Unique identifier for this quote',
+  }),
+  tokenIn: Type.String({
+    description: 'Address of the token being swapped from',
+  }),
+  tokenOut: Type.String({
+    description: 'Address of the token being swapped to',
+  }),
+  amountIn: Type.Number({
+    description: 'Amount of tokenIn to be swapped',
+  }),
+  amountOut: Type.Number({
+    description: 'Expected amount of tokenOut to receive',
+  }),
+  price: Type.Number({
+    description: 'Exchange rate between tokenIn and tokenOut',
+  }),
+  priceImpactPct: Type.Number({
+    description: 'Estimated price impact percentage (0-100)',
+  }),
+  minAmountOut: Type.Number({
+    description: 'Minimum amount of tokenOut that will be accepted',
+  }),
+  maxAmountIn: Type.Number({
+    description: 'Maximum amount of tokenIn that will be spent',
+  }),
+  approximation: Type.Optional(
+    Type.Boolean({
+      description:
+        'True when a BUY was approximated via a sell-leg exactIn quote because exactOut was unavailable; amountOut is an estimate',
+    }),
+  ),
+  routerResult: Type.Any({
+    description: "OKX's native quote result (amounts, price impact, routing breakdown)",
+  }),
+});
+
+// OKX-specific execute-quote request (superset of base ExecuteQuoteRequest)
+export const OkxExecuteQuoteRequest = Type.Object({
+  walletAddress: Type.Optional(
+    Type.String({
+      description: 'Solana wallet address that will execute the swap',
+      default: solanaChainConfig.defaultWallet,
+    }),
+  ),
+  network: Type.Optional(
+    Type.String({
+      description: 'Solana network to use',
+      default: solanaChainConfig.defaultNetwork,
+      enum: [...OkxConfig.networks],
+    }),
+  ),
+  quoteId: Type.String({
+    description: 'ID of the OKX quote to execute',
+    examples: ['123e4567-e89b-12d3-a456-426614174000'],
+  }),
+});
+
+// OKX-specific execute-swap request (superset of base ExecuteSwapRequest)
+export const OkxExecuteSwapRequest = Type.Object({
+  walletAddress: Type.Optional(
+    Type.String({
+      description: 'Solana wallet address that will execute the swap',
+      default: solanaChainConfig.defaultWallet,
+    }),
+  ),
+  network: Type.Optional(
+    Type.String({
+      description: 'Solana network to use',
+      default: solanaChainConfig.defaultNetwork,
+      enum: [...OkxConfig.networks],
+    }),
+  ),
+  baseToken: Type.String({
+    description: 'Solana token symbol or address to determine swap direction',
+    examples: [BASE_TOKEN],
+  }),
+  quoteToken: Type.String({
+    description: 'The other Solana token symbol or address in the pair',
+    examples: [QUOTE_TOKEN],
+  }),
+  amount: Type.Number({
+    description: 'Amount of base token to trade',
+    examples: [SWAP_AMOUNT],
+  }),
+  side: Type.String({
+    description:
+      'Trade direction - BUY means buying base token with quote token, SELL means selling base token for quote token',
+    enum: ['BUY', 'SELL'],
+    default: 'SELL',
+  }),
+  slippagePct: Type.Optional(
+    Type.Number({
+      minimum: 0,
+      maximum: 100,
+      description: 'Maximum acceptable slippage percentage',
+      default: OkxConfig.config.slippagePct,
+    }),
+  ),
+  approximateIfNoExactOut: Type.Optional(
+    Type.Boolean({
+      description:
+        'For BUY orders when OKX cannot serve an exactOut quote: approximate via a sell-leg exactIn quote instead of failing',
+      default: true,
+    }),
+  ),
+});

--- a/src/connectors/router-utils.ts
+++ b/src/connectors/router-utils.ts
@@ -1,0 +1,100 @@
+import { httpErrors } from '../services/error-handler';
+import { logger } from '../services/logger';
+
+/**
+ * Minimal token shape needed for BUY approximation (subset of chain TokenInfo).
+ */
+export interface RouterToken {
+  symbol: string;
+  address: string;
+  decimals: number;
+}
+
+/**
+ * An ExactIn quote in raw (smallest-unit) amounts, as returned by a router API.
+ */
+export interface ExactInQuote<TQuote = unknown> {
+  /** Raw input amount in smallest units */
+  inAmount: string;
+  /** Raw expected output amount in smallest units */
+  outAmount: string;
+  /** The router's native quote payload, passed through for caching/execution */
+  quote: TQuote;
+}
+
+export interface ApproximateBuyParams<TQuote> {
+  /**
+   * Fetches an ExactIn quote from the router. Called twice: once for the sell leg
+   * (base -> quote) to discover the price, once for the forward leg (quote -> base)
+   * to produce the executable quote.
+   */
+  getExactInQuote: (
+    inputToken: RouterToken,
+    outputToken: RouterToken,
+    amountRaw: string,
+  ) => Promise<ExactInQuote<TQuote>>;
+  baseToken: RouterToken;
+  quoteToken: RouterToken;
+  /** Human-readable amount of base token the caller wants to buy */
+  baseAmount: number;
+}
+
+export interface ApproximateBuyResult<TQuote> {
+  /** Raw quote-token input amount for the executable forward quote (smallest units) */
+  quoteAmountInRaw: string;
+  /** Human-readable quote-token input amount */
+  quoteAmountIn: number;
+  /** Human-readable estimated base-token output of the forward quote */
+  estimatedBaseOut: number;
+  /** The executable forward (quote -> base) ExactIn quote from the router */
+  forwardQuote: ExactInQuote<TQuote>;
+}
+
+/**
+ * Approximates a BUY (ExactOut) on a router that only supports ExactIn quotes.
+ *
+ * 1. Sell leg: quote ExactIn base -> quote for the desired base amount, which implies the
+ *    current price for that trade size.
+ * 2. Forward leg: quote ExactIn quote -> base spending the sell leg's output, producing an
+ *    executable quote whose output is approximately (not exactly) the desired base amount.
+ *
+ * Callers must surface `approximation: true` in their response so clients know amountOut
+ * is an estimate. Costs two router quote calls.
+ */
+export async function approximateBuyViaSellLeg<TQuote>({
+  getExactInQuote,
+  baseToken,
+  quoteToken,
+  baseAmount,
+}: ApproximateBuyParams<TQuote>): Promise<ApproximateBuyResult<TQuote>> {
+  const baseAmountRaw = Math.floor(baseAmount * 10 ** baseToken.decimals).toString();
+
+  logger.info(
+    `Approximating BUY of ${baseAmount} ${baseToken.symbol} via sell-leg quote (router lacks ExactOut support)`,
+  );
+
+  // Sell leg: how much quote token does selling the desired base amount yield right now?
+  const sellLeg = await getExactInQuote(baseToken, quoteToken, baseAmountRaw);
+  const quoteAmountInRaw = sellLeg.outAmount;
+  if (!quoteAmountInRaw || Number(quoteAmountInRaw) <= 0) {
+    throw httpErrors.badRequest(
+      `Cannot approximate BUY: sell-leg quote for ${baseToken.symbol} -> ${quoteToken.symbol} returned no output`,
+    );
+  }
+
+  // Forward leg: the executable quote, spending that quote amount to buy base.
+  const forwardQuote = await getExactInQuote(quoteToken, baseToken, quoteAmountInRaw);
+  const estimatedBaseOut = Number(forwardQuote.outAmount) / 10 ** baseToken.decimals;
+  if (!forwardQuote.outAmount || estimatedBaseOut <= 0) {
+    throw httpErrors.badRequest(
+      `Cannot approximate BUY: forward quote for ${quoteToken.symbol} -> ${baseToken.symbol} returned no output`,
+    );
+  }
+
+  return {
+    quoteAmountInRaw,
+    quoteAmountIn: Number(quoteAmountInRaw) / 10 ** quoteToken.decimals,
+    estimatedBaseOut,
+    forwardQuote,
+  };
+}

--- a/src/connectors/titan/router-routes/executeQuote.ts
+++ b/src/connectors/titan/router-routes/executeQuote.ts
@@ -1,0 +1,99 @@
+import { FastifyPluginAsync } from 'fastify';
+
+import { Solana } from '../../../chains/solana/solana';
+import { ExecuteQuoteRequestType, SwapExecuteResponseType, SwapExecuteResponse } from '../../../schemas/router-schema';
+import { httpErrors } from '../../../services/error-handler';
+import { logger } from '../../../services/logger';
+import { quoteCache } from '../../../services/quote-cache';
+import { TitanExecuteQuoteRequest } from '../schemas';
+import { buildVersionedTransactionFromInstructions } from '../titan.utils';
+
+export async function executeQuote(
+  walletAddress: string,
+  network: string,
+  quoteId: string,
+): Promise<SwapExecuteResponseType> {
+  // Retrieve cached quote
+  const cached = quoteCache.get(quoteId);
+  if (!cached || cached.connector !== 'titan') {
+    throw httpErrors.badRequest('Quote not found or expired');
+  }
+
+  const { wallet, inputToken, outputToken, swapRoute } = cached;
+
+  // Titan instructions are built for a specific wallet; executing them from another wallet
+  // would fail on-chain or move the wrong accounts — require a re-quote instead
+  if (walletAddress !== wallet) {
+    throw httpErrors.badRequest(
+      `Quote ${quoteId} was created for wallet ${wallet}; re-quote with walletAddress=${walletAddress}`,
+    );
+  }
+
+  const solana = await Solana.getInstance(network);
+
+  // Compile the swap UNSIGNED from the cached instructions + address lookup tables with a
+  // fresh blockhash, then sign + send via the wallet-type-aware chokepoint (local keypair /
+  // Ledger) — no per-wallet-type branching here.
+  logger.info(`Executing Titan quote ${quoteId} for ${inputToken.symbol} -> ${outputToken.symbol}`);
+  const transaction = await buildVersionedTransactionFromInstructions(
+    solana.connection,
+    walletAddress,
+    swapRoute.instructions,
+    swapRoute.addressLookupTables,
+  );
+
+  const { signature } = await solana.sendAndConfirmTransactionForWallet(transaction, walletAddress);
+  const txData = await solana.connection.getTransaction(signature, {
+    commitment: 'confirmed',
+    maxSupportedTransactionVersion: 0,
+  });
+
+  const result = await solana.handleConfirmation(
+    signature,
+    txData !== null,
+    txData,
+    inputToken.address,
+    outputToken.address,
+    walletAddress,
+  );
+
+  // Remove quote from cache only after successful execution (confirmed)
+  if (result.status === 1) {
+    quoteCache.delete(quoteId);
+    logger.info(
+      `Swap executed successfully: ${result.data?.amountIn.toFixed(4)} ${inputToken.symbol} -> ${result.data?.amountOut.toFixed(4)} ${outputToken.symbol}`,
+    );
+  }
+
+  return result as SwapExecuteResponseType;
+}
+
+export const executeQuoteRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.post<{
+    Body: ExecuteQuoteRequestType;
+    Reply: SwapExecuteResponseType;
+  }>(
+    '/execute-quote',
+    {
+      schema: {
+        description: 'Execute a previously fetched quote from Titan (DART)',
+        tags: ['/connector/titan'],
+        body: TitanExecuteQuoteRequest,
+        response: { 200: SwapExecuteResponse },
+      },
+    },
+    async (request) => {
+      try {
+        const { walletAddress, network, quoteId } = request.body as typeof TitanExecuteQuoteRequest._type;
+
+        return await executeQuote(walletAddress, network, quoteId);
+      } catch (e) {
+        if (e.statusCode) throw e;
+        logger.error('Error executing Titan quote:', e);
+        throw httpErrors.internalServerError(e.message || 'Internal server error');
+      }
+    },
+  );
+};
+
+export default executeQuoteRoute;

--- a/src/connectors/titan/router-routes/executeSwap.ts
+++ b/src/connectors/titan/router-routes/executeSwap.ts
@@ -1,0 +1,78 @@
+import { FastifyPluginAsync } from 'fastify';
+
+import { ExecuteSwapRequestType, SwapExecuteResponseType, SwapExecuteResponse } from '../../../schemas/router-schema';
+import { httpErrors } from '../../../services/error-handler';
+import { logger } from '../../../services/logger';
+import { TitanExecuteSwapRequest } from '../schemas';
+import { TitanConfig } from '../titan.config';
+
+import { executeQuote } from './executeQuote';
+import { quoteSwap } from './quoteSwap';
+
+async function executeSwap(
+  walletAddress: string,
+  network: string,
+  baseToken: string,
+  quoteToken: string,
+  amount: number,
+  side: 'BUY' | 'SELL',
+  slippagePct: number = TitanConfig.config.slippagePct,
+  approximateIfNoExactOut: boolean = true,
+): Promise<SwapExecuteResponseType> {
+  // Step 1: Get a fresh quote bound to the executing wallet
+  const quoteResult = await quoteSwap(
+    network,
+    baseToken,
+    quoteToken,
+    amount,
+    side,
+    slippagePct,
+    approximateIfNoExactOut,
+    walletAddress,
+  );
+
+  // Step 2: Execute the quote immediately
+  return await executeQuote(walletAddress, network, quoteResult.quoteId);
+}
+
+export { executeSwap };
+
+export const executeSwapRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.post<{
+    Body: ExecuteSwapRequestType;
+    Reply: SwapExecuteResponseType;
+  }>(
+    '/execute-swap',
+    {
+      schema: {
+        description: 'Quote and execute a token swap on Titan (DART) in one step',
+        tags: ['/connector/titan'],
+        body: TitanExecuteSwapRequest,
+        response: { 200: SwapExecuteResponse },
+      },
+    },
+    async (request) => {
+      try {
+        const { walletAddress, network, baseToken, quoteToken, amount, side, slippagePct, approximateIfNoExactOut } =
+          request.body as typeof TitanExecuteSwapRequest._type;
+
+        return await executeSwap(
+          walletAddress,
+          network,
+          baseToken,
+          quoteToken,
+          amount,
+          side as 'BUY' | 'SELL',
+          slippagePct,
+          approximateIfNoExactOut,
+        );
+      } catch (e) {
+        if (e.statusCode) throw e;
+        logger.error('Error executing Titan swap:', e);
+        throw httpErrors.internalServerError(e.message || 'Internal server error');
+      }
+    },
+  );
+};
+
+export default executeSwapRoute;

--- a/src/connectors/titan/router-routes/index.ts
+++ b/src/connectors/titan/router-routes/index.ts
@@ -1,0 +1,13 @@
+import { FastifyPluginAsync } from 'fastify';
+
+import executeQuoteRoute from './executeQuote';
+import executeSwapRoute from './executeSwap';
+import quoteSwapRoute from './quoteSwap';
+
+export const titanRouterRoutes: FastifyPluginAsync = async (fastify) => {
+  await fastify.register(quoteSwapRoute);
+  await fastify.register(executeQuoteRoute);
+  await fastify.register(executeSwapRoute);
+};
+
+export default titanRouterRoutes;

--- a/src/connectors/titan/router-routes/quoteSwap.ts
+++ b/src/connectors/titan/router-routes/quoteSwap.ts
@@ -1,0 +1,170 @@
+import { Static } from '@sinclair/typebox';
+import { FastifyPluginAsync } from 'fastify';
+import { v4 as uuidv4 } from 'uuid';
+
+import { Solana } from '../../../chains/solana/solana';
+import { getSolanaChainConfig } from '../../../chains/solana/solana.config';
+import { QuoteSwapRequestType } from '../../../schemas/router-schema';
+import { httpErrors } from '../../../services/error-handler';
+import { logger } from '../../../services/logger';
+import { quoteCache } from '../../../services/quote-cache';
+import { sanitizeErrorMessage } from '../../../services/sanitize';
+import { approximateBuyViaSellLeg } from '../../router-utils';
+import { TitanQuoteSwapRequest, TitanQuoteSwapResponse } from '../schemas';
+import { Titan, TitanSwapResponse } from '../titan';
+import { TitanConfig } from '../titan.config';
+
+export async function quoteSwap(
+  network: string,
+  baseToken: string,
+  quoteToken: string,
+  amount: number,
+  side: 'BUY' | 'SELL',
+  slippagePct: number = TitanConfig.config.slippagePct,
+  approximateIfNoExactOut: boolean = true,
+  walletAddress?: string,
+): Promise<Static<typeof TitanQuoteSwapResponse>> {
+  const solana = await Solana.getInstance(network);
+  const titan = await Titan.getInstance(network);
+
+  // Titan DART quotes are wallet-bound; fall back to the configured default wallet when
+  // the caller does not specify one (the unified /trading/swap dispatcher omits it)
+  const wallet = walletAddress || getSolanaChainConfig().defaultWallet;
+  if (!wallet) {
+    throw httpErrors.badRequest(
+      'Titan quotes are wallet-bound: provide walletAddress or set solana.defaultWallet in the config',
+    );
+  }
+
+  // Resolve token symbols to addresses
+  const baseTokenInfo = await solana.getToken(baseToken);
+  const quoteTokenInfo = await solana.getToken(quoteToken);
+
+  if (!baseTokenInfo || !quoteTokenInfo) {
+    throw httpErrors.badRequest(sanitizeErrorMessage('Token not found: {}', !baseTokenInfo ? baseToken : quoteToken));
+  }
+
+  // Determine input/output based on side
+  const inputToken = side === 'SELL' ? baseTokenInfo : quoteTokenInfo;
+  const outputToken = side === 'SELL' ? quoteTokenInfo : baseTokenInfo;
+  const slippageBps = Math.round(slippagePct * 100);
+
+  logger.info(`Getting Titan quote for ${amount} ${inputToken.symbol} -> ${outputToken.symbol} (${side})`);
+
+  let swapRoute: TitanSwapResponse;
+  let isApproximation = false;
+
+  if (side === 'SELL') {
+    const amountRaw = Math.floor(amount * Math.pow(10, baseTokenInfo.decimals)).toString();
+    try {
+      swapRoute = await titan.getSwapRoute(inputToken.address, outputToken.address, amountRaw, wallet, slippageBps);
+    } catch (error) {
+      throw httpErrors.noRouteFound(
+        `No route found for ${baseTokenInfo.symbol} -> ${quoteTokenInfo.symbol} (ExactIn). ${error?.message || error}`,
+      );
+    }
+  } else {
+    // Titan DART is ExactIn-only: BUY orders are served via the shared sell-leg approximation
+    if (!approximateIfNoExactOut) {
+      throw httpErrors.badRequest(
+        'Titan DART supports ExactIn only: BUY orders require approximateIfNoExactOut=true (approximated via a sell-leg quote) or use side=SELL',
+      );
+    }
+    const approximated = await approximateBuyViaSellLeg<TitanSwapResponse>({
+      getExactInQuote: async (inputTokenInfo, outputTokenInfo, legAmountRaw) => {
+        const route = await titan.getSwapRoute(
+          inputTokenInfo.address,
+          outputTokenInfo.address,
+          legAmountRaw,
+          wallet,
+          slippageBps,
+        );
+        return { inAmount: String(route.inputAmount), outAmount: String(route.outputAmount), quote: route };
+      },
+      baseToken: baseTokenInfo,
+      quoteToken: quoteTokenInfo,
+      baseAmount: amount,
+    });
+    swapRoute = approximated.forwardQuote.quote;
+    isApproximation = true;
+  }
+
+  const estimatedAmountIn = Number(swapRoute.inputAmount) / Math.pow(10, inputToken.decimals);
+  const estimatedAmountOut = Number(swapRoute.outputAmount) / Math.pow(10, outputToken.decimals);
+
+  // SELL and approximated BUY are both ExactIn: input fixed, slippage applies to output
+  const minAmountOut = estimatedAmountOut * (1 - slippagePct / 100);
+  const maxAmountIn = estimatedAmountIn;
+
+  const price = side === 'SELL' ? estimatedAmountOut / estimatedAmountIn : estimatedAmountIn / estimatedAmountOut;
+
+  // Cache the wallet-bound swap payload (instructions + ALTs). Execution compiles a fresh
+  // V0 transaction from these with a fresh blockhash, so instructions do not expire; the
+  // route's minOut is baked in via slippageBps.
+  const quoteId = uuidv4();
+  quoteCache.set(quoteId, {
+    connector: 'titan',
+    network,
+    wallet,
+    inputToken,
+    outputToken,
+    side,
+    slippagePct,
+    swapRoute,
+    isApproximation,
+  });
+
+  return {
+    quoteId,
+    tokenIn: inputToken.address,
+    tokenOut: outputToken.address,
+    amountIn: side === 'SELL' ? amount : estimatedAmountIn,
+    amountOut: estimatedAmountOut,
+    price,
+    priceImpactPct: 0,
+    minAmountOut,
+    maxAmountIn,
+    ...(isApproximation ? { approximation: true } : {}),
+    wallet,
+  };
+}
+
+export const quoteSwapRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.get<{
+    Querystring: QuoteSwapRequestType;
+    Reply: Static<typeof TitanQuoteSwapResponse>;
+  }>(
+    '/quote-swap',
+    {
+      schema: {
+        description: 'Get an executable swap quote from Titan (DART)',
+        tags: ['/connector/titan'],
+        querystring: TitanQuoteSwapRequest,
+        response: { 200: TitanQuoteSwapResponse },
+      },
+    },
+    async (request) => {
+      try {
+        const { network, baseToken, quoteToken, amount, side, slippagePct, approximateIfNoExactOut, walletAddress } =
+          request.query as typeof TitanQuoteSwapRequest._type;
+
+        return await quoteSwap(
+          network,
+          baseToken,
+          quoteToken,
+          amount,
+          side as 'BUY' | 'SELL',
+          slippagePct,
+          approximateIfNoExactOut,
+          walletAddress,
+        );
+      } catch (e) {
+        if (e.statusCode) throw e;
+        logger.error('Error getting Titan quote:', e);
+        throw httpErrors.internalServerError(e.message || 'Internal server error');
+      }
+    },
+  );
+};
+
+export default quoteSwapRoute;

--- a/src/connectors/titan/schemas.ts
+++ b/src/connectors/titan/schemas.ts
@@ -1,0 +1,177 @@
+import { Type } from '@sinclair/typebox';
+
+import { getSolanaChainConfig } from '../../chains/solana/solana.config';
+
+import { TitanConfig } from './titan.config';
+
+// Get chain config for defaults
+const solanaChainConfig = getSolanaChainConfig();
+
+// Constants for examples
+const BASE_TOKEN = 'SOL';
+const QUOTE_TOKEN = 'USDC';
+const SWAP_AMOUNT = 0.1;
+
+// Titan-specific quote-swap request (superset of base QuoteSwapRequest).
+// Titan DART quotes are wallet-bound (the API builds instructions for a wallet even when
+// only quoting), so walletAddress is accepted here and defaults to the Solana default wallet.
+export const TitanQuoteSwapRequest = Type.Object({
+  network: Type.Optional(
+    Type.String({
+      description: 'Solana network to use',
+      default: solanaChainConfig.defaultNetwork,
+      enum: [...TitanConfig.networks],
+    }),
+  ),
+  baseToken: Type.String({
+    description: 'Solana token symbol or address to determine swap direction',
+    examples: [BASE_TOKEN],
+  }),
+  quoteToken: Type.String({
+    description: 'The other Solana token symbol or address in the pair',
+    examples: [QUOTE_TOKEN],
+  }),
+  amount: Type.Number({
+    description: 'Amount of base token to trade',
+    examples: [SWAP_AMOUNT],
+  }),
+  side: Type.String({
+    description:
+      'Trade direction - BUY means buying base token with quote token, SELL means selling base token for quote token',
+    enum: ['BUY', 'SELL'],
+    default: 'SELL',
+  }),
+  slippagePct: Type.Optional(
+    Type.Number({
+      minimum: 0,
+      maximum: 100,
+      description: 'Maximum acceptable slippage percentage',
+      default: TitanConfig.config.slippagePct,
+    }),
+  ),
+  approximateIfNoExactOut: Type.Optional(
+    Type.Boolean({
+      description:
+        'For BUY orders: Titan DART is ExactIn-only, so BUYs are approximated via a sell-leg ExactIn quote. If false, BUY requests fail with a clear error.',
+      default: true,
+    }),
+  ),
+  walletAddress: Type.Optional(
+    Type.String({
+      description: 'Solana wallet the quote instructions are built for (Titan quotes are wallet-bound)',
+      default: solanaChainConfig.defaultWallet,
+    }),
+  ),
+});
+
+// Titan-specific quote-swap response (superset of base QuoteSwapResponse)
+export const TitanQuoteSwapResponse = Type.Object({
+  quoteId: Type.String({
+    description: 'Unique identifier for this quote',
+  }),
+  tokenIn: Type.String({
+    description: 'Address of the token being swapped from',
+  }),
+  tokenOut: Type.String({
+    description: 'Address of the token being swapped to',
+  }),
+  amountIn: Type.Number({
+    description: 'Amount of tokenIn to be swapped',
+  }),
+  amountOut: Type.Number({
+    description: 'Expected amount of tokenOut to receive',
+  }),
+  price: Type.Number({
+    description: 'Exchange rate between tokenIn and tokenOut',
+  }),
+  priceImpactPct: Type.Number({
+    description: 'Estimated price impact percentage (0-100); Titan DART does not report price impact, so this is 0',
+  }),
+  minAmountOut: Type.Number({
+    description: 'Minimum amount of tokenOut that will be accepted',
+  }),
+  maxAmountIn: Type.Number({
+    description: 'Maximum amount of tokenIn that will be spent',
+  }),
+  approximation: Type.Optional(
+    Type.Boolean({
+      description:
+        'True when a BUY was approximated via a sell-leg ExactIn quote (Titan DART is ExactIn-only); amountOut is an estimate',
+    }),
+  ),
+  wallet: Type.String({
+    description:
+      'Wallet address this quote is bound to; execute-quote must be called with the same wallet or it will fail',
+  }),
+});
+
+// Titan-specific execute-quote request (superset of base ExecuteQuoteRequest)
+export const TitanExecuteQuoteRequest = Type.Object({
+  walletAddress: Type.Optional(
+    Type.String({
+      description: 'Solana wallet address that will execute the swap (must match the wallet the quote was created for)',
+      default: solanaChainConfig.defaultWallet,
+    }),
+  ),
+  network: Type.Optional(
+    Type.String({
+      description: 'Solana network to use',
+      default: solanaChainConfig.defaultNetwork,
+      enum: [...TitanConfig.networks],
+    }),
+  ),
+  quoteId: Type.String({
+    description: 'ID of the Titan quote to execute',
+    examples: ['123e4567-e89b-12d3-a456-426614174000'],
+  }),
+});
+
+// Titan-specific execute-swap request (superset of base ExecuteSwapRequest)
+export const TitanExecuteSwapRequest = Type.Object({
+  walletAddress: Type.Optional(
+    Type.String({
+      description: 'Solana wallet address that will execute the swap',
+      default: solanaChainConfig.defaultWallet,
+    }),
+  ),
+  network: Type.Optional(
+    Type.String({
+      description: 'Solana network to use',
+      default: solanaChainConfig.defaultNetwork,
+      enum: [...TitanConfig.networks],
+    }),
+  ),
+  baseToken: Type.String({
+    description: 'Solana token symbol or address to determine swap direction',
+    examples: [BASE_TOKEN],
+  }),
+  quoteToken: Type.String({
+    description: 'The other Solana token symbol or address in the pair',
+    examples: [QUOTE_TOKEN],
+  }),
+  amount: Type.Number({
+    description: 'Amount of base token to trade',
+    examples: [SWAP_AMOUNT],
+  }),
+  side: Type.String({
+    description:
+      'Trade direction - BUY means buying base token with quote token, SELL means selling base token for quote token',
+    enum: ['BUY', 'SELL'],
+    default: 'SELL',
+  }),
+  slippagePct: Type.Optional(
+    Type.Number({
+      minimum: 0,
+      maximum: 100,
+      description: 'Maximum acceptable slippage percentage',
+      default: TitanConfig.config.slippagePct,
+    }),
+  ),
+  approximateIfNoExactOut: Type.Optional(
+    Type.Boolean({
+      description:
+        'For BUY orders: Titan DART is ExactIn-only, so BUYs are approximated via a sell-leg ExactIn quote. If false, BUY requests fail with a clear error.',
+      default: true,
+    }),
+  ),
+});

--- a/src/connectors/titan/titan.config.ts
+++ b/src/connectors/titan/titan.config.ts
@@ -1,0 +1,34 @@
+import { AvailableNetworks } from '../../services/base';
+import { ConfigManagerV2 } from '../../services/config-manager-v2';
+
+export namespace TitanConfig {
+  // Titan's DART swap API serves Solana mainnet only
+  export const chain = 'solana';
+  export const networks = ['mainnet-beta'];
+  export type Network = string;
+
+  // Supported trading types
+  export const tradingTypes = ['router'] as const;
+
+  export interface RootConfig {
+    slippagePct: number;
+    apiKey?: string;
+    computeUnitPrice: number;
+
+    // Available networks
+    availableNetworks: Array<AvailableNetworks>;
+  }
+
+  export const config: RootConfig = {
+    slippagePct: ConfigManagerV2.getInstance().get('titan.slippagePct'),
+    apiKey: ConfigManagerV2.getInstance().get('titan.apiKey'),
+    computeUnitPrice: ConfigManagerV2.getInstance().get('titan.computeUnitPrice'),
+
+    availableNetworks: [
+      {
+        chain,
+        networks: networks,
+      },
+    ],
+  };
+}

--- a/src/connectors/titan/titan.routes.ts
+++ b/src/connectors/titan/titan.routes.ts
@@ -1,0 +1,26 @@
+import sensible from '@fastify/sensible';
+import type { FastifyPluginAsync } from 'fastify';
+
+// Import routes
+import { titanRouterRoutes } from './router-routes';
+
+// Titan routes with 3 endpoints
+const titanRouterRoutesWrapper: FastifyPluginAsync = async (fastify) => {
+  await fastify.register(sensible);
+
+  await fastify.register(async (instance) => {
+    // Decorate the instance with a hook to modify route options
+    instance.addHook('onRoute', (routeOptions) => {
+      if (routeOptions.schema && routeOptions.schema.tags) {
+        routeOptions.schema.tags = ['/connector/titan'];
+      }
+    });
+
+    await instance.register(titanRouterRoutes);
+  });
+};
+
+// Export routes in the same pattern as Jupiter
+export const titanRoutes = {
+  router: titanRouterRoutesWrapper,
+};

--- a/src/connectors/titan/titan.ts
+++ b/src/connectors/titan/titan.ts
@@ -1,0 +1,136 @@
+import { Solana } from '../../chains/solana/solana';
+import { createHttpClient, HttpClient, HttpClientError } from '../../services/http-client';
+import { logger } from '../../services/logger';
+
+import { TitanConfig } from './titan.config';
+import { TitanApiInstruction } from './titan.utils';
+
+// Titan DART swap API base URL (https://titan-exchange.gitbook.io/titan/developer-doc/dart-swap-api)
+// Public tier: no API key, 1 request/second per IP, JSON responses.
+const TITAN_API_BASE = 'https://api.titan.exchange';
+const DART_SWAP_PATH = '/dart/swap';
+
+// Type definitions for the Titan DART swap API response
+export interface TitanSwapResponse {
+  provider: string;
+  inputAmount: string | number;
+  outputAmount: string | number;
+  slippageBps: number;
+  instructions: TitanApiInstruction[];
+  addressLookupTables: string[];
+}
+
+export class Titan {
+  private static _instances: { [name: string]: Titan };
+  private solana: Solana;
+  public config: TitanConfig.RootConfig;
+  private httpClient: HttpClient;
+
+  private constructor() {
+    this.config = TitanConfig.config;
+    this.solana = null;
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.config.apiKey && this.config.apiKey.length > 0) {
+      headers['X-API-Key'] = this.config.apiKey;
+      logger.info('Using Titan DART API with key');
+    } else {
+      logger.warn(
+        'No Titan API key configured. Using the public DART endpoint, which is limited to ' +
+          '1 request/second per IP. Set titan.apiKey for production use.',
+      );
+    }
+
+    this.httpClient = createHttpClient({
+      baseURL: TITAN_API_BASE,
+      timeout: 30000,
+      headers,
+    });
+  }
+
+  /**
+   * Gets or creates a singleton instance of Titan for the specified network
+   */
+  public static async getInstance(network: string): Promise<Titan> {
+    if (!Titan._instances) {
+      Titan._instances = {};
+    }
+    if (!Titan._instances[network]) {
+      const instance = new Titan();
+      await instance.init(network);
+      Titan._instances[network] = instance;
+    }
+    return Titan._instances[network];
+  }
+
+  private async init(network: string): Promise<void> {
+    try {
+      this.solana = await Solana.getInstance(network);
+      logger.info('Initialized Titan for network:', network);
+    } catch (error) {
+      logger.error('Failed to initialize Titan:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Gets an executable swap route (quote + instructions) from the Titan DART API.
+   * DART quotes are wallet-bound: the instructions are built for userPublicKey.
+   * ExactIn only — DART has no ExactOut mode.
+   *
+   * @param inputMint Input token mint address
+   * @param outputMint Output token mint address
+   * @param amountRaw Input amount in smallest units
+   * @param userPublicKey Wallet the instructions are built for
+   * @param slippageBps Slippage tolerance in basis points
+   */
+  async getSwapRoute(
+    inputMint: string,
+    outputMint: string,
+    amountRaw: string,
+    userPublicKey: string,
+    slippageBps: number,
+  ): Promise<TitanSwapResponse> {
+    const swapRequest: Record<string, any> = {
+      inputMint,
+      outputMint,
+      amount: amountRaw,
+      userPublicKey,
+      slippageBps,
+    };
+    if (this.config.computeUnitPrice > 0) {
+      swapRequest.computeUnitPrice = Math.floor(this.config.computeUnitPrice);
+    }
+
+    logger.info(
+      `Titan DART swap route: ${inputMint} -> ${outputMint}, amountRaw=${amountRaw}, slippageBps=${slippageBps}`,
+    );
+
+    try {
+      const response = await this.httpClient.post<TitanSwapResponse>(DART_SWAP_PATH, swapRequest);
+      const route = response.data;
+      if (!route || !route.instructions || route.instructions.length === 0) {
+        throw new Error('Titan DART returned no instructions for this swap');
+      }
+      return route;
+    } catch (error) {
+      if (error instanceof HttpClientError) {
+        logger.error('Titan API error:', error.message);
+        const data = error.response?.data;
+        if (data) {
+          logger.error('Titan API error response:', data);
+          const apiMessage = typeof data === 'string' ? data : data.error || data.message || JSON.stringify(data);
+          if (error.status === 429) {
+            throw new Error(
+              `Titan rate limit exceeded (public tier is 1 req/s; set titan.apiKey for higher limits): ${apiMessage}`,
+            );
+          }
+          throw new Error(`Titan API error: ${apiMessage}`);
+        }
+      }
+      throw error;
+    }
+  }
+}

--- a/src/connectors/titan/titan.utils.ts
+++ b/src/connectors/titan/titan.utils.ts
@@ -1,0 +1,111 @@
+import {
+  AddressLookupTableAccount,
+  ComputeBudgetProgram,
+  Connection,
+  PublicKey,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from '@solana/web3.js';
+
+/**
+ * Instruction shape returned by the Titan DART swap API
+ */
+export interface TitanApiInstruction {
+  programId: string;
+  accounts: Array<{
+    pubkey: string;
+    isSigner: boolean;
+    isWritable: boolean;
+  }>;
+  data: string; // base64-encoded
+}
+
+/**
+ * Converts Titan DART API instructions (base58 keys, base64 data) into web3.js
+ * TransactionInstruction objects.
+ */
+export function deserializeInstructions(rawInstructions: TitanApiInstruction[]): TransactionInstruction[] {
+  return rawInstructions.map((instruction) => {
+    if (!instruction.programId || !instruction.data || !Array.isArray(instruction.accounts)) {
+      throw new Error(`Malformed Titan instruction: ${JSON.stringify(instruction).slice(0, 200)}`);
+    }
+    return new TransactionInstruction({
+      programId: new PublicKey(instruction.programId),
+      keys: instruction.accounts.map((account) => ({
+        pubkey: new PublicKey(account.pubkey),
+        isSigner: account.isSigner,
+        isWritable: account.isWritable,
+      })),
+      data: Buffer.from(instruction.data, 'base64'),
+    });
+  });
+}
+
+/**
+ * Drops repeated ComputeBudget instructions of the same type (first data byte is the
+ * instruction discriminator), keeping the first occurrence. The Titan DART API has been
+ * observed returning a duplicated RequestHeapFrame instruction, which the Solana runtime
+ * rejects with 'Transaction contains a duplicate instruction that is not allowed'.
+ */
+export function dedupeComputeBudgetInstructions(instructions: TransactionInstruction[]): TransactionInstruction[] {
+  const seenDiscriminators = new Set<number>();
+  return instructions.filter((instruction) => {
+    if (!instruction.programId.equals(ComputeBudgetProgram.programId)) {
+      return true;
+    }
+    const discriminator = instruction.data[0];
+    if (seenDiscriminators.has(discriminator)) {
+      return false;
+    }
+    seenDiscriminators.add(discriminator);
+    return true;
+  });
+}
+
+/**
+ * Resolves address lookup table accounts by address, throwing a clear error when
+ * any table cannot be found on-chain.
+ */
+export async function resolveAddressLookupTables(
+  connection: Connection,
+  altAddresses: string[],
+): Promise<AddressLookupTableAccount[]> {
+  return await Promise.all(
+    altAddresses.map(async (address) => {
+      const result = await connection.getAddressLookupTable(new PublicKey(address));
+      if (!result.value) {
+        throw new Error(`Address lookup table not found: ${address}`);
+      }
+      return result.value;
+    }),
+  );
+}
+
+/**
+ * Compiles an UNSIGNED V0 VersionedTransaction from raw instructions and address lookup
+ * tables, using a fresh blockhash. Signing/simulation happen in the wallet-type-aware
+ * chokepoint (Solana.sendAndConfirmTransactionForWallet).
+ */
+export async function buildVersionedTransactionFromInstructions(
+  connection: Connection,
+  payerAddress: string,
+  rawInstructions: TitanApiInstruction[],
+  altAddresses: string[],
+): Promise<VersionedTransaction> {
+  if (!rawInstructions || rawInstructions.length === 0) {
+    throw new Error('No instructions provided to build the transaction');
+  }
+
+  const instructions = dedupeComputeBudgetInstructions(deserializeInstructions(rawInstructions));
+  const lookupTables = await resolveAddressLookupTables(connection, altAddresses ?? []);
+  const { blockhash } = await connection.getLatestBlockhash();
+
+  const messageV0 = new TransactionMessage({
+    payerKey: new PublicKey(payerAddress),
+    recentBlockhash: blockhash,
+    instructions,
+  }).compileToV0Message(lookupTables);
+
+  return new VersionedTransaction(messageV0);
+}

--- a/src/schemas/router-schema.ts
+++ b/src/schemas/router-schema.ts
@@ -33,6 +33,13 @@ export const QuoteSwapRequest = Type.Object(
         description: 'Maximum acceptable slippage percentage',
       }),
     ),
+    approximateIfNoExactOut: Type.Optional(
+      Type.Boolean({
+        description:
+          'For BUY orders on routers without ExactOut support: approximate the required input via a sell-leg quote and return an ExactIn quote flagged as an approximation. If false, such BUY requests fail with a clear error.',
+        default: true,
+      }),
+    ),
   },
   { $id: 'QuoteSwapRequest' },
 );
@@ -67,6 +74,12 @@ export const QuoteSwapResponse = Type.Object(
     maxAmountIn: Type.Number({
       description: 'Maximum amount of tokenIn that will be spent',
     }),
+    approximation: Type.Optional(
+      Type.Boolean({
+        description:
+          'True when a BUY was approximated via a sell-leg ExactIn quote because the router does not support ExactOut; amountOut is an estimate rather than exact',
+      }),
+    ),
   },
   { $id: 'QuoteSwapResponse' },
 );
@@ -123,6 +136,13 @@ export const ExecuteSwapRequest = Type.Object(
         minimum: 0,
         maximum: 100,
         description: 'Maximum acceptable slippage percentage',
+      }),
+    ),
+    approximateIfNoExactOut: Type.Optional(
+      Type.Boolean({
+        description:
+          'For BUY orders on routers without ExactOut support: approximate the required input via a sell-leg quote and execute an ExactIn swap. If false, such BUY requests fail with a clear error.',
+        default: true,
       }),
     ),
   },

--- a/src/templates/connectors/dflow.yml
+++ b/src/templates/connectors/dflow.yml
@@ -1,0 +1,15 @@
+# Default slippage percentage for swaps (as a decimal, e.g., 1 = 1%)
+slippagePct: 1
+
+# DFlow API key
+# Without a key: uses dev-quote-api.dflow.net (rate-limited, development only)
+# With a key: uses quote-api.dflow.net (production)
+# Apply at https://pond.dflow.net/build/api-key (see src/connectors/dflow/README.md)
+apiKey: ''
+
+# Compute unit price in micro-lamports for priority fees
+# 0 = let DFlow determine the priority fee automatically (prioritizationFeeLamports: auto)
+computeUnitPriceMicroLamports: 0
+
+# Let DFlow simulate the transaction to determine the compute unit limit
+dynamicComputeUnitLimit: true

--- a/src/templates/connectors/okx.yml
+++ b/src/templates/connectors/okx.yml
@@ -1,0 +1,12 @@
+# Default slippage percentage for swaps (as a decimal, e.g., 1 = 1%)
+slippagePct: 1
+
+# OKX DEX aggregator API credentials (all three required)
+# Create them at https://web3.okx.com/build/dev-portal
+apiKey: ''
+secretKey: ''
+passphrase: ''
+
+# Compute unit price in micro-lamports for Solana priority fees
+# 0 = let OKX determine the priority fee automatically
+computeUnitPrice: 0

--- a/src/templates/connectors/titan.yml
+++ b/src/templates/connectors/titan.yml
@@ -1,0 +1,11 @@
+# Default slippage percentage for swaps (as a decimal, e.g., 1 = 1%)
+slippagePct: 1
+
+# Titan DART API key (optional)
+# Without a key, the public endpoint is used (limited to 1 request/second per IP).
+# An API key is recommended for bots; apply at https://titan.exchange
+apiKey: ''
+
+# Compute unit price in micro-lamports for priority fees
+# 0 = use the Titan DART default (10,000 micro-lamports)
+computeUnitPrice: 0

--- a/src/templates/namespace/dflow-schema.json
+++ b/src/templates/namespace/dflow-schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "slippagePct": {
+      "type": "number",
+      "description": "Default slippage percentage for swaps (e.g., 1 = 1%)"
+    },
+    "apiKey": {
+      "type": "string",
+      "description": "DFlow API key (https://pond.dflow.net/build/api-key)"
+    },
+    "computeUnitPriceMicroLamports": {
+      "type": "number",
+      "description": "Compute unit price in micro-lamports; 0 = automatic priority fee"
+    },
+    "dynamicComputeUnitLimit": {
+      "type": "boolean",
+      "description": "Let DFlow simulate to determine the compute unit limit"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["slippagePct", "computeUnitPriceMicroLamports", "dynamicComputeUnitLimit"]
+}

--- a/src/templates/namespace/ethereum-network-schema.json
+++ b/src/templates/namespace/ethereum-network-schema.json
@@ -11,7 +11,16 @@
     },
     "swapProvider": {
       "type": "string",
-      "description": "Default swap router provider for this network (format: connector/type, e.g., uniswap/router)",
+      "description": "Default swap provider used by the unified /trading/swap routes when no connector is specified (format: connector/type)",
+      "enum": [
+        "uniswap/router",
+        "0x/router",
+        "pancakeswap/router",
+        "uniswap/amm",
+        "uniswap/clmm",
+        "pancakeswap/amm",
+        "pancakeswap/clmm"
+      ],
       "default": "uniswap/router"
     },
     "transactionExecutionTimeoutMs": {

--- a/src/templates/namespace/okx-schema.json
+++ b/src/templates/namespace/okx-schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "slippagePct": {
+      "type": "number",
+      "description": "Default slippage percentage for swaps (e.g., 1 = 1%)"
+    },
+    "apiKey": {
+      "type": "string",
+      "description": "OKX DEX API key (https://web3.okx.com/build/dev-portal)"
+    },
+    "secretKey": {
+      "type": "string",
+      "description": "OKX DEX API secret key used to sign requests"
+    },
+    "passphrase": {
+      "type": "string",
+      "description": "OKX DEX API passphrase"
+    },
+    "computeUnitPrice": {
+      "type": "number",
+      "description": "Compute unit price in micro-lamports for Solana priority fees; 0 = automatic"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["slippagePct", "computeUnitPrice"]
+}

--- a/src/templates/namespace/solana-network-schema.json
+++ b/src/templates/namespace/solana-network-schema.json
@@ -14,7 +14,18 @@
     },
     "swapProvider": {
       "type": "string",
-      "description": "Default swap router provider for this network (format: connector/type, e.g., jupiter/router)",
+      "description": "Default swap provider used by the unified /trading/swap routes when no connector is specified (format: connector/type)",
+      "enum": [
+        "jupiter/router",
+        "dflow/router",
+        "okx/router",
+        "titan/router",
+        "raydium/amm",
+        "raydium/clmm",
+        "meteora/clmm",
+        "orca/clmm",
+        "pancakeswap-sol/clmm"
+      ],
       "default": "jupiter/router"
     },
     "defaultComputeUnits": { "type": "number" },

--- a/src/templates/namespace/titan-schema.json
+++ b/src/templates/namespace/titan-schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "slippagePct": {
+      "type": "number",
+      "description": "Default slippage percentage for swaps (e.g., 1 = 1%)"
+    },
+    "apiKey": {
+      "type": "string",
+      "description": "Titan DART API key (optional; keyless public tier is limited to 1 req/s)"
+    },
+    "computeUnitPrice": {
+      "type": "number",
+      "description": "Compute unit price in micro-lamports; 0 = Titan DART default"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["slippagePct", "computeUnitPrice"]
+}

--- a/src/templates/root.yml
+++ b/src/templates/root.yml
@@ -104,6 +104,18 @@ configurations:
     configurationPath: connectors/pancakeswap-sol.yml
     schemaPath: pancakeswap-sol-schema.json
 
+  $namespace dflow:
+    configurationPath: connectors/dflow.yml
+    schemaPath: dflow-schema.json
+
+  $namespace okx:
+    configurationPath: connectors/okx.yml
+    schemaPath: okx-schema.json
+
+  $namespace titan:
+    configurationPath: connectors/titan.yml
+    schemaPath: titan-schema.json
+
   # API Keys (centralized)
   $namespace apiKeys:
     configurationPath: apiKeys.yml

--- a/src/trading/swap/execute.ts
+++ b/src/trading/swap/execute.ts
@@ -5,8 +5,10 @@ import { FastifyPluginAsync } from 'fastify';
 import { getEthereumChainConfig, getEthereumNetworkConfig } from '../../chains/ethereum/ethereum.config';
 import { getSolanaChainConfig, getSolanaNetworkConfig } from '../../chains/solana/solana.config';
 import { executeSwap as zeroXRouterExecuteSwap } from '../../connectors/0x/router-routes/executeSwap';
+import { executeSwap as dflowRouterExecuteSwap } from '../../connectors/dflow/router-routes/executeSwap';
 import { executeSwap as jupiterRouterExecuteSwap } from '../../connectors/jupiter/router-routes/executeSwap';
 import { executeSwap as meteoraClmmExecuteSwap } from '../../connectors/meteora/clmm-routes/executeSwap';
+import { executeSwap as okxRouterExecuteSwap } from '../../connectors/okx/router-routes/executeSwap';
 import { executeSwap as orcaClmmExecuteSwap } from '../../connectors/orca/clmm-routes/executeSwap';
 import { executeSwap as pancakeswapAmmExecuteSwap } from '../../connectors/pancakeswap/amm-routes/executeSwap';
 import { executeSwap as pancakeswapClmmExecuteSwap } from '../../connectors/pancakeswap/clmm-routes/executeSwap';
@@ -14,6 +16,7 @@ import { executeSwap as pancakeswapRouterExecuteSwap } from '../../connectors/pa
 import { executeSwap as pancakeswapSolClmmExecuteSwap } from '../../connectors/pancakeswap-sol/clmm-routes/executeSwap';
 import { executeSwap as raydiumAmmExecuteSwap } from '../../connectors/raydium/amm-routes/executeSwap';
 import { executeSwap as raydiumClmmExecuteSwap } from '../../connectors/raydium/clmm-routes/executeSwap';
+import { executeSwap as titanRouterExecuteSwap } from '../../connectors/titan/router-routes/executeSwap';
 
 // Ethereum connector imports
 import { executeSwap as uniswapAmmExecuteSwap } from '../../connectors/uniswap/amm-routes/executeSwap';
@@ -54,7 +57,7 @@ const UnifiedExecuteSwapRequestSchema = Type.Object({
     Type.String({
       description:
         "Connector to use in format: connector/type (e.g., jupiter/router, raydium/amm, uniswap/clmm). If not provided, uses network's configured swapProvider",
-      default: 'jupiter/router',
+      examples: ['jupiter/router'],
     }),
   ),
   baseToken: Type.String({
@@ -163,6 +166,12 @@ async function executeSolanaSwap(
         undefined, // priorityLevel
         undefined, // maxLamports
       );
+    } else if (providerKey === 'dflow/router') {
+      return await dflowRouterExecuteSwap(walletAddress, network, baseToken, quoteToken, amount, side, slippagePct);
+    } else if (providerKey === 'okx/router') {
+      return await okxRouterExecuteSwap(walletAddress, network, baseToken, quoteToken, amount, side, slippagePct);
+    } else if (providerKey === 'titan/router') {
+      return await titanRouterExecuteSwap(walletAddress, network, baseToken, quoteToken, amount, side, slippagePct);
     } else if (providerKey === 'raydium/amm') {
       return await raydiumAmmExecuteSwap(
         network,

--- a/src/trading/swap/quote.ts
+++ b/src/trading/swap/quote.ts
@@ -5,8 +5,10 @@ import { FastifyPluginAsync } from 'fastify';
 import { getEthereumNetworkConfig } from '../../chains/ethereum/ethereum.config';
 import { getSolanaNetworkConfig } from '../../chains/solana/solana.config';
 import { quoteSwap as zeroXRouterQuoteSwap } from '../../connectors/0x/router-routes/quoteSwap';
+import { quoteSwap as dflowRouterQuoteSwap } from '../../connectors/dflow/router-routes/quoteSwap';
 import { quoteSwap as jupiterRouterQuoteSwap } from '../../connectors/jupiter/router-routes/quoteSwap';
 import { quoteSwap as meteoraClmmQuoteSwap } from '../../connectors/meteora/clmm-routes/quoteSwap';
+import { quoteSwap as okxRouterQuoteSwap } from '../../connectors/okx/router-routes/quoteSwap';
 import { quoteSwap as orcaClmmQuoteSwap } from '../../connectors/orca/clmm-routes/quoteSwap';
 import { quoteSwap as pancakeswapAmmQuoteSwap } from '../../connectors/pancakeswap/amm-routes/quoteSwap';
 import { quoteSwap as pancakeswapClmmQuoteSwap } from '../../connectors/pancakeswap/clmm-routes/quoteSwap';
@@ -14,6 +16,7 @@ import { quoteSwap as pancakeswapRouterQuoteSwap } from '../../connectors/pancak
 import { quoteSwap as pancakeswapSolClmmQuoteSwap } from '../../connectors/pancakeswap-sol/clmm-routes/quoteSwap';
 import { quoteSwap as raydiumAmmQuoteSwap } from '../../connectors/raydium/amm-routes/quoteSwap';
 import { quoteSwap as raydiumClmmQuoteSwap } from '../../connectors/raydium/clmm-routes/quoteSwap';
+import { quoteSwap as titanRouterQuoteSwap } from '../../connectors/titan/router-routes/quoteSwap';
 
 // Ethereum connector imports
 import { quoteSwap as uniswapAmmQuoteSwap } from '../../connectors/uniswap/amm-routes/quoteSwap';
@@ -40,7 +43,7 @@ const UnifiedQuoteSwapRequestSchema = Type.Object({
     Type.String({
       description:
         "Connector to use in format: connector/type (e.g., jupiter/router, raydium/amm, uniswap/clmm). If not provided, uses network's configured swapProvider",
-      default: 'jupiter/router',
+      examples: ['jupiter/router'],
     }),
   ),
   baseToken: Type.String({
@@ -147,6 +150,12 @@ async function getSolanaQuoteSwap(
         undefined, // onlyDirectRoutes
         undefined, // restrictIntermediateTokens
       );
+    } else if (providerKey === 'dflow/router') {
+      return await dflowRouterQuoteSwap(network, baseToken, quoteToken, amount, side, slippagePct);
+    } else if (providerKey === 'okx/router') {
+      return await okxRouterQuoteSwap(network, baseToken, quoteToken, amount, side, slippagePct);
+    } else if (providerKey === 'titan/router') {
+      return await titanRouterQuoteSwap(network, baseToken, quoteToken, amount, side, slippagePct);
     } else if (providerKey === 'raydium/amm') {
       return await raydiumAmmQuoteSwap(network, poolAddress!, baseToken, quoteToken, amount, side, slippagePct);
     } else if (providerKey === 'raydium/clmm') {

--- a/test/connectors/dflow/dflow.routes.test.ts
+++ b/test/connectors/dflow/dflow.routes.test.ts
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+
+import '../../mocks/app-mocks';
+
+import { FastifyInstance } from 'fastify';
+
+import { gatewayApp } from '../../../src/app';
+
+describe('DFlow Routes Structure', () => {
+  const CONNECTOR_NAME = 'dflow';
+  let fastify: FastifyInstance;
+
+  beforeAll(async () => {
+    fastify = gatewayApp;
+    await fastify.ready();
+  });
+
+  afterAll(async () => {
+    await fastify.close();
+  });
+
+  describe('Folder Structure', () => {
+    it('should have appropriate route folders based on trading types', async () => {
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/config/connectors',
+      });
+
+      const { connectors } = JSON.parse(response.body);
+      const dflowConfig = connectors.find((c: any) => c.name === CONNECTOR_NAME);
+
+      expect(dflowConfig).toBeDefined();
+      expect(dflowConfig.chain).toBe('solana');
+      expect(dflowConfig.trading_types).toEqual(['router']);
+      expect(dflowConfig.networks).toEqual(['mainnet-beta']);
+
+      const connectorPath = path.join(__dirname, `../../../src/connectors/${CONNECTOR_NAME}`);
+      const routerRoutesPath = path.join(connectorPath, 'router-routes');
+      expect(fs.existsSync(routerRoutesPath)).toBe(true);
+
+      const files = fs.readdirSync(routerRoutesPath);
+      expect(files.some((f) => f.toLowerCase().includes('swap'))).toBe(true);
+    });
+  });
+
+  describe('Route Registration', () => {
+    it('should register DFlow router routes at /connectors/dflow/router', async () => {
+      const routes = fastify.printRoutes();
+
+      expect(routes).toContain('dflow/router/');
+      expect(routes).toContain('quote-swap');
+      expect(routes).toContain('execute-swap');
+    });
+  });
+});

--- a/test/connectors/dflow/router-routes/quoteSwap.test.ts
+++ b/test/connectors/dflow/router-routes/quoteSwap.test.ts
@@ -1,0 +1,213 @@
+import { Solana } from '../../../../src/chains/solana/solana';
+import { DFlow } from '../../../../src/connectors/dflow/dflow';
+import { fastifyWithTypeProvider } from '../../../utils/testUtils';
+
+jest.mock('../../../../src/chains/solana/solana');
+jest.mock('../../../../src/connectors/dflow/dflow');
+
+const buildApp = async () => {
+  const server = fastifyWithTypeProvider();
+  await server.register(require('@fastify/sensible'));
+  const { quoteSwapRoute } = await import('../../../../src/connectors/dflow/router-routes/quoteSwap');
+  await server.register(quoteSwapRoute);
+  return server;
+};
+
+const mockSOL = {
+  symbol: 'SOL',
+  address: 'So11111111111111111111111111111111111111112',
+  decimals: 9,
+};
+
+const mockUSDC = {
+  symbol: 'USDC',
+  address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+  decimals: 6,
+};
+
+const sellQuote = {
+  inputMint: mockSOL.address,
+  inAmount: '100000000', // 0.1 SOL
+  outputMint: mockUSDC.address,
+  outAmount: '15000000', // 15 USDC
+  otherAmountThreshold: '14900000',
+  slippageBps: 50,
+  priceImpactPct: '0.001',
+  routePlan: [],
+};
+
+describe('GET /quote-swap (dflow)', () => {
+  let server: any;
+
+  beforeAll(async () => {
+    server = await buildApp();
+  });
+
+  afterAll(async () => {
+    if (server) {
+      await server.close();
+    }
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockSolana = () => {
+    const mockSolanaInstance = {
+      getToken: jest.fn().mockResolvedValueOnce(mockSOL).mockResolvedValueOnce(mockUSDC),
+    };
+    (Solana.getInstance as jest.Mock).mockResolvedValue(mockSolanaInstance);
+    return mockSolanaInstance;
+  };
+
+  it('should return a swap quote for SELL side', async () => {
+    mockSolana();
+    const mockDFlowInstance = {
+      getQuote: jest.fn().mockResolvedValue(sellQuote),
+    };
+    (DFlow.getInstance as jest.Mock).mockResolvedValue(mockDFlowInstance);
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: '0.1',
+        side: 'SELL',
+        slippagePct: '0.5',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body).toHaveProperty('quoteId');
+    expect(body).toHaveProperty('amountIn', 0.1);
+    expect(body).toHaveProperty('amountOut', 15);
+    expect(body).toHaveProperty('price', 150);
+    expect(body).toHaveProperty('tokenIn', mockSOL.address);
+    expect(body).toHaveProperty('tokenOut', mockUSDC.address);
+    expect(body).toHaveProperty('quoteResponse');
+    expect(body.approximation).toBeUndefined();
+
+    // ExactIn with the base amount in raw units
+    expect(mockDFlowInstance.getQuote).toHaveBeenCalledWith(mockSOL.address, mockUSDC.address, '100000000', 50);
+  });
+
+  it('should approximate BUY via sell leg (DFlow is ExactIn-only)', async () => {
+    mockSolana();
+    const mockDFlowInstance = {
+      getQuote: jest
+        .fn()
+        // Sell leg: 0.1 SOL -> 15 USDC
+        .mockResolvedValueOnce({ ...sellQuote })
+        // Forward leg: 15 USDC -> 0.0999 SOL
+        .mockResolvedValueOnce({
+          ...sellQuote,
+          inputMint: mockUSDC.address,
+          inAmount: '15000000',
+          outputMint: mockSOL.address,
+          outAmount: '99900000',
+        }),
+    };
+    (DFlow.getInstance as jest.Mock).mockResolvedValue(mockDFlowInstance);
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: '0.1',
+        side: 'BUY',
+        slippagePct: '0.5',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body).toHaveProperty('approximation', true);
+    expect(body).toHaveProperty('amountIn', 15);
+    expect(body.amountOut).toBeCloseTo(0.0999);
+    // Input is fixed for the approximated ExactIn quote
+    expect(body.maxAmountIn).toBeCloseTo(15);
+    // Slippage applies to the estimated output
+    expect(body.minAmountOut).toBeCloseTo(0.0999 * (1 - 0.005));
+    expect(mockDFlowInstance.getQuote).toHaveBeenCalledTimes(2);
+  });
+
+  it('should return 400 for BUY when approximation is disabled', async () => {
+    mockSolana();
+    const mockDFlowInstance = { getQuote: jest.fn() };
+    (DFlow.getInstance as jest.Mock).mockResolvedValue(mockDFlowInstance);
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: '0.1',
+        side: 'BUY',
+        slippagePct: '0.5',
+        approximateIfNoExactOut: 'false',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body);
+    expect(body.message).toContain('ExactIn only');
+    expect(mockDFlowInstance.getQuote).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 if token not found', async () => {
+    const mockSolanaInstance = {
+      getToken: jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(mockUSDC),
+    };
+    (Solana.getInstance as jest.Mock).mockResolvedValue(mockSolanaInstance);
+    (DFlow.getInstance as jest.Mock).mockResolvedValue({ getQuote: jest.fn() });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        baseToken: 'INVALID',
+        quoteToken: 'USDC',
+        amount: '0.1',
+        side: 'SELL',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body)).toHaveProperty('error');
+  });
+
+  it('should return 400 if no routes found for SELL', async () => {
+    mockSolana();
+    const mockDFlowInstance = {
+      getQuote: jest.fn().mockRejectedValue(new Error('DFlow API error: no route')),
+    };
+    (DFlow.getInstance as jest.Mock).mockResolvedValue(mockDFlowInstance);
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: '0.1',
+        side: 'SELL',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body);
+    expect(body.message).toContain('No route found');
+  });
+});

--- a/test/connectors/dflow/schemas.test.ts
+++ b/test/connectors/dflow/schemas.test.ts
@@ -1,0 +1,127 @@
+import { Value } from '@sinclair/typebox/value';
+
+import * as DFlow from '../../../src/connectors/dflow/schemas';
+import * as Base from '../../../src/schemas/router-schema';
+
+describe('DFlow Schema Tests', () => {
+  describe('Schema Superset Validation', () => {
+    it('DFlowQuoteSwapRequest should be a superset of QuoteSwapRequest', () => {
+      const baseRequired = Base.QuoteSwapRequest.required || [];
+      const dflowRequired = DFlow.DFlowQuoteSwapRequest.required || [];
+
+      for (const field of baseRequired) {
+        expect(dflowRequired).toContain(field);
+      }
+
+      const baseProps = Object.keys(Base.QuoteSwapRequest.properties);
+      const dflowProps = Object.keys(DFlow.DFlowQuoteSwapRequest.properties);
+
+      for (const prop of baseProps) {
+        expect(dflowProps).toContain(prop);
+      }
+
+      const sampleRequest = {
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: 1,
+        side: 'SELL',
+        slippagePct: 0.5,
+      };
+
+      expect(Value.Check(Base.QuoteSwapRequest, sampleRequest)).toBe(true);
+      expect(Value.Check(DFlow.DFlowQuoteSwapRequest, sampleRequest)).toBe(true);
+    });
+
+    it('DFlowQuoteSwapResponse should be a superset of QuoteSwapResponse', () => {
+      const baseRequired = Base.QuoteSwapResponse.required || [];
+      const dflowRequired = DFlow.DFlowQuoteSwapResponse.required || [];
+
+      for (const field of baseRequired) {
+        expect(dflowRequired).toContain(field);
+      }
+
+      const baseProps = Object.keys(Base.QuoteSwapResponse.properties);
+      const dflowProps = Object.keys(DFlow.DFlowQuoteSwapResponse.properties);
+
+      for (const prop of baseProps) {
+        expect(dflowProps).toContain(prop);
+      }
+    });
+
+    it('DFlowExecuteQuoteRequest should be a superset of ExecuteQuoteRequest', () => {
+      const baseRequired = Base.ExecuteQuoteRequest.required || [];
+      const dflowRequired = DFlow.DFlowExecuteQuoteRequest.required || [];
+
+      for (const field of baseRequired) {
+        expect(dflowRequired).toContain(field);
+      }
+
+      const baseProps = Object.keys(Base.ExecuteQuoteRequest.properties);
+      const dflowProps = Object.keys(DFlow.DFlowExecuteQuoteRequest.properties);
+
+      for (const prop of baseProps) {
+        expect(dflowProps).toContain(prop);
+      }
+
+      const sampleRequest = {
+        walletAddress: '7aaee2311351ac9e4de53bf981fd3c882969e4edcd8e858b4eac50f6b8a41112',
+        network: 'mainnet-beta',
+        quoteId: '123e4567-e89b-12d3-a456-426614174000',
+      };
+
+      expect(Value.Check(Base.ExecuteQuoteRequest, sampleRequest)).toBe(true);
+      expect(Value.Check(DFlow.DFlowExecuteQuoteRequest, sampleRequest)).toBe(true);
+    });
+
+    it('DFlowExecuteSwapRequest should be a superset of ExecuteSwapRequest', () => {
+      const baseRequired = Base.ExecuteSwapRequest.required || [];
+      const dflowRequired = DFlow.DFlowExecuteSwapRequest.required || [];
+
+      for (const field of baseRequired) {
+        expect(dflowRequired).toContain(field);
+      }
+
+      const baseProps = Object.keys(Base.ExecuteSwapRequest.properties);
+      const dflowProps = Object.keys(DFlow.DFlowExecuteSwapRequest.properties);
+
+      for (const prop of baseProps) {
+        expect(dflowProps).toContain(prop);
+      }
+
+      const sampleRequest = {
+        walletAddress: '7aaee2311351ac9e4de53bf981fd3c882969e4edcd8e858b4eac50f6b8a41112',
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: 1,
+        side: 'SELL',
+        slippagePct: 0.5,
+      };
+
+      expect(Value.Check(Base.ExecuteSwapRequest, sampleRequest)).toBe(true);
+      expect(Value.Check(DFlow.DFlowExecuteSwapRequest, sampleRequest)).toBe(true);
+    });
+  });
+
+  describe('DFlow-specific Fields', () => {
+    it('DFlowQuoteSwapRequest should include the BUY approximation flag', () => {
+      const props = Object.keys(DFlow.DFlowQuoteSwapRequest.properties);
+      expect(props).toContain('approximateIfNoExactOut');
+    });
+
+    it('DFlowQuoteSwapResponse should include DFlow-specific fields', () => {
+      const props = Object.keys(DFlow.DFlowQuoteSwapResponse.properties);
+      expect(props).toContain('quoteResponse');
+      expect(props).toContain('approximation');
+    });
+  });
+
+  describe('Field Examples and Defaults', () => {
+    it('should have Solana mainnet-only network enum', () => {
+      const networkProp = DFlow.DFlowQuoteSwapRequest.properties.network;
+      expect(networkProp.default).toBe('mainnet-beta');
+      expect(networkProp.enum).toEqual(['mainnet-beta']);
+    });
+  });
+});

--- a/test/connectors/jupiter/router-routes/quoteSwap.test.ts
+++ b/test/connectors/jupiter/router-routes/quoteSwap.test.ts
@@ -193,6 +193,93 @@ describe('GET /quote-swap', () => {
     expect(JSON.parse(response.body)).toHaveProperty('error');
   });
 
+  it('should approximate BUY via sell leg when ExactOut is not supported', async () => {
+    const mockSolanaInstance = {
+      getToken: jest.fn().mockResolvedValueOnce(mockSOL).mockResolvedValueOnce(mockUSDC),
+    };
+    (Solana.getInstance as jest.Mock).mockResolvedValue(mockSolanaInstance);
+
+    const mockJupiterInstance = {
+      getQuote: jest
+        .fn()
+        // ExactOut attempt fails with Jupiter's specific error
+        .mockRejectedValueOnce(new Error('ExactOut not supported for this token pair'))
+        // Sell leg: 0.1 SOL -> 15 USDC
+        .mockResolvedValueOnce({
+          inAmount: '100000000',
+          outAmount: '15000000',
+          priceImpactPct: '0.001',
+          routePlan: [],
+          slippageBps: 50,
+        })
+        // Forward leg: 15 USDC -> 0.0999 SOL
+        .mockResolvedValueOnce({
+          inAmount: '15000000',
+          outAmount: '99900000',
+          priceImpactPct: '0.001',
+          routePlan: [],
+          slippageBps: 50,
+        }),
+    };
+    (Jupiter.getInstance as jest.Mock).mockResolvedValue(mockJupiterInstance);
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: '0.1',
+        side: 'BUY',
+        slippagePct: '0.5',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body).toHaveProperty('approximation', true);
+    expect(body).toHaveProperty('amountIn', 15);
+    expect(body.amountOut).toBeCloseTo(0.0999);
+    // Input is fixed for the approximated ExactIn quote
+    expect(body.maxAmountIn).toBeCloseTo(15);
+    // Slippage applies to the estimated output
+    expect(body.minAmountOut).toBeCloseTo(0.0999 * (1 - 0.005));
+    // ExactOut attempt + sell leg + forward leg
+    expect(mockJupiterInstance.getQuote).toHaveBeenCalledTimes(3);
+  });
+
+  it('should return 400 for BUY when ExactOut is unsupported and approximation is disabled', async () => {
+    const mockSolanaInstance = {
+      getToken: jest.fn().mockResolvedValueOnce(mockSOL).mockResolvedValueOnce(mockUSDC),
+    };
+    (Solana.getInstance as jest.Mock).mockResolvedValue(mockSolanaInstance);
+
+    const mockJupiterInstance = {
+      getQuote: jest.fn().mockRejectedValue(new Error('ExactOut not supported for this token pair')),
+    };
+    (Jupiter.getInstance as jest.Mock).mockResolvedValue(mockJupiterInstance);
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: '0.1',
+        side: 'BUY',
+        slippagePct: '0.5',
+        approximateIfNoExactOut: 'false',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body);
+    expect(body.message).toContain('ExactOut');
+    expect(mockJupiterInstance.getQuote).toHaveBeenCalledTimes(1);
+  });
+
   it('should return 400 when both ExactOut and the ExactIn fallback fail for BUY side', async () => {
     const mockSolanaInstance = {
       getToken: jest.fn().mockResolvedValueOnce(mockSOL).mockResolvedValueOnce(mockUSDC),

--- a/test/connectors/okx/okx.routes.test.ts
+++ b/test/connectors/okx/okx.routes.test.ts
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import path from 'path';
+
+import '../../mocks/app-mocks';
+
+import { FastifyInstance } from 'fastify';
+
+import { gatewayApp } from '../../../src/app';
+
+describe('OKX Routes Structure', () => {
+  const CONNECTOR_NAME = 'okx';
+  let fastify: FastifyInstance;
+
+  beforeAll(async () => {
+    fastify = gatewayApp;
+    await fastify.ready();
+  });
+
+  afterAll(async () => {
+    await fastify.close();
+  });
+
+  describe('Folder Structure', () => {
+    it('should have appropriate route folders based on trading types', async () => {
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/config/connectors',
+      });
+
+      const { connectors } = JSON.parse(response.body);
+      const okxConfig = connectors.find((c: any) => c.name === CONNECTOR_NAME);
+
+      expect(okxConfig).toBeDefined();
+      expect(okxConfig.chain).toBe('solana');
+      expect(okxConfig.trading_types).toEqual(['router']);
+      expect(okxConfig.networks).toEqual(['mainnet-beta']);
+
+      const connectorPath = path.join(__dirname, `../../../src/connectors/${CONNECTOR_NAME}`);
+      const routerRoutesPath = path.join(connectorPath, 'router-routes');
+      expect(fs.existsSync(routerRoutesPath)).toBe(true);
+
+      const files = fs.readdirSync(routerRoutesPath);
+      expect(files.some((f) => f.toLowerCase().includes('swap'))).toBe(true);
+    });
+  });
+
+  describe('Route Registration', () => {
+    it('should register OKX router routes at /connectors/okx/router', async () => {
+      // printRoutes compresses shared prefixes (okx/orca), so probe the routes directly:
+      // a registered route responds with validation/handler errors, an absent one with 404
+      const quoteSwap = await fastify.inject({ method: 'GET', url: '/connectors/okx/router/quote-swap' });
+      expect(quoteSwap.statusCode).not.toBe(404);
+
+      const executeSwap = await fastify.inject({ method: 'POST', url: '/connectors/okx/router/execute-swap' });
+      expect(executeSwap.statusCode).not.toBe(404);
+    });
+  });
+});

--- a/test/connectors/okx/okx.test.ts
+++ b/test/connectors/okx/okx.test.ts
@@ -1,0 +1,90 @@
+import * as crypto from 'crypto';
+
+import { Okx } from '../../../src/connectors/okx/okx';
+
+jest.mock('../../../src/chains/solana/solana', () => ({
+  Solana: {
+    getInstance: jest.fn().mockResolvedValue({ network: 'mainnet-beta' }),
+  },
+}));
+
+jest.mock('../../../src/connectors/okx/okx.config', () => ({
+  OkxConfig: {
+    chain: 'solana',
+    networks: ['mainnet-beta'],
+    tradingTypes: ['router'],
+    config: {
+      slippagePct: 1,
+      apiKey: 'test-api-key',
+      secretKey: 'test-secret-key',
+      passphrase: 'test-passphrase',
+      computeUnitPrice: 0,
+      availableNetworks: [{ chain: 'solana', networks: ['mainnet-beta'] }],
+    },
+  },
+}));
+
+describe('Okx request signing', () => {
+  it('produces OKX-format HMAC headers for a fixed timestamp', async () => {
+    const okx = await Okx.getInstance('mainnet-beta');
+
+    const timestamp = '2026-07-03T00:00:00.000Z';
+    const pathWithQuery = '/api/v6/dex/aggregator/quote?amount=1000&chainIndex=501';
+    const headers = okx.signedHeaders('GET', pathWithQuery, timestamp);
+
+    // The signature is base64(HMAC-SHA256(timestamp + method + requestPathWithQuery, secretKey))
+    const expectedSign = crypto
+      .createHmac('sha256', 'test-secret-key')
+      .update(timestamp + 'GET' + pathWithQuery)
+      .digest('base64');
+
+    expect(headers).toEqual({
+      'OK-ACCESS-KEY': 'test-api-key',
+      'OK-ACCESS-SIGN': expectedSign,
+      'OK-ACCESS-PASSPHRASE': 'test-passphrase',
+      'OK-ACCESS-TIMESTAMP': timestamp,
+    });
+
+    // Known vector: locks the exact signing-string composition against regressions
+    expect(expectedSign).toBe(
+      crypto
+        .createHmac('sha256', 'test-secret-key')
+        .update('2026-07-03T00:00:00.000ZGET/api/v6/dex/aggregator/quote?amount=1000&chainIndex=501')
+        .digest('base64'),
+    );
+  });
+
+  it('signature changes when the query string changes', async () => {
+    const okx = await Okx.getInstance('mainnet-beta');
+    const timestamp = '2026-07-03T00:00:00.000Z';
+
+    const a = okx.signedHeaders('GET', '/api/v6/dex/aggregator/quote?amount=1000', timestamp);
+    const b = okx.signedHeaders('GET', '/api/v6/dex/aggregator/quote?amount=1001', timestamp);
+
+    expect(a['OK-ACCESS-SIGN']).not.toBe(b['OK-ACCESS-SIGN']);
+  });
+});
+
+describe('Okx constructor credential validation', () => {
+  it('throws a clear error when credentials are missing', async () => {
+    jest.resetModules();
+    jest.doMock('../../../src/connectors/okx/okx.config', () => ({
+      OkxConfig: {
+        chain: 'solana',
+        networks: ['mainnet-beta'],
+        tradingTypes: ['router'],
+        config: {
+          slippagePct: 1,
+          apiKey: '',
+          secretKey: '',
+          passphrase: '',
+          computeUnitPrice: 0,
+          availableNetworks: [{ chain: 'solana', networks: ['mainnet-beta'] }],
+        },
+      },
+    }));
+    const { Okx: FreshOkx } = await import('../../../src/connectors/okx/okx');
+
+    await expect(FreshOkx.getInstance('mainnet-beta')).rejects.toThrow(/OKX DEX API credentials are not configured/);
+  });
+});

--- a/test/connectors/okx/router-routes/quoteSwap.test.ts
+++ b/test/connectors/okx/router-routes/quoteSwap.test.ts
@@ -1,0 +1,221 @@
+import { Solana } from '../../../../src/chains/solana/solana';
+import { Okx } from '../../../../src/connectors/okx/okx';
+import { fastifyWithTypeProvider } from '../../../utils/testUtils';
+
+jest.mock('../../../../src/chains/solana/solana');
+jest.mock('../../../../src/connectors/okx/okx');
+
+const buildApp = async () => {
+  const server = fastifyWithTypeProvider();
+  await server.register(require('@fastify/sensible'));
+  const { quoteSwapRoute } = await import('../../../../src/connectors/okx/router-routes/quoteSwap');
+  await server.register(quoteSwapRoute);
+  return server;
+};
+
+const mockSOL = {
+  symbol: 'SOL',
+  address: 'So11111111111111111111111111111111111111112',
+  decimals: 9,
+};
+
+const mockUSDC = {
+  symbol: 'USDC',
+  address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+  decimals: 6,
+};
+
+describe('GET /quote-swap (okx)', () => {
+  let server: any;
+
+  beforeAll(async () => {
+    server = await buildApp();
+  });
+
+  afterAll(async () => {
+    if (server) {
+      await server.close();
+    }
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockSolana = () => {
+    const mockSolanaInstance = {
+      getToken: jest.fn().mockResolvedValueOnce(mockSOL).mockResolvedValueOnce(mockUSDC),
+    };
+    (Solana.getInstance as jest.Mock).mockResolvedValue(mockSolanaInstance);
+    return mockSolanaInstance;
+  };
+
+  it('should return a swap quote for SELL side', async () => {
+    mockSolana();
+    const mockOkxInstance = {
+      getQuote: jest.fn().mockResolvedValue({
+        fromTokenAmount: '100000000', // 0.1 SOL
+        toTokenAmount: '15000000', // 15 USDC
+        priceImpactPercent: '0.05',
+      }),
+    };
+    (Okx.getInstance as jest.Mock).mockResolvedValue(mockOkxInstance);
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: '0.1',
+        side: 'SELL',
+        slippagePct: '0.5',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body).toHaveProperty('quoteId');
+    expect(body).toHaveProperty('amountIn', 0.1);
+    expect(body).toHaveProperty('amountOut', 15);
+    expect(body).toHaveProperty('price', 150);
+    expect(body).toHaveProperty('priceImpactPct', 0.05);
+    expect(body).toHaveProperty('tokenIn', mockSOL.address);
+    expect(body).toHaveProperty('tokenOut', mockUSDC.address);
+    expect(body).toHaveProperty('routerResult');
+    expect(body.approximation).toBeUndefined();
+
+    expect(mockOkxInstance.getQuote).toHaveBeenCalledWith(mockSOL.address, mockUSDC.address, '100000000', 'exactIn');
+  });
+
+  it('should use native exactOut for BUY side when supported', async () => {
+    mockSolana();
+    const mockOkxInstance = {
+      getQuote: jest.fn().mockResolvedValue({
+        fromTokenAmount: '15000000', // 15 USDC in
+        toTokenAmount: '100000000', // 0.1 SOL out
+        priceImpactPercent: '0.05',
+      }),
+    };
+    (Okx.getInstance as jest.Mock).mockResolvedValue(mockOkxInstance);
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: '0.1',
+        side: 'BUY',
+        slippagePct: '0.5',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body).toHaveProperty('amountIn', 15);
+    expect(body).toHaveProperty('amountOut', 0.1);
+    expect(body.approximation).toBeUndefined();
+    // maxAmountIn includes slippage buffer for native exactOut
+    expect(body.maxAmountIn).toBeCloseTo(15 * 1.005);
+    expect(mockOkxInstance.getQuote).toHaveBeenCalledTimes(1);
+    expect(mockOkxInstance.getQuote).toHaveBeenCalledWith(mockUSDC.address, mockSOL.address, '100000000', 'exactOut');
+  });
+
+  it('should approximate BUY via sell leg when exactOut fails', async () => {
+    mockSolana();
+    const mockOkxInstance = {
+      getQuote: jest
+        .fn()
+        // exactOut attempt fails
+        .mockRejectedValueOnce(new Error('OKX API error: exactOut not supported'))
+        // Sell leg: 0.1 SOL -> 15 USDC
+        .mockResolvedValueOnce({
+          fromTokenAmount: '100000000',
+          toTokenAmount: '15000000',
+          priceImpactPercent: '0.05',
+        })
+        // Forward leg: 15 USDC -> 0.0999 SOL
+        .mockResolvedValueOnce({
+          fromTokenAmount: '15000000',
+          toTokenAmount: '99900000',
+          priceImpactPercent: '0.05',
+        }),
+    };
+    (Okx.getInstance as jest.Mock).mockResolvedValue(mockOkxInstance);
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: '0.1',
+        side: 'BUY',
+        slippagePct: '0.5',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body).toHaveProperty('approximation', true);
+    expect(body).toHaveProperty('amountIn', 15);
+    expect(body.amountOut).toBeCloseTo(0.0999);
+    expect(body.maxAmountIn).toBeCloseTo(15);
+    expect(body.minAmountOut).toBeCloseTo(0.0999 * (1 - 0.005));
+    expect(mockOkxInstance.getQuote).toHaveBeenCalledTimes(3);
+  });
+
+  it('should return 400 for BUY when exactOut fails and approximation is disabled', async () => {
+    mockSolana();
+    const mockOkxInstance = {
+      getQuote: jest.fn().mockRejectedValue(new Error('OKX API error: exactOut not supported')),
+    };
+    (Okx.getInstance as jest.Mock).mockResolvedValue(mockOkxInstance);
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: '0.1',
+        side: 'BUY',
+        slippagePct: '0.5',
+        approximateIfNoExactOut: 'false',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body);
+    expect(body.message).toContain('No route found');
+    expect(mockOkxInstance.getQuote).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return 400 if token not found', async () => {
+    const mockSolanaInstance = {
+      getToken: jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(mockUSDC),
+    };
+    (Solana.getInstance as jest.Mock).mockResolvedValue(mockSolanaInstance);
+    (Okx.getInstance as jest.Mock).mockResolvedValue({ getQuote: jest.fn() });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        baseToken: 'INVALID',
+        quoteToken: 'USDC',
+        amount: '0.1',
+        side: 'SELL',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body)).toHaveProperty('error');
+  });
+});

--- a/test/connectors/okx/schemas.test.ts
+++ b/test/connectors/okx/schemas.test.ts
@@ -1,0 +1,127 @@
+import { Value } from '@sinclair/typebox/value';
+
+import * as Okx from '../../../src/connectors/okx/schemas';
+import * as Base from '../../../src/schemas/router-schema';
+
+describe('OKX Schema Tests', () => {
+  describe('Schema Superset Validation', () => {
+    it('OkxQuoteSwapRequest should be a superset of QuoteSwapRequest', () => {
+      const baseRequired = Base.QuoteSwapRequest.required || [];
+      const okxRequired = Okx.OkxQuoteSwapRequest.required || [];
+
+      for (const field of baseRequired) {
+        expect(okxRequired).toContain(field);
+      }
+
+      const baseProps = Object.keys(Base.QuoteSwapRequest.properties);
+      const okxProps = Object.keys(Okx.OkxQuoteSwapRequest.properties);
+
+      for (const prop of baseProps) {
+        expect(okxProps).toContain(prop);
+      }
+
+      const sampleRequest = {
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: 1,
+        side: 'SELL',
+        slippagePct: 0.5,
+      };
+
+      expect(Value.Check(Base.QuoteSwapRequest, sampleRequest)).toBe(true);
+      expect(Value.Check(Okx.OkxQuoteSwapRequest, sampleRequest)).toBe(true);
+    });
+
+    it('OkxQuoteSwapResponse should be a superset of QuoteSwapResponse', () => {
+      const baseRequired = Base.QuoteSwapResponse.required || [];
+      const okxRequired = Okx.OkxQuoteSwapResponse.required || [];
+
+      for (const field of baseRequired) {
+        expect(okxRequired).toContain(field);
+      }
+
+      const baseProps = Object.keys(Base.QuoteSwapResponse.properties);
+      const okxProps = Object.keys(Okx.OkxQuoteSwapResponse.properties);
+
+      for (const prop of baseProps) {
+        expect(okxProps).toContain(prop);
+      }
+    });
+
+    it('OkxExecuteQuoteRequest should be a superset of ExecuteQuoteRequest', () => {
+      const baseRequired = Base.ExecuteQuoteRequest.required || [];
+      const okxRequired = Okx.OkxExecuteQuoteRequest.required || [];
+
+      for (const field of baseRequired) {
+        expect(okxRequired).toContain(field);
+      }
+
+      const baseProps = Object.keys(Base.ExecuteQuoteRequest.properties);
+      const okxProps = Object.keys(Okx.OkxExecuteQuoteRequest.properties);
+
+      for (const prop of baseProps) {
+        expect(okxProps).toContain(prop);
+      }
+
+      const sampleRequest = {
+        walletAddress: '7aaee2311351ac9e4de53bf981fd3c882969e4edcd8e858b4eac50f6b8a41112',
+        network: 'mainnet-beta',
+        quoteId: '123e4567-e89b-12d3-a456-426614174000',
+      };
+
+      expect(Value.Check(Base.ExecuteQuoteRequest, sampleRequest)).toBe(true);
+      expect(Value.Check(Okx.OkxExecuteQuoteRequest, sampleRequest)).toBe(true);
+    });
+
+    it('OkxExecuteSwapRequest should be a superset of ExecuteSwapRequest', () => {
+      const baseRequired = Base.ExecuteSwapRequest.required || [];
+      const okxRequired = Okx.OkxExecuteSwapRequest.required || [];
+
+      for (const field of baseRequired) {
+        expect(okxRequired).toContain(field);
+      }
+
+      const baseProps = Object.keys(Base.ExecuteSwapRequest.properties);
+      const okxProps = Object.keys(Okx.OkxExecuteSwapRequest.properties);
+
+      for (const prop of baseProps) {
+        expect(okxProps).toContain(prop);
+      }
+
+      const sampleRequest = {
+        walletAddress: '7aaee2311351ac9e4de53bf981fd3c882969e4edcd8e858b4eac50f6b8a41112',
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: 1,
+        side: 'SELL',
+        slippagePct: 0.5,
+      };
+
+      expect(Value.Check(Base.ExecuteSwapRequest, sampleRequest)).toBe(true);
+      expect(Value.Check(Okx.OkxExecuteSwapRequest, sampleRequest)).toBe(true);
+    });
+  });
+
+  describe('OKX-specific Fields', () => {
+    it('OkxQuoteSwapRequest should include the BUY approximation flag', () => {
+      const props = Object.keys(Okx.OkxQuoteSwapRequest.properties);
+      expect(props).toContain('approximateIfNoExactOut');
+    });
+
+    it('OkxQuoteSwapResponse should include OKX-specific fields', () => {
+      const props = Object.keys(Okx.OkxQuoteSwapResponse.properties);
+      expect(props).toContain('routerResult');
+      expect(props).toContain('approximation');
+    });
+  });
+
+  describe('Field Examples and Defaults', () => {
+    it('should have Solana mainnet-only network enum', () => {
+      const networkProp = Okx.OkxQuoteSwapRequest.properties.network;
+      expect(networkProp.default).toBe('mainnet-beta');
+      expect(networkProp.enum).toEqual(['mainnet-beta']);
+    });
+  });
+});

--- a/test/connectors/orca/orca.routes.test.ts
+++ b/test/connectors/orca/orca.routes.test.ts
@@ -66,30 +66,25 @@ describe('Orca Routes Structure', () => {
 
   describe('Route Registration', () => {
     it('should register Orca CLMM routes at /connectors/orca/clmm', async () => {
-      const routes = fastify.printRoutes();
+      // printRoutes compresses shared prefixes (okx/orca), so probe the routes directly:
+      // a registered route responds with validation/handler errors, an absent one with 404
+      const clmmRoute = await fastify.inject({ method: 'GET', url: '/connectors/orca/clmm/pool-info' });
+      expect(clmmRoute.statusCode).not.toBe(404);
 
-      // Check that Orca CLMM routes are registered
-      expect(routes).toContain('orca/clmm/');
+      // Check that AMM and router routes are NOT registered
+      const ammRoute = await fastify.inject({ method: 'GET', url: '/connectors/orca/amm/pool-info' });
+      expect(ammRoute.statusCode).toBe(404);
 
-      // Check that swap routes are NOT directly under /swap
-      expect(routes).not.toContain('orca/swap/');
-
-      // Check that AMM routes are NOT registered
-      expect(routes).not.toContain('orca/amm/');
-
-      // Check that router routes are NOT registered
-      expect(routes).not.toContain('orca/router/');
+      const routerRoute = await fastify.inject({ method: 'GET', url: '/connectors/orca/router/quote-swap' });
+      expect(routerRoute.statusCode).toBe(404);
     });
 
     it('should have key CLMM endpoints', async () => {
-      const routes = fastify.printRoutes();
+      const quoteSwap = await fastify.inject({ method: 'GET', url: '/connectors/orca/clmm/quote-swap' });
+      expect(quoteSwap.statusCode).not.toBe(404);
 
-      // Check for key swap endpoints
-      expect(routes).toContain('orca/clmm/');
-
-      // Verify some core endpoints exist (routes may be named differently)
-      // Just verify orca routes are registered
-      expect(routes.includes('orca')).toBe(true);
+      const executeSwap = await fastify.inject({ method: 'POST', url: '/connectors/orca/clmm/execute-swap' });
+      expect(executeSwap.statusCode).not.toBe(404);
     });
   });
 });

--- a/test/connectors/router-utils.test.ts
+++ b/test/connectors/router-utils.test.ts
@@ -1,0 +1,76 @@
+import { approximateBuyViaSellLeg, RouterToken } from '../../src/connectors/router-utils';
+
+const SOL: RouterToken = { symbol: 'SOL', address: 'So11111111111111111111111111111111111111112', decimals: 9 };
+const USDC: RouterToken = { symbol: 'USDC', address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', decimals: 6 };
+
+describe('approximateBuyViaSellLeg', () => {
+  it('derives the forward ExactIn quote from the sell leg output', async () => {
+    // Buying 2 SOL with USDC at ~150 USDC/SOL
+    const getExactInQuote = jest.fn().mockImplementation(async (inputToken, outputToken, amountRaw) => {
+      if (inputToken.symbol === 'SOL') {
+        // Sell leg: 2 SOL -> 300 USDC
+        expect(amountRaw).toBe((2e9).toString());
+        return { inAmount: amountRaw, outAmount: (300e6).toString(), quote: { leg: 'sell' } };
+      }
+      // Forward leg: 300 USDC -> ~1.99 SOL
+      expect(inputToken.symbol).toBe('USDC');
+      expect(outputToken.symbol).toBe('SOL');
+      expect(amountRaw).toBe((300e6).toString());
+      return { inAmount: amountRaw, outAmount: (1.99e9).toString(), quote: { leg: 'forward' } };
+    });
+
+    const result = await approximateBuyViaSellLeg({
+      getExactInQuote,
+      baseToken: SOL,
+      quoteToken: USDC,
+      baseAmount: 2,
+    });
+
+    expect(getExactInQuote).toHaveBeenCalledTimes(2);
+    expect(result.quoteAmountInRaw).toBe((300e6).toString());
+    expect(result.quoteAmountIn).toBeCloseTo(300);
+    expect(result.estimatedBaseOut).toBeCloseTo(1.99);
+    expect(result.forwardQuote.quote).toEqual({ leg: 'forward' });
+  });
+
+  it('floors the raw sell-leg amount to an integer of smallest units', async () => {
+    const getExactInQuote = jest.fn().mockImplementation(async (inputToken, _outputToken, amountRaw) => {
+      if (inputToken.symbol === 'SOL') {
+        expect(amountRaw).toBe(Math.floor(0.123456789123 * 1e9).toString());
+        return { inAmount: amountRaw, outAmount: '1000000', quote: {} };
+      }
+      return { inAmount: amountRaw, outAmount: '123000000', quote: {} };
+    });
+
+    await approximateBuyViaSellLeg({ getExactInQuote, baseToken: SOL, quoteToken: USDC, baseAmount: 0.123456789123 });
+    expect(getExactInQuote).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws a clear error when the sell leg returns no output', async () => {
+    const getExactInQuote = jest.fn().mockResolvedValue({ inAmount: '1', outAmount: '0', quote: {} });
+
+    await expect(
+      approximateBuyViaSellLeg({ getExactInQuote, baseToken: SOL, quoteToken: USDC, baseAmount: 1 }),
+    ).rejects.toThrow(/sell-leg quote.*returned no output/);
+    expect(getExactInQuote).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws a clear error when the forward leg returns no output', async () => {
+    const getExactInQuote = jest
+      .fn()
+      .mockResolvedValueOnce({ inAmount: '1000000000', outAmount: '150000000', quote: {} })
+      .mockResolvedValueOnce({ inAmount: '150000000', outAmount: '0', quote: {} });
+
+    await expect(
+      approximateBuyViaSellLeg({ getExactInQuote, baseToken: SOL, quoteToken: USDC, baseAmount: 1 }),
+    ).rejects.toThrow(/forward quote.*returned no output/);
+  });
+
+  it('propagates router errors from the quote callback', async () => {
+    const getExactInQuote = jest.fn().mockRejectedValue(new Error('No route found for this token pair'));
+
+    await expect(
+      approximateBuyViaSellLeg({ getExactInQuote, baseToken: SOL, quoteToken: USDC, baseAmount: 1 }),
+    ).rejects.toThrow('No route found for this token pair');
+  });
+});

--- a/test/connectors/titan/router-routes/quoteSwap.test.ts
+++ b/test/connectors/titan/router-routes/quoteSwap.test.ts
@@ -1,0 +1,232 @@
+import { Solana } from '../../../../src/chains/solana/solana';
+import { Titan } from '../../../../src/connectors/titan/titan';
+import { quoteCache } from '../../../../src/services/quote-cache';
+import { fastifyWithTypeProvider } from '../../../utils/testUtils';
+
+jest.mock('../../../../src/chains/solana/solana');
+jest.mock('../../../../src/connectors/titan/titan');
+
+const buildApp = async () => {
+  const server = fastifyWithTypeProvider();
+  await server.register(require('@fastify/sensible'));
+  const { quoteSwapRoute } = await import('../../../../src/connectors/titan/router-routes/quoteSwap');
+  await server.register(quoteSwapRoute);
+  return server;
+};
+
+const mockSOL = {
+  symbol: 'SOL',
+  address: 'So11111111111111111111111111111111111111112',
+  decimals: 9,
+};
+
+const mockUSDC = {
+  symbol: 'USDC',
+  address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+  decimals: 6,
+};
+
+const WALLET = 'HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH';
+
+const sellRoute = {
+  provider: 'Titan-DART',
+  inputAmount: '100000000', // 0.1 SOL
+  outputAmount: '15000000', // 15 USDC
+  slippageBps: 50,
+  instructions: [
+    {
+      programId: 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4',
+      accounts: [{ pubkey: WALLET, isSigner: true, isWritable: true }],
+      data: Buffer.from('deadbeef', 'hex').toString('base64'),
+    },
+  ],
+  addressLookupTables: ['9mQGjcTFmhVDMEkP7Nq3wzYRTztTv8XibnwvyR3ZQ1FS'],
+};
+
+describe('GET /quote-swap (titan)', () => {
+  let server: any;
+
+  beforeAll(async () => {
+    server = await buildApp();
+  });
+
+  afterAll(async () => {
+    if (server) {
+      await server.close();
+    }
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockSolana = () => {
+    const mockSolanaInstance = {
+      getToken: jest.fn().mockResolvedValueOnce(mockSOL).mockResolvedValueOnce(mockUSDC),
+    };
+    (Solana.getInstance as jest.Mock).mockResolvedValue(mockSolanaInstance);
+    return mockSolanaInstance;
+  };
+
+  it('should return a wallet-bound swap quote for SELL side', async () => {
+    mockSolana();
+    const mockTitanInstance = {
+      getSwapRoute: jest.fn().mockResolvedValue(sellRoute),
+    };
+    (Titan.getInstance as jest.Mock).mockResolvedValue(mockTitanInstance);
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: '0.1',
+        side: 'SELL',
+        slippagePct: '0.5',
+        walletAddress: WALLET,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body).toHaveProperty('quoteId');
+    expect(body).toHaveProperty('amountIn', 0.1);
+    expect(body).toHaveProperty('amountOut', 15);
+    expect(body).toHaveProperty('price', 150);
+    expect(body).toHaveProperty('wallet', WALLET);
+    expect(body.approximation).toBeUndefined();
+
+    // The route was requested for the provided wallet
+    expect(mockTitanInstance.getSwapRoute).toHaveBeenCalledWith(
+      mockSOL.address,
+      mockUSDC.address,
+      '100000000',
+      WALLET,
+      50,
+    );
+
+    // Cached quote is bound to the wallet for the execute-quote wallet-match check
+    const cached = quoteCache.get(body.quoteId);
+    expect(cached.wallet).toBe(WALLET);
+    expect(cached.connector).toBe('titan');
+    quoteCache.delete(body.quoteId);
+  });
+
+  it('should approximate BUY via sell leg (Titan DART is ExactIn-only)', async () => {
+    mockSolana();
+    const mockTitanInstance = {
+      getSwapRoute: jest
+        .fn()
+        // Sell leg: 0.1 SOL -> 15 USDC
+        .mockResolvedValueOnce(sellRoute)
+        // Forward leg: 15 USDC -> 0.0999 SOL
+        .mockResolvedValueOnce({
+          ...sellRoute,
+          inputAmount: '15000000',
+          outputAmount: '99900000',
+        }),
+    };
+    (Titan.getInstance as jest.Mock).mockResolvedValue(mockTitanInstance);
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: '0.1',
+        side: 'BUY',
+        slippagePct: '0.5',
+        walletAddress: WALLET,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body).toHaveProperty('approximation', true);
+    expect(body).toHaveProperty('amountIn', 15);
+    expect(body.amountOut).toBeCloseTo(0.0999);
+    expect(body.maxAmountIn).toBeCloseTo(15);
+    expect(body.minAmountOut).toBeCloseTo(0.0999 * (1 - 0.005));
+    expect(mockTitanInstance.getSwapRoute).toHaveBeenCalledTimes(2);
+    quoteCache.delete(body.quoteId);
+  });
+
+  it('should return 400 for BUY when approximation is disabled', async () => {
+    mockSolana();
+    const mockTitanInstance = { getSwapRoute: jest.fn() };
+    (Titan.getInstance as jest.Mock).mockResolvedValue(mockTitanInstance);
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: '0.1',
+        side: 'BUY',
+        slippagePct: '0.5',
+        walletAddress: WALLET,
+        approximateIfNoExactOut: 'false',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body);
+    expect(body.message).toContain('ExactIn only');
+    expect(mockTitanInstance.getSwapRoute).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 if token not found', async () => {
+    const mockSolanaInstance = {
+      getToken: jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(mockUSDC),
+    };
+    (Solana.getInstance as jest.Mock).mockResolvedValue(mockSolanaInstance);
+    (Titan.getInstance as jest.Mock).mockResolvedValue({ getSwapRoute: jest.fn() });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        baseToken: 'INVALID',
+        quoteToken: 'USDC',
+        amount: '0.1',
+        side: 'SELL',
+        walletAddress: WALLET,
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body)).toHaveProperty('error');
+  });
+
+  it('should return 400 if no route found for SELL', async () => {
+    mockSolana();
+    const mockTitanInstance = {
+      getSwapRoute: jest.fn().mockRejectedValue(new Error('Titan API error: no route')),
+    };
+    (Titan.getInstance as jest.Mock).mockResolvedValue(mockTitanInstance);
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/quote-swap',
+      query: {
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: '0.1',
+        side: 'SELL',
+        walletAddress: WALLET,
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body);
+    expect(body.message).toContain('No route found');
+  });
+});

--- a/test/connectors/titan/schemas.test.ts
+++ b/test/connectors/titan/schemas.test.ts
@@ -1,0 +1,128 @@
+import { Value } from '@sinclair/typebox/value';
+
+import * as Titan from '../../../src/connectors/titan/schemas';
+import * as Base from '../../../src/schemas/router-schema';
+
+describe('Titan Schema Tests', () => {
+  describe('Schema Superset Validation', () => {
+    it('TitanQuoteSwapRequest should be a superset of QuoteSwapRequest', () => {
+      const baseRequired = Base.QuoteSwapRequest.required || [];
+      const titanRequired = Titan.TitanQuoteSwapRequest.required || [];
+
+      for (const field of baseRequired) {
+        expect(titanRequired).toContain(field);
+      }
+
+      const baseProps = Object.keys(Base.QuoteSwapRequest.properties);
+      const titanProps = Object.keys(Titan.TitanQuoteSwapRequest.properties);
+
+      for (const prop of baseProps) {
+        expect(titanProps).toContain(prop);
+      }
+
+      const sampleRequest = {
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: 1,
+        side: 'SELL',
+        slippagePct: 0.5,
+      };
+
+      expect(Value.Check(Base.QuoteSwapRequest, sampleRequest)).toBe(true);
+      expect(Value.Check(Titan.TitanQuoteSwapRequest, sampleRequest)).toBe(true);
+    });
+
+    it('TitanQuoteSwapResponse should be a superset of QuoteSwapResponse', () => {
+      const baseRequired = Base.QuoteSwapResponse.required || [];
+      const titanRequired = Titan.TitanQuoteSwapResponse.required || [];
+
+      for (const field of baseRequired) {
+        expect(titanRequired).toContain(field);
+      }
+
+      const baseProps = Object.keys(Base.QuoteSwapResponse.properties);
+      const titanProps = Object.keys(Titan.TitanQuoteSwapResponse.properties);
+
+      for (const prop of baseProps) {
+        expect(titanProps).toContain(prop);
+      }
+    });
+
+    it('TitanExecuteQuoteRequest should be a superset of ExecuteQuoteRequest', () => {
+      const baseRequired = Base.ExecuteQuoteRequest.required || [];
+      const titanRequired = Titan.TitanExecuteQuoteRequest.required || [];
+
+      for (const field of baseRequired) {
+        expect(titanRequired).toContain(field);
+      }
+
+      const baseProps = Object.keys(Base.ExecuteQuoteRequest.properties);
+      const titanProps = Object.keys(Titan.TitanExecuteQuoteRequest.properties);
+
+      for (const prop of baseProps) {
+        expect(titanProps).toContain(prop);
+      }
+
+      const sampleRequest = {
+        walletAddress: '7aaee2311351ac9e4de53bf981fd3c882969e4edcd8e858b4eac50f6b8a41112',
+        network: 'mainnet-beta',
+        quoteId: '123e4567-e89b-12d3-a456-426614174000',
+      };
+
+      expect(Value.Check(Base.ExecuteQuoteRequest, sampleRequest)).toBe(true);
+      expect(Value.Check(Titan.TitanExecuteQuoteRequest, sampleRequest)).toBe(true);
+    });
+
+    it('TitanExecuteSwapRequest should be a superset of ExecuteSwapRequest', () => {
+      const baseRequired = Base.ExecuteSwapRequest.required || [];
+      const titanRequired = Titan.TitanExecuteSwapRequest.required || [];
+
+      for (const field of baseRequired) {
+        expect(titanRequired).toContain(field);
+      }
+
+      const baseProps = Object.keys(Base.ExecuteSwapRequest.properties);
+      const titanProps = Object.keys(Titan.TitanExecuteSwapRequest.properties);
+
+      for (const prop of baseProps) {
+        expect(titanProps).toContain(prop);
+      }
+
+      const sampleRequest = {
+        walletAddress: '7aaee2311351ac9e4de53bf981fd3c882969e4edcd8e858b4eac50f6b8a41112',
+        network: 'mainnet-beta',
+        baseToken: 'SOL',
+        quoteToken: 'USDC',
+        amount: 1,
+        side: 'SELL',
+        slippagePct: 0.5,
+      };
+
+      expect(Value.Check(Base.ExecuteSwapRequest, sampleRequest)).toBe(true);
+      expect(Value.Check(Titan.TitanExecuteSwapRequest, sampleRequest)).toBe(true);
+    });
+  });
+
+  describe('Titan-specific Fields', () => {
+    it('TitanQuoteSwapRequest should include wallet binding and the BUY approximation flag', () => {
+      const props = Object.keys(Titan.TitanQuoteSwapRequest.properties);
+      expect(props).toContain('walletAddress');
+      expect(props).toContain('approximateIfNoExactOut');
+    });
+
+    it('TitanQuoteSwapResponse should include the bound wallet', () => {
+      const props = Object.keys(Titan.TitanQuoteSwapResponse.properties);
+      expect(props).toContain('wallet');
+      expect(props).toContain('approximation');
+    });
+  });
+
+  describe('Field Examples and Defaults', () => {
+    it('should have Solana mainnet-only network enum', () => {
+      const networkProp = Titan.TitanQuoteSwapRequest.properties.network;
+      expect(networkProp.default).toBe('mainnet-beta');
+      expect(networkProp.enum).toEqual(['mainnet-beta']);
+    });
+  });
+});

--- a/test/connectors/titan/titan.routes.test.ts
+++ b/test/connectors/titan/titan.routes.test.ts
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+
+import '../../mocks/app-mocks';
+
+import { FastifyInstance } from 'fastify';
+
+import { gatewayApp } from '../../../src/app';
+
+describe('Titan Routes Structure', () => {
+  const CONNECTOR_NAME = 'titan';
+  let fastify: FastifyInstance;
+
+  beforeAll(async () => {
+    fastify = gatewayApp;
+    await fastify.ready();
+  });
+
+  afterAll(async () => {
+    await fastify.close();
+  });
+
+  describe('Folder Structure', () => {
+    it('should have appropriate route folders based on trading types', async () => {
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/config/connectors',
+      });
+
+      const { connectors } = JSON.parse(response.body);
+      const titanConfig = connectors.find((c: any) => c.name === CONNECTOR_NAME);
+
+      expect(titanConfig).toBeDefined();
+      expect(titanConfig.chain).toBe('solana');
+      expect(titanConfig.trading_types).toEqual(['router']);
+      expect(titanConfig.networks).toEqual(['mainnet-beta']);
+
+      const connectorPath = path.join(__dirname, `../../../src/connectors/${CONNECTOR_NAME}`);
+      const routerRoutesPath = path.join(connectorPath, 'router-routes');
+      expect(fs.existsSync(routerRoutesPath)).toBe(true);
+
+      const files = fs.readdirSync(routerRoutesPath);
+      expect(files.some((f) => f.toLowerCase().includes('swap'))).toBe(true);
+    });
+  });
+
+  describe('Route Registration', () => {
+    it('should register Titan router routes at /connectors/titan/router', async () => {
+      const routes = fastify.printRoutes();
+
+      expect(routes).toContain('titan/router/');
+      expect(routes).toContain('quote-swap');
+      expect(routes).toContain('execute-swap');
+    });
+  });
+});

--- a/test/connectors/titan/titan.utils.test.ts
+++ b/test/connectors/titan/titan.utils.test.ts
@@ -1,0 +1,131 @@
+import { AddressLookupTableAccount, PublicKey, VersionedTransaction } from '@solana/web3.js';
+
+import {
+  buildVersionedTransactionFromInstructions,
+  dedupeComputeBudgetInstructions,
+  deserializeInstructions,
+  resolveAddressLookupTables,
+  TitanApiInstruction,
+} from '../../../src/connectors/titan/titan.utils';
+
+const PAYER = 'HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH';
+const PROGRAM = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4';
+const ALT_ADDRESS = '9mQGjcTFmhVDMEkP7Nq3wzYRTztTv8XibnwvyR3ZQ1FS';
+const BLOCKHASH = 'EETubP5AKHgjPAhzPAFcb8BAY1hMH639CWCFTqi3hq1k';
+
+const rawInstruction: TitanApiInstruction = {
+  programId: PROGRAM,
+  accounts: [
+    { pubkey: PAYER, isSigner: true, isWritable: true },
+    { pubkey: ALT_ADDRESS, isSigner: false, isWritable: false },
+  ],
+  data: Buffer.from([1, 2, 3, 4]).toString('base64'),
+};
+
+describe('deserializeInstructions', () => {
+  it('converts Titan API instructions to web3.js TransactionInstructions', () => {
+    const [instruction] = deserializeInstructions([rawInstruction]);
+
+    expect(instruction.programId.toBase58()).toBe(PROGRAM);
+    expect(instruction.keys).toHaveLength(2);
+    expect(instruction.keys[0].pubkey.toBase58()).toBe(PAYER);
+    expect(instruction.keys[0].isSigner).toBe(true);
+    expect(instruction.keys[0].isWritable).toBe(true);
+    expect(instruction.keys[1].isSigner).toBe(false);
+    expect(Array.from(instruction.data)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('throws on malformed instructions', () => {
+    expect(() => deserializeInstructions([{ programId: PROGRAM } as any])).toThrow(/Malformed Titan instruction/);
+  });
+});
+
+describe('dedupeComputeBudgetInstructions', () => {
+  const COMPUTE_BUDGET = 'ComputeBudget111111111111111111111111111111';
+
+  const computeBudgetIx = (discriminator: number, extra: number[] = [0, 0, 0, 0]): TitanApiInstruction => ({
+    programId: COMPUTE_BUDGET,
+    accounts: [],
+    data: Buffer.from([discriminator, ...extra]).toString('base64'),
+  });
+
+  it('drops repeated ComputeBudget instructions of the same type (live DART duplicate-heap-frame shape)', () => {
+    // Shape observed from the live DART API: RequestHeapFrame (1), SetComputeUnitLimit (2),
+    // SetComputeUnitPrice (3), then a DUPLICATE RequestHeapFrame (1), then the swap ix
+    const instructions = deserializeInstructions([
+      computeBudgetIx(1),
+      computeBudgetIx(2),
+      computeBudgetIx(3, [0, 0, 0, 0, 0, 0, 0, 0]),
+      computeBudgetIx(1),
+      rawInstruction,
+    ]);
+
+    const deduped = dedupeComputeBudgetInstructions(instructions);
+
+    expect(deduped).toHaveLength(4);
+    const discriminators = deduped.filter((ix) => ix.programId.toBase58() === COMPUTE_BUDGET).map((ix) => ix.data[0]);
+    expect(discriminators).toEqual([1, 2, 3]);
+    // Non-ComputeBudget instruction passes through untouched
+    expect(deduped[3].programId.toBase58()).toBe(PROGRAM);
+  });
+
+  it('leaves instruction lists without duplicates unchanged', () => {
+    const instructions = deserializeInstructions([computeBudgetIx(2), rawInstruction]);
+    expect(dedupeComputeBudgetInstructions(instructions)).toHaveLength(2);
+  });
+});
+
+describe('resolveAddressLookupTables', () => {
+  it('throws a clear error when a lookup table is missing on-chain', async () => {
+    const connection: any = {
+      getAddressLookupTable: jest.fn().mockResolvedValue({ value: null }),
+    };
+
+    await expect(resolveAddressLookupTables(connection, [ALT_ADDRESS])).rejects.toThrow(
+      `Address lookup table not found: ${ALT_ADDRESS}`,
+    );
+  });
+});
+
+describe('buildVersionedTransactionFromInstructions', () => {
+  const altAccount = new AddressLookupTableAccount({
+    key: new PublicKey(ALT_ADDRESS),
+    state: {
+      deactivationSlot: BigInt('18446744073709551615'),
+      lastExtendedSlot: 0,
+      lastExtendedSlotStartIndex: 0,
+      authority: undefined,
+      addresses: [],
+    },
+  });
+
+  it('compiles an unsigned V0 transaction with a fresh blockhash', async () => {
+    const connection: any = {
+      getAddressLookupTable: jest.fn().mockResolvedValue({ value: altAccount }),
+      getLatestBlockhash: jest.fn().mockResolvedValue({ blockhash: BLOCKHASH, lastValidBlockHeight: 1 }),
+    };
+
+    const transaction = await buildVersionedTransactionFromInstructions(
+      connection,
+      PAYER,
+      [rawInstruction],
+      [ALT_ADDRESS],
+    );
+
+    expect(transaction).toBeInstanceOf(VersionedTransaction);
+    expect(transaction.message.version).toBe(0);
+    expect(transaction.message.recentBlockhash).toBe(BLOCKHASH);
+    // Unsigned: signature slots are present but zero-filled
+    expect(transaction.signatures.every((sig) => sig.every((byte) => byte === 0))).toBe(true);
+    // Payer is the first static account key
+    expect(transaction.message.staticAccountKeys[0].toBase58()).toBe(PAYER);
+    expect(connection.getAddressLookupTable).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when there are no instructions', async () => {
+    const connection: any = {};
+    await expect(buildVersionedTransactionFromInstructions(connection, PAYER, [], [])).rejects.toThrow(
+      /No instructions/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds three new Solana router/aggregator connectors — **DFlow**, **OKX DEX**, and **Titan** — so all four major Solana aggregators (with Jupiter) are supported through Gateway's standard router endpoints (`quote-swap`, `execute-quote`, `execute-swap`) and the unified `/trading/swap` dispatch.

> **⚠️ Rebased off Swig, now stacked on #665** (`feat/robinhood-chain`): Swig is excluded from the next release, so this branch was rebased off `feat/swig-solana-clean` onto #665, which ports the wallet-type-aware chokepoint `Solana.sendAndConfirmTransactionForWallet` (swig-free) that these connectors execute through. The PR shows #665's commits until it merges — then retarget to `development`. Review the three commits at the tip:
> - `feat(router)`: base-schema BUY approximation flag + shared sell-leg helper + Jupiter fallback (merged with #665's jupiter ExactIn fallback: the shared helper supersedes the jupiter-local one; the fallback still triggers on any BUY ExactOut failure and reports the combined error when both legs fail)
> - `feat(connectors)`: the three connectors, templates, registration, tests
> - `fix(solana)`: preserve heap-frame ComputeBudget instructions; honor `swapProvider` config

## Connectors

| | DFlow | OKX DEX | Titan (DART) |
|---|---|---|---|
| API | `quote-api.dflow.net` (`x-api-key`; keyless dev endpoint without one) | `web3.okx.com` v6 aggregator, HMAC-signed (`OK-ACCESS-*`) | `api.titan.exchange/dart` (keyless 1 req/s tier, optional `X-API-Key`) |
| Swap tx | base64 `swapTransaction` (Jupiter-like) | serialized tx from wallet-bound `GET /swap` (route re-fetched at execution) | instructions + ALTs → unsigned V0 tx compiled client-side |
| BUY (ExactOut) | ExactIn-only → sell-leg approximation | native `exactOut`, approximation fallback | ExactIn-only → sell-leg approximation |

Credential setup is documented in `src/connectors/{dflow,okx}/README.md`.

## Router-standard change

New optional `approximateIfNoExactOut` (default `true`) on quote/execute-swap requests + `approximation` on quote responses (base `router-schema`, backward compatible). ExactIn-only routers serve BUYs by deriving the price from a sell-leg quote via the shared `src/connectors/router-utils.ts` helper; Jupiter's `ExactOut not supported` path uses the same fallback.

## Bug fixes found by live execution on mainnet-beta

- **Titan DART returns a duplicated `RequestHeapFrame`** ComputeBudget instruction, which the runtime rejects → deduped by discriminator when compiling (`titan.utils.ts`).
- **`prepareTx`/`prepareVersionedTx` stripped ALL ComputeBudget instructions** when injecting CU limit/price, discarding Titan's required 256KB heap frame → on-chain `Access violation in heap section`. Now only CU-limit/price (discriminators 2/3) are replaced.
- **Network `swapProvider` config was ignored** by `/trading/swap`: the unified schemas' `connector` param had `default: 'jupiter/router'`, so Fastify injected it on every request (this also broke Ethereum unified swaps). Default removed; both network schemas now enum the valid providers.
- **DFlow silently ignores `swapMode=ExactOut`** and quotes ExactIn (mislabeling BUY amounts) → treated as ExactIn-only.

## Testing

- 123 suites / 1136 tests pass (`pnpm test`), lint + typecheck clean; new suites cover schema-superset contracts, BUY approximation, OKX HMAC vector, Titan instruction/ALT/V0 compile + dedupe.
- Live on mainnet-beta: DFlow SELL executed and confirmed on-chain ([`DzBWWH…WfpW`](https://solscan.io/tx/DzBWWHx1uNYo7YAoLDZP8W4W2MtMEkxJTMdffUM5mi6yC9Bep8zkixQvcSt6WUpBtNMdVJQHLGUVVekvQH3WfpW)); Titan + DFlow quotes (SELL and approximated BUY) verified keyless; OKX verified to fail fast with clear credential errors.
- Remaining before undraft: re-run Titan execute post-heap-frame-fix, live-verify config-driven `swapProvider` dispatch and DFlow approximated-BUY execution, and an OKX execute once credentials are available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHA8E865HgkeMmCCmy4oZm
