### PR TITLE
fix(orca): read position state from consistent snapshot

### DIFF
--- a/src/connectors/orca/orca.position.ts
+++ b/src/connectors/orca/orca.position.ts
@@ -1,6 +1,8 @@
 import {
-  fetchAllTickArray,
-  fetchPosition,
+  decodePosition,
+  decodeTickArray,
+  decodeWhirlpool,
+  fetchMaybePosition,
   fetchWhirlpool,
   getTickArrayAddress,
   type WhirlpoolDeployment,
@@ -18,6 +20,8 @@ import {
 } from '@orca-so/whirlpools-core';
 import {
   address,
+  assertAccountExists,
+  fetchEncodedAccounts,
   type GetAccountInfoApi,
   type GetEpochInfoApi,
   type GetMultipleAccountsApi,
@@ -25,11 +29,25 @@ import {
   Account,
   MaybeAccount,
 } from '@solana/kit';
-import { fetchAllMint, type Mint } from '@solana-program/token-2022';
+import { decodeMint, type Mint } from '@solana-program/token-2022';
 
 import { PositionInfo } from '../../schemas/clmm-schema';
+import { logger } from '../../services/logger';
 
 type OrcaRpc = Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetEpochInfoApi>;
+
+const MAX_POSITION_SNAPSHOT_ATTEMPTS = 2;
+
+class PositionSnapshotChangedError extends Error {
+  constructor() {
+    super('Orca position changed while its account snapshot was being assembled');
+  }
+}
+
+const isRetryableSnapshotError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+  return error instanceof PositionSnapshotChangedError || message.includes('Amount exceeds max u64');
+};
 
 export const getCurrentTransferFee = (
   mint: MaybeAccount<Mint> | Account<Mint>,
@@ -51,22 +69,69 @@ export const getCurrentTransferFee = (
   };
 };
 
-export const getPositionDetails = async (
+const getPositionDetailsFromSnapshot = async (
   rpc: OrcaRpc,
   positionAddress: string,
   deployment: WhirlpoolDeployment,
-): Promise<PositionInfo> => {
-  const position = await fetchPosition(rpc, address(positionAddress));
-  const whirlpool = await fetchWhirlpool(rpc, position.data.whirlpool);
-  const [mintA, mintB] = await fetchAllMint(rpc, [whirlpool.data.tokenMintA, whirlpool.data.tokenMintB]);
+): Promise<PositionInfo | null> => {
+  // The discovery reads provide only the addresses needed for the final batch.
+  // No changing fee or liquidity value from these reads is used below.
+  const discoveredPosition = await fetchMaybePosition(rpc, address(positionAddress));
+  if (!discoveredPosition.exists) {
+    return null;
+  }
+  const discoveredWhirlpool = await fetchWhirlpool(rpc, discoveredPosition.data.whirlpool);
 
-  const lowerStartIndex = getTickArrayStartTickIndex(position.data.tickLowerIndex, whirlpool.data.tickSpacing);
-  const upperStartIndex = getTickArrayStartTickIndex(position.data.tickUpperIndex, whirlpool.data.tickSpacing);
+  const lowerStartIndex = getTickArrayStartTickIndex(
+    discoveredPosition.data.tickLowerIndex,
+    discoveredWhirlpool.data.tickSpacing,
+  );
+  const upperStartIndex = getTickArrayStartTickIndex(
+    discoveredPosition.data.tickUpperIndex,
+    discoveredWhirlpool.data.tickSpacing,
+  );
   const [[lowerTickArrayAddress], [upperTickArrayAddress]] = await Promise.all([
-    getTickArrayAddress(whirlpool.address, lowerStartIndex, deployment.programId),
-    getTickArrayAddress(whirlpool.address, upperStartIndex, deployment.programId),
+    getTickArrayAddress(discoveredWhirlpool.address, lowerStartIndex, deployment.programId),
+    getTickArrayAddress(discoveredWhirlpool.address, upperStartIndex, deployment.programId),
   ]);
-  const [lowerTickArray, upperTickArray] = await fetchAllTickArray(rpc, [lowerTickArrayAddress, upperTickArrayAddress]);
+
+  // Fee growth is spread across the position, Whirlpool, and boundary ticks.
+  // Fetch all of them in one RPC response so collectFeesQuote never receives a
+  // mix of values from opposite sides of a tick-crossing transaction.
+  const encodedAccounts = await fetchEncodedAccounts(rpc, [
+    discoveredPosition.address,
+    discoveredWhirlpool.address,
+    discoveredWhirlpool.data.tokenMintA,
+    discoveredWhirlpool.data.tokenMintB,
+    lowerTickArrayAddress,
+    upperTickArrayAddress,
+  ]);
+  const position = decodePosition(encodedAccounts[0]);
+  if (!position.exists) {
+    return null;
+  }
+  const whirlpool = decodeWhirlpool(encodedAccounts[1]);
+  const mintA = decodeMint(encodedAccounts[2]);
+  const mintB = decodeMint(encodedAccounts[3]);
+  const lowerTickArray = decodeTickArray(encodedAccounts[4]);
+  const upperTickArray = decodeTickArray(encodedAccounts[5]);
+  assertAccountExists(whirlpool);
+  assertAccountExists(mintA);
+  assertAccountExists(mintB);
+  assertAccountExists(lowerTickArray);
+  assertAccountExists(upperTickArray);
+
+  if (
+    position.data.whirlpool !== discoveredPosition.data.whirlpool ||
+    position.data.tickLowerIndex !== discoveredPosition.data.tickLowerIndex ||
+    position.data.tickUpperIndex !== discoveredPosition.data.tickUpperIndex ||
+    whirlpool.data.tokenMintA !== discoveredWhirlpool.data.tokenMintA ||
+    whirlpool.data.tokenMintB !== discoveredWhirlpool.data.tokenMintB ||
+    whirlpool.data.tickSpacing !== discoveredWhirlpool.data.tickSpacing
+  ) {
+    throw new PositionSnapshotChangedError();
+  }
+
   const lowerTick =
     lowerTickArray.data.ticks[
       getTickIndexInArray(position.data.tickLowerIndex, lowerStartIndex, whirlpool.data.tickSpacing)
@@ -120,4 +185,23 @@ export const getPositionDetails = async (
     quoteTokenAmount: Number(tokenB) / scaleB,
     price: sqrtPriceToPrice(whirlpool.data.sqrtPrice, mintA.data.decimals, mintB.data.decimals),
   };
+};
+
+export const getPositionDetails = async (
+  rpc: OrcaRpc,
+  positionAddress: string,
+  deployment: WhirlpoolDeployment,
+): Promise<PositionInfo | null> => {
+  for (let attempt = 1; attempt <= MAX_POSITION_SNAPSHOT_ATTEMPTS; attempt++) {
+    try {
+      return await getPositionDetailsFromSnapshot(rpc, positionAddress, deployment);
+    } catch (error) {
+      if (attempt === MAX_POSITION_SNAPSHOT_ATTEMPTS || !isRetryableSnapshotError(error)) {
+        throw error;
+      }
+      logger.warn(`Retrying Orca position snapshot for ${positionAddress} after an inconsistent read`);
+    }
+  }
+
+  throw new Error(`Failed to read Orca position snapshot: ${positionAddress}`);
 };

--- a/src/connectors/orca/orca.position.ts
+++ b/src/connectors/orca/orca.position.ts
@@ -32,22 +32,8 @@ import {
 import { decodeMint, type Mint } from '@solana-program/token-2022';
 
 import { PositionInfo } from '../../schemas/clmm-schema';
-import { logger } from '../../services/logger';
 
 type OrcaRpc = Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetEpochInfoApi>;
-
-const MAX_POSITION_SNAPSHOT_ATTEMPTS = 2;
-
-class PositionSnapshotChangedError extends Error {
-  constructor() {
-    super('Orca position changed while its account snapshot was being assembled');
-  }
-}
-
-const isRetryableSnapshotError = (error: unknown): boolean => {
-  const message = error instanceof Error ? error.message : String(error);
-  return error instanceof PositionSnapshotChangedError || message.includes('Amount exceeds max u64');
-};
 
 export const getCurrentTransferFee = (
   mint: MaybeAccount<Mint> | Account<Mint>,
@@ -69,7 +55,7 @@ export const getCurrentTransferFee = (
   };
 };
 
-const getPositionDetailsFromSnapshot = async (
+export const getPositionDetails = async (
   rpc: OrcaRpc,
   positionAddress: string,
   deployment: WhirlpoolDeployment,
@@ -129,7 +115,7 @@ const getPositionDetailsFromSnapshot = async (
     whirlpool.data.tokenMintB !== discoveredWhirlpool.data.tokenMintB ||
     whirlpool.data.tickSpacing !== discoveredWhirlpool.data.tickSpacing
   ) {
-    throw new PositionSnapshotChangedError();
+    throw new Error('Orca position changed while its account snapshot was being assembled');
   }
 
   const lowerTick =
@@ -185,23 +171,4 @@ const getPositionDetailsFromSnapshot = async (
     quoteTokenAmount: Number(tokenB) / scaleB,
     price: sqrtPriceToPrice(whirlpool.data.sqrtPrice, mintA.data.decimals, mintB.data.decimals),
   };
-};
-
-export const getPositionDetails = async (
-  rpc: OrcaRpc,
-  positionAddress: string,
-  deployment: WhirlpoolDeployment,
-): Promise<PositionInfo | null> => {
-  for (let attempt = 1; attempt <= MAX_POSITION_SNAPSHOT_ATTEMPTS; attempt++) {
-    try {
-      return await getPositionDetailsFromSnapshot(rpc, positionAddress, deployment);
-    } catch (error) {
-      if (attempt === MAX_POSITION_SNAPSHOT_ATTEMPTS || !isRetryableSnapshotError(error)) {
-        throw error;
-      }
-      logger.warn(`Retrying Orca position snapshot for ${positionAddress} after an inconsistent read`);
-    }
-  }
-
-  throw new Error(`Failed to read Orca position snapshot: ${positionAddress}`);
 };

--- a/src/connectors/orca/orca.ts
+++ b/src/connectors/orca/orca.ts
@@ -1,5 +1,5 @@
 import { fetchPositionsForOwner, setNativeMintWrappingStrategy, type WhirlpoolDeployment } from '@orca-so/whirlpools';
-import { fetchWhirlpool, fetchPosition, fetchMaybePosition } from '@orca-so/whirlpools-client';
+import { fetchWhirlpool, fetchPosition } from '@orca-so/whirlpools-client';
 import { address, createSolanaRpc, mainnet, devnet } from '@solana/kit';
 import { PublicKey } from '@solana/web3.js';
 
@@ -336,7 +336,11 @@ export class Orca {
             position.address.toString(),
             this.deployment,
           );
-          positions.push(positionDetails);
+          if (positionDetails) {
+            positions.push(positionDetails);
+          } else {
+            logger.debug(`Position ${position.address} appears to be closed, skipping`);
+          }
         } catch (positionError: any) {
           // Skip positions that fail to fetch (e.g., closed positions, invalid data)
           // Only log as debug since this is expected for closed positions
@@ -369,16 +373,8 @@ export class Orca {
       throw httpErrors.badRequest(`Invalid position address: ${positionAddress}`);
     }
 
-    // null means "the position account does not exist" — a definitive on-chain
-    // answer that callers (position-info 404, close reconciliation in
-    // Hummingbot's LP executor) treat as "position closed". Anything else must
-    // throw: swallowing a transient RPC failure here serves "position closed"
-    // for a network blip, and an executor acting on that abandons a live,
-    // funded position while reporting success.
-    const maybePosition = await fetchMaybePosition(this.solanaKitRpc, address(positionAddress));
-    if (!maybePosition.exists) {
-      return null;
-    }
+    // getPositionDetails returns null only when its final atomic snapshot proves
+    // the position account does not exist. All transient failures propagate.
     return await getPositionDetails(this.solanaKitRpc, positionAddress, this.deployment);
   }
 }

--- a/test/connectors/orca/orca.position.test.ts
+++ b/test/connectors/orca/orca.position.test.ts
@@ -1,0 +1,219 @@
+jest.mock('@orca-so/whirlpools-client', () => ({
+  decodePosition: jest.fn(),
+  decodeTickArray: jest.fn(),
+  decodeWhirlpool: jest.fn(),
+  fetchMaybePosition: jest.fn(),
+  fetchWhirlpool: jest.fn(),
+  getTickArrayAddress: jest.fn(),
+}));
+jest.mock('@orca-so/whirlpools-core', () => ({
+  collectFeesQuote: jest.fn(),
+  getTickArrayStartTickIndex: jest.fn((tickIndex: number) => tickIndex),
+  getTickIndexInArray: jest.fn(() => 0),
+  sqrtPriceToPrice: jest.fn(() => 100),
+  tickIndexToPrice: jest.fn((tickIndex: number) => tickIndex),
+  tickIndexToSqrtPrice: jest.fn((tickIndex: number) => BigInt(tickIndex)),
+  tryGetAmountDeltaA: jest.fn(() => 3_000_000_000n),
+  tryGetAmountDeltaB: jest.fn(() => 4_000_000n),
+}));
+jest.mock('@solana/kit', () => ({
+  address: jest.fn((value: string) => value),
+  assertAccountExists: jest.fn((account: any) => {
+    if (!account.exists) {
+      throw new Error(`Account not found: ${account.address}`);
+    }
+  }),
+  fetchEncodedAccounts: jest.fn(),
+}));
+jest.mock('@solana-program/token-2022', () => ({
+  decodeMint: jest.fn(),
+}));
+jest.mock('../../../src/services/logger', () => ({
+  logger: {
+    warn: jest.fn(),
+  },
+}));
+
+import {
+  decodePosition,
+  decodeTickArray,
+  decodeWhirlpool,
+  fetchMaybePosition,
+  fetchWhirlpool,
+  getTickArrayAddress,
+} from '@orca-so/whirlpools-client';
+import { collectFeesQuote, tryGetAmountDeltaA, tryGetAmountDeltaB } from '@orca-so/whirlpools-core';
+import { fetchEncodedAccounts } from '@solana/kit';
+import { decodeMint } from '@solana-program/token-2022';
+
+import { getPositionDetails } from '../../../src/connectors/orca/orca.position';
+import { logger } from '../../../src/services/logger';
+
+describe('Orca position snapshot', () => {
+  const rpc = {
+    getEpochInfo: jest.fn(() => ({
+      send: jest.fn().mockResolvedValue({ epoch: 42n }),
+    })),
+  } as any;
+  const deployment = { programId: 'orca-program' } as any;
+
+  const encoded = Array.from({ length: 6 }, (_, index) => ({ encoded: index }));
+  const discoveredPosition = {
+    exists: true,
+    address: 'position',
+    data: {
+      whirlpool: 'pool',
+      tickLowerIndex: 10,
+      tickUpperIndex: 20,
+    },
+  };
+  const discoveredWhirlpool = {
+    exists: true,
+    address: 'pool',
+    data: {
+      tokenMintA: 'mint-a',
+      tokenMintB: 'mint-b',
+      tickSpacing: 1,
+    },
+  };
+  const position = {
+    exists: true,
+    address: 'position',
+    data: {
+      ...discoveredPosition.data,
+      liquidity: 1_000n,
+    },
+  };
+  const whirlpool = {
+    exists: true,
+    address: 'pool',
+    data: {
+      ...discoveredWhirlpool.data,
+      tickCurrentIndex: 15,
+      sqrtPrice: 15n,
+    },
+  };
+  const mintA = {
+    exists: true,
+    address: 'mint-a',
+    data: { decimals: 9, extensions: { __option: 'None' } },
+  };
+  const mintB = {
+    exists: true,
+    address: 'mint-b',
+    data: { decimals: 6, extensions: { __option: 'None' } },
+  };
+  const lowerTickArray = { exists: true, address: 'lower-ticks', data: { ticks: [{ lower: true }] } };
+  const upperTickArray = { exists: true, address: 'upper-ticks', data: { ticks: [{ upper: true }] } };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (fetchMaybePosition as jest.Mock).mockResolvedValue(discoveredPosition);
+    (fetchWhirlpool as jest.Mock).mockResolvedValue(discoveredWhirlpool);
+    (getTickArrayAddress as jest.Mock).mockImplementation(async (_pool: string, startIndex: number) => [
+      startIndex === 10 ? 'lower-ticks' : 'upper-ticks',
+    ]);
+    (fetchEncodedAccounts as jest.Mock).mockResolvedValue(encoded);
+    (decodePosition as jest.Mock).mockImplementation((account) =>
+      account === encoded[0] ? position : { exists: false, address: 'position' },
+    );
+    (decodeWhirlpool as jest.Mock).mockReturnValue(whirlpool);
+    (decodeMint as jest.Mock).mockImplementation((account) => (account === encoded[2] ? mintA : mintB));
+    (decodeTickArray as jest.Mock).mockImplementation((account) =>
+      account === encoded[4] ? lowerTickArray : upperTickArray,
+    );
+    (collectFeesQuote as jest.Mock).mockReturnValue({ feeOwedA: 5_000_000n, feeOwedB: 7_000_000n });
+  });
+
+  it.each([
+    { name: 'below range', tickCurrentIndex: 5, baseTokenAmount: 3, quoteTokenAmount: 0 },
+    { name: 'in range', tickCurrentIndex: 15, baseTokenAmount: 3, quoteTokenAmount: 4 },
+    { name: 'above range', tickCurrentIndex: 25, baseTokenAmount: 0, quoteTokenAmount: 4 },
+  ])('calculates $name amounts from one final account batch', async (testCase) => {
+    whirlpool.data.tickCurrentIndex = testCase.tickCurrentIndex;
+
+    const result = await getPositionDetails(rpc, 'position', deployment);
+
+    expect(fetchEncodedAccounts).toHaveBeenCalledTimes(1);
+    expect(fetchEncodedAccounts).toHaveBeenCalledWith(rpc, [
+      'position',
+      'pool',
+      'mint-a',
+      'mint-b',
+      'lower-ticks',
+      'upper-ticks',
+    ]);
+    expect(result).toEqual(
+      expect.objectContaining({
+        address: 'position',
+        poolAddress: 'pool',
+        baseTokenAmount: testCase.baseTokenAmount,
+        quoteTokenAmount: testCase.quoteTokenAmount,
+        baseFeeAmount: 0.005,
+        quoteFeeAmount: 7,
+      }),
+    );
+    expect(tryGetAmountDeltaA).toHaveBeenCalledTimes(testCase.tickCurrentIndex < 20 ? 1 : 0);
+    expect(tryGetAmountDeltaB).toHaveBeenCalledTimes(testCase.tickCurrentIndex >= 10 ? 1 : 0);
+  });
+
+  it('returns null when the position is absent during discovery', async () => {
+    (fetchMaybePosition as jest.Mock).mockResolvedValue({ exists: false, address: 'position' });
+
+    await expect(getPositionDetails(rpc, 'position', deployment)).resolves.toBeNull();
+    expect(fetchWhirlpool).not.toHaveBeenCalled();
+    expect(fetchEncodedAccounts).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the position closes before the final account batch', async () => {
+    (decodePosition as jest.Mock).mockReturnValue({ exists: false, address: 'position' });
+
+    await expect(getPositionDetails(rpc, 'position', deployment)).resolves.toBeNull();
+    expect(fetchEncodedAccounts).toHaveBeenCalledTimes(1);
+    expect(decodeWhirlpool).not.toHaveBeenCalled();
+  });
+
+  it('retries once when Orca rejects an inconsistent fee-growth snapshot', async () => {
+    (collectFeesQuote as jest.Mock)
+      .mockImplementationOnce(() => {
+        throw new Error('Amount exceeds max u64');
+      })
+      .mockReturnValueOnce({ feeOwedA: 5_000_000n, feeOwedB: 7_000_000n });
+
+    await expect(getPositionDetails(rpc, 'position', deployment)).resolves.toEqual(
+      expect.objectContaining({ address: 'position' }),
+    );
+    expect(fetchEncodedAccounts).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries discovery when the position changes before the final batch', async () => {
+    (decodePosition as jest.Mock)
+      .mockReturnValueOnce({
+        ...position,
+        data: { ...position.data, tickUpperIndex: 21 },
+      })
+      .mockReturnValue(position);
+
+    await expect(getPositionDetails(rpc, 'position', deployment)).resolves.toEqual(
+      expect.objectContaining({ address: 'position' }),
+    );
+    expect(fetchEncodedAccounts).toHaveBeenCalledTimes(2);
+    expect(collectFeesQuote).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates non-snapshot failures without retrying', async () => {
+    (fetchEncodedAccounts as jest.Mock).mockRejectedValue(new Error('429 Too Many Requests'));
+
+    await expect(getPositionDetails(rpc, 'position', deployment)).rejects.toThrow('429 Too Many Requests');
+    expect(fetchEncodedAccounts).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('propagates a missing Whirlpool dependency instead of reporting the position closed', async () => {
+    (decodeWhirlpool as jest.Mock).mockReturnValue({ exists: false, address: 'pool' });
+
+    await expect(getPositionDetails(rpc, 'position', deployment)).rejects.toThrow('Account not found: pool');
+    expect(fetchEncodedAccounts).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/connectors/orca/orca.position.test.ts
+++ b/test/connectors/orca/orca.position.test.ts
@@ -28,11 +28,6 @@ jest.mock('@solana/kit', () => ({
 jest.mock('@solana-program/token-2022', () => ({
   decodeMint: jest.fn(),
 }));
-jest.mock('../../../src/services/logger', () => ({
-  logger: {
-    warn: jest.fn(),
-  },
-}));
 
 import {
   decodePosition,
@@ -47,7 +42,6 @@ import { fetchEncodedAccounts } from '@solana/kit';
 import { decodeMint } from '@solana-program/token-2022';
 
 import { getPositionDetails } from '../../../src/connectors/orca/orca.position';
-import { logger } from '../../../src/services/logger';
 
 describe('Orca position snapshot', () => {
   const rpc = {
@@ -173,33 +167,26 @@ describe('Orca position snapshot', () => {
     expect(decodeWhirlpool).not.toHaveBeenCalled();
   });
 
-  it('retries once when Orca rejects an inconsistent fee-growth snapshot', async () => {
-    (collectFeesQuote as jest.Mock)
-      .mockImplementationOnce(() => {
-        throw new Error('Amount exceeds max u64');
-      })
-      .mockReturnValueOnce({ feeOwedA: 5_000_000n, feeOwedB: 7_000_000n });
+  it('propagates an inconsistent fee-growth calculation without connector-specific retry', async () => {
+    (collectFeesQuote as jest.Mock).mockImplementation(() => {
+      throw new Error('Amount exceeds max u64');
+    });
 
-    await expect(getPositionDetails(rpc, 'position', deployment)).resolves.toEqual(
-      expect.objectContaining({ address: 'position' }),
-    );
-    expect(fetchEncodedAccounts).toHaveBeenCalledTimes(2);
-    expect(logger.warn).toHaveBeenCalledTimes(1);
+    await expect(getPositionDetails(rpc, 'position', deployment)).rejects.toThrow('Amount exceeds max u64');
+    expect(fetchEncodedAccounts).toHaveBeenCalledTimes(1);
   });
 
-  it('retries discovery when the position changes before the final batch', async () => {
-    (decodePosition as jest.Mock)
-      .mockReturnValueOnce({
-        ...position,
-        data: { ...position.data, tickUpperIndex: 21 },
-      })
-      .mockReturnValue(position);
+  it('rejects when discovery metadata changes before the final batch', async () => {
+    (decodePosition as jest.Mock).mockReturnValue({
+      ...position,
+      data: { ...position.data, tickUpperIndex: 21 },
+    });
 
-    await expect(getPositionDetails(rpc, 'position', deployment)).resolves.toEqual(
-      expect.objectContaining({ address: 'position' }),
+    await expect(getPositionDetails(rpc, 'position', deployment)).rejects.toThrow(
+      'Orca position changed while its account snapshot was being assembled',
     );
-    expect(fetchEncodedAccounts).toHaveBeenCalledTimes(2);
-    expect(collectFeesQuote).toHaveBeenCalledTimes(1);
+    expect(fetchEncodedAccounts).toHaveBeenCalledTimes(1);
+    expect(collectFeesQuote).not.toHaveBeenCalled();
   });
 
   it('propagates non-snapshot failures without retrying', async () => {
@@ -207,7 +194,6 @@ describe('Orca position snapshot', () => {
 
     await expect(getPositionDetails(rpc, 'position', deployment)).rejects.toThrow('429 Too Many Requests');
     expect(fetchEncodedAccounts).toHaveBeenCalledTimes(1);
-    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it('propagates a missing Whirlpool dependency instead of reporting the position closed', async () => {

--- a/test/connectors/orca/orca.test.ts
+++ b/test/connectors/orca/orca.test.ts
@@ -17,7 +17,6 @@ jest.mock('@orca-so/whirlpools', () => ({
 jest.mock('@orca-so/whirlpools-client', () => ({
   fetchWhirlpool: jest.fn(),
   fetchPosition: jest.fn(),
-  fetchMaybePosition: jest.fn(),
 }));
 jest.mock('@solana/kit', () => ({
   address: jest.fn((value: string) => value),
@@ -28,7 +27,7 @@ jest.mock('@solana/kit', () => ({
 }));
 
 import { fetchPositionsForOwner, setNativeMintWrappingStrategy } from '@orca-so/whirlpools';
-import { fetchMaybePosition, fetchPosition, fetchWhirlpool } from '@orca-so/whirlpools-client';
+import { fetchPosition, fetchWhirlpool } from '@orca-so/whirlpools-client';
 
 import { Solana } from '../../../src/chains/solana/solana';
 import { Orca } from '../../../src/connectors/orca/orca';
@@ -147,9 +146,18 @@ describe('Orca', () => {
     );
   });
 
+  it('omits an owned position only when the final snapshot proves it closed', async () => {
+    const positionAddress = Keypair.generate().publicKey.toBase58();
+    (fetchPositionsForOwner as jest.Mock).mockResolvedValue([{ address: positionAddress, isPositionBundle: false }]);
+    (getPositionDetails as jest.Mock).mockResolvedValue(null);
+    const orca = await Orca.getInstance('mainnet-beta');
+
+    await expect(orca.getPositionsForWalletAddress(wallet.publicKey.toBase58())).resolves.toEqual([]);
+    expect(logger.debug).toHaveBeenCalledWith(`Position ${positionAddress} appears to be closed, skipping`);
+  });
+
   it('validates and reads a specific position without a wallet-bound SDK client', async () => {
     const info = { address: Keypair.generate().publicKey.toBase58() };
-    (fetchMaybePosition as jest.Mock).mockResolvedValue({ exists: true });
     (getPositionDetails as jest.Mock).mockResolvedValue(info);
     const orca = await Orca.getInstance('mainnet-beta');
     await expect(orca.getPositionInfo(info.address, wallet.publicKey.toBase58())).resolves.toEqual(info);
@@ -159,22 +167,18 @@ describe('Orca', () => {
   });
 
   it('returns null from getPositionInfo only when the account definitively does not exist', async () => {
-    (fetchMaybePosition as jest.Mock).mockResolvedValue({ exists: false });
+    (getPositionDetails as jest.Mock).mockResolvedValue(null);
     const orca = await Orca.getInstance('mainnet-beta');
     const positionAddress = Keypair.generate().publicKey.toBase58();
     await expect(orca.getPositionInfo(positionAddress, wallet.publicKey.toBase58())).resolves.toBeNull();
-    expect(getPositionDetails).not.toHaveBeenCalled();
+    expect(getPositionDetails).toHaveBeenCalledWith(orca.solanaKitRpc, positionAddress, orca.deployment);
   });
 
   it('propagates transient errors from getPositionInfo instead of reporting the position closed', async () => {
     // Callers treat null as "position closed"; a swallowed RPC error here would
     // let an LP executor abandon a live, funded position while reporting success.
-    (fetchMaybePosition as jest.Mock).mockRejectedValue(new Error('429 Too Many Requests'));
     const orca = await Orca.getInstance('mainnet-beta');
     const positionAddress = Keypair.generate().publicKey.toBase58();
-    await expect(orca.getPositionInfo(positionAddress, wallet.publicKey.toBase58())).rejects.toThrow('429');
-
-    (fetchMaybePosition as jest.Mock).mockResolvedValue({ exists: true });
     (getPositionDetails as jest.Mock).mockRejectedValue(new Error('RPC node behind'));
     await expect(orca.getPositionInfo(positionAddress, wallet.publicKey.toBase58())).rejects.toThrow('RPC node behind');
   });


### PR DESCRIPTION
## Summary

- read the Orca position, Whirlpool, token mints, and boundary tick arrays from one getMultipleAccounts response
- validate discovery metadata against the final snapshot and propagate any inconsistency without connector-specific retry
- return null only when the position account is definitively absent, while propagating fee-calculation, RPC, and dependency failures
- add focused regression tests for below-range, in-range, above-range, closure, single-attempt snapshot validation, and error behavior

## Verification

- Orca test suite: 17 suites and 118 tests passed
- pnpm typecheck passed
- pnpm build passed
- pnpm lint completed with zero errors; existing repository warnings remain
- no-retry read-only live verification against pool Czfq3xZZDmsdGdUyrNLtRhGc47cXcZtLG4crryfu44zE: 20 of 20 paced reads succeeded over 65.5 seconds on active position 3bpb4oEB1UtvZtragJQ2TnxPhVDn4eftDmY6owHBu16H, with no snapshot or u64 overflow errors
- the originally supplied position FkxgqEyPwPRdwR1UdL7233tJV2TGoLweKYeHvSUisPTM is now definitively closed on-chain
- full suite from the initial implementation: 1,448 tests passed; one unrelated Meteora routing test timed out during unmocked external initialization and reproduced in isolation

## Dependency

This is a stacked PR based on #683 and targets its feat/unified-trading-routes branch so this review contains only the Orca fix.

Addresses #686.