### PR TITLE
fix(meteora): refresh cached DLMM state when active bin drifts

### DIFF
--- a/src/connectors/meteora/meteora.ts
+++ b/src/connectors/meteora/meteora.ts
@@ -262,6 +262,21 @@ export class Meteora {
         return null;
       }
 
+      // getActiveBin() fetches activeId fresh from chain, but the cached DLMM
+      // instance's lbPair state (which getBinsAroundActiveBin centers on) is
+      // only refreshed once, when getDlmmPool first created it. After price
+      // drifts, pool-info returns a fresh price/activeBinId alongside a bins
+      // window frozen around the creation-time active bin - and once the drift
+      // exceeds the window, the bins no longer even contain the active bin.
+      // When the fresh activeId disagrees with the cached one, refresh the
+      // cached state before reading bins. Costs nothing when nothing drifted.
+      if (activeBin.binId !== dlmmPool.lbPair.activeId) {
+        logger.info(
+          `Pool ${poolAddress} active bin drifted (cached ${dlmmPool.lbPair.activeId} -> onchain ${activeBin.binId}); refreshing cached pool state`,
+        );
+        await dlmmPool.refetchStates();
+      }
+
       const poolInfo: MeteoraPoolInfo = {
         address: poolAddress,
         baseTokenAddress: dlmmPool.tokenX.publicKey.toBase58(),


### PR DESCRIPTION
## Problem

`Meteora.getDlmmPool()` caches the DLMM instance and calls `refetchStates()` exactly once, at creation. Two reads then diverge permanently:

- `getActiveBin()` fetches `activeId` **fresh from chain** on every call — so `pool-info`'s `price` and `activeBinId` always look current.
- `getBinsAroundActiveBin()` centers its window on the **cached** `lbPair.activeId` — frozen at whatever the active bin was when the pool instance was first created.

After price drifts, `pool-info` returns a fresh price/activeBinId alongside a bins window centered on a stale bin. Once the drift exceeds the window (±70 bins), **the returned bins no longer contain the active bin at all** — silently breaking any consumer computing liquidity depth around price. There is no error; the data just stops meaning what it appears to mean.

## Observed live

SOL-USDC pool `5rCf1DM8LjKTw4YqhnoLcngyZYeNnQqztScTogYHAS6` (binStep 4), Gateway 2.16.0, after several hours of uptime during a ~5% move:

```
price 96.8751 | activeBinId -5837 | bins window -5790..-5650
active bin inside window: FALSE
implied price of activeBinId from bin math: 96.8751   <- price is fresh, bins are not
```

Restarting Gateway re-centred the window to `-5908..-5768` (active bin inside again), confirming the cache as the cause.

## Fix

`getPoolInfo()` already fetches the fresh `activeId` — when it disagrees with the cached `lbPair.activeId`, call `refetchStates()` before reading bins. Costs nothing when nothing drifted; self-heals (and logs) when it did.

## Testing

- `pnpm typecheck` clean
- `test/connectors/meteora`: 5/5 suites, 44/44 tests pass
- Deployed on a live mainnet instance since 2026-08-26: drift-refresh triggers as expected during price moves, bins window stays centered on the active bin, no added RPC load while idle
