### PR TITLE
feat(meteora): open a price range wider than one transaction can fund

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1564,7 +1564,15 @@
             "format": "decimal",
             "type": "string"
           },
-          "liquidity": {}
+          "liquidity": {},
+          "positionCount": {
+            "description": "Number of positions required to cover this price range",
+            "type": "number"
+          },
+          "transactionCount": {
+            "description": "Number of transactions required to open and fund this range",
+            "type": "number"
+          }
         },
         "required": [
           "baseLimited",

--- a/src/chains/solana/solana-error-parser.ts
+++ b/src/chains/solana/solana-error-parser.ts
@@ -66,7 +66,9 @@ const PROGRAM_ERROR_CODES: Record<string, Record<number, { type: SolanaErrorType
     },
     6040: {
       type: 'INVALID_POSITION',
-      message: 'Invalid position width. Use a position width of 69 bins or lower.',
+      message:
+        'Invalid position width. A DLMM position spans up to 1400 bins, but only about 69 can be created ' +
+        'and funded in one transaction — a wider range has to be deposited in chunks.',
     },
   },
 
@@ -167,7 +169,9 @@ const GENERIC_ERROR_CODES: Record<number, { type: SolanaErrorType; message: stri
   },
   6040: {
     type: 'INVALID_POSITION',
-    message: 'Invalid position width. Use a position width of 69 bins or lower.',
+    message:
+      'Invalid position width. A DLMM position spans up to 1400 bins, but only about 69 can be created ' +
+      'and funded in one transaction — a wider range has to be deposited in chunks.',
   },
   // Math errors
   6018: {
@@ -397,8 +401,9 @@ export function parseSolanaError(errorMessage: string): ParsedSolanaError {
 
   // Solana caps account data growth via CPI at 10,240 bytes; programs allocate accounts
   // through the system program via CPI even in top-level instructions. The common trigger
-  // is a Meteora DLMM position whose price range spans too many bins (~112 bytes/bin; the
-  // program caps positions at 69 bins anyway).
+  // is a Meteora DLMM position grown too far in one instruction (~112 bytes/bin). Note the
+  // limit is on the growth, not on the position: a position spans up to POSITION_MAX_LENGTH
+  // (1400) bins, reached by depositing in chunks rather than in one go.
   if (errorMessage.includes('Failed to reallocate account data')) {
     return {
       type: 'INSTRUCTION_ERROR',
@@ -408,8 +413,8 @@ export function parseSolanaError(errorMessage: string): ParsedSolanaError {
       instructionIndex,
       message:
         'An instruction tried to grow an account beyond Solana’s 10,240-byte allocation limit. If this is a ' +
-        'Meteora DLMM position, the price range spans too many bins — a position holds at most 69 bins, so ' +
-        'narrow the range or open multiple positions to cover it.',
+        'Meteora DLMM position, the range was deposited in one instruction rather than in chunks — a position ' +
+        'spans up to 1400 bins, but only about 69 fit in a single transaction.',
       rawError: errorMessage,
     };
   }

--- a/src/chains/solana/solana-error-parser.ts
+++ b/src/chains/solana/solana-error-parser.ts
@@ -67,7 +67,7 @@ const PROGRAM_ERROR_CODES: Record<string, Record<number, { type: SolanaErrorType
     6040: {
       type: 'INVALID_POSITION',
       message:
-        'Invalid position width. A DLMM position spans up to 1400 bins, but only about 69 can be created ' +
+        'Invalid position width. A DLMM position spans up to 1400 bins, but only 70 can be created ' +
         'and funded in one transaction — a wider range has to be deposited in chunks.',
     },
   },
@@ -170,7 +170,7 @@ const GENERIC_ERROR_CODES: Record<number, { type: SolanaErrorType; message: stri
   6040: {
     type: 'INVALID_POSITION',
     message:
-      'Invalid position width. A DLMM position spans up to 1400 bins, but only about 69 can be created ' +
+      'Invalid position width. A DLMM position spans up to 1400 bins, but only 70 can be created ' +
       'and funded in one transaction — a wider range has to be deposited in chunks.',
   },
   // Math errors
@@ -414,7 +414,7 @@ export function parseSolanaError(errorMessage: string): ParsedSolanaError {
       message:
         'An instruction tried to grow an account beyond Solana’s 10,240-byte allocation limit. If this is a ' +
         'Meteora DLMM position, the range was deposited in one instruction rather than in chunks — a position ' +
-        'spans up to 1400 bins, but only about 69 fit in a single transaction.',
+        'spans up to 1400 bins, but only 70 fit in a single transaction.',
       rawError: errorMessage,
     };
   }

--- a/src/connectors/meteora/clmm-routes/addLiquidity.ts
+++ b/src/connectors/meteora/clmm-routes/addLiquidity.ts
@@ -98,7 +98,12 @@ export async function addLiquidity(
   const totalXAmount = new BN(DecimalUtil.toBN(new Decimal(baseTokenAmount), dlmmPool.tokenX.mint.decimals));
   const totalYAmount = new BN(DecimalUtil.toBN(new Decimal(quoteTokenAmount), dlmmPool.tokenY.mint.decimals));
 
-  const addLiquidityTx = await dlmmPool.addLiquidityByStrategy({
+  // Chunkable, because a position can be wider than one transaction can deposit into.
+  // openPosition will now create such a position, and remove-liquidity, close-position and
+  // collect-fees already send whatever the SDK hands back, so this was the one route on the
+  // position's lifecycle that could not service the wide end of it: the non-chunkable
+  // builder returns a single transaction and silently assumes the range fits in one.
+  const addLiquidityTxs = await dlmmPool.addLiquidityByStrategyChunkable({
     positionPubKey: new PublicKey(position.publicKey),
     user: walletPublicKey,
     totalXAmount,
@@ -111,12 +116,32 @@ export async function addLiquidity(
     slippage: slippagePct,
   });
 
-  // Set the fee payer for simulation
-  addLiquidityTx.feePayer = walletPublicKey;
+  const transactions = Array.isArray(addLiquidityTxs) ? addLiquidityTxs : [addLiquidityTxs];
 
   // Sign + send via the wallet-type-aware chokepoint (handles local/hardware and
-  // simulates internally).
-  const { signature, fee } = await solana.sendAndConfirmTransactionForWallet(addLiquidityTx, address);
+  // simulates internally). A narrow position is still one transaction; a wide one deposits
+  // over several, and a failure partway leaves the earlier chunks funded.
+  const signatures: string[] = [];
+  let fee = 0;
+  for (let i = 0; i < transactions.length; i++) {
+    const tx = transactions[i];
+    tx.feePayer = walletPublicKey;
+    try {
+      const result = await solana.sendAndConfirmTransactionForWallet(tx, address);
+      signatures.push(result.signature);
+      fee += result.fee;
+    } catch (error) {
+      if (signatures.length === 0) throw error;
+      throw httpErrors.internalServerError(
+        `Added liquidity in ${signatures.length} of ${transactions.length} chunks before ` +
+          `${error instanceof Error ? error.message : String(error)}. The position holds what landed — ` +
+          `re-run add-liquidity with the remaining amount. Transactions: ${signatures.join(', ')}`,
+      );
+    }
+  }
+
+  // The first transaction; the amounts below are summed across all of them.
+  const signature = signatures[0];
 
   // Get transaction data for confirmation
   // Retrying re-fetch; throws the shared landed-but-failed error if the transaction
@@ -126,15 +151,19 @@ export async function addLiquidity(
   const confirmed = txData !== null;
 
   if (confirmed && txData) {
-    // Track wallet's balance changes for the tokens
-    const { balanceChanges } = await solana.extractBalanceChangesAndFee(signature, walletPublicKey.toBase58(), [
-      dlmmPool.tokenX.publicKey.toBase58(),
-      dlmmPool.tokenY.publicKey.toBase58(),
-    ]);
-
-    // Balance changes are negative (tokens leaving wallet)
-    let tokenXAddedAmount = Math.abs(balanceChanges[0]);
-    let tokenYAddedAmount = Math.abs(balanceChanges[1]);
+    // Track wallet's balance changes for the tokens, over every transaction that
+    // deposited. Reading only the first would report a fraction of a chunked add.
+    let tokenXAddedAmount = 0;
+    let tokenYAddedAmount = 0;
+    for (const sig of signatures) {
+      const { balanceChanges } = await solana.extractBalanceChangesAndFee(sig, walletPublicKey.toBase58(), [
+        dlmmPool.tokenX.publicKey.toBase58(),
+        dlmmPool.tokenY.publicKey.toBase58(),
+      ]);
+      // Balance changes are negative (tokens leaving wallet)
+      tokenXAddedAmount += Math.abs(balanceChanges[0]);
+      tokenYAddedAmount += Math.abs(balanceChanges[1]);
+    }
 
     // When SOL is base/quote, wallet pays: liquidity + tx fee
     // Subtract fee to get actual liquidity added

--- a/src/connectors/meteora/clmm-routes/openPosition.ts
+++ b/src/connectors/meteora/clmm-routes/openPosition.ts
@@ -1,5 +1,5 @@
 import { DecimalUtil } from '@orca-so/common-sdk';
-import { Keypair, PublicKey } from '@solana/web3.js';
+import { Keypair, PublicKey, Transaction } from '@solana/web3.js';
 import { BN } from 'bn.js';
 import { Decimal } from 'decimal.js';
 
@@ -61,7 +61,10 @@ export async function openPosition(
     }
     // Handle InvalidPositionWidth error from Meteora SDK
     if (error instanceof Error && error.message.includes('InvalidPositionWidth')) {
-      throw httpErrors.badRequest('Invalid position width. Please use a position width of 69 bins or lower.');
+      throw httpErrors.badRequest(
+        `Invalid position width. Use a width of ${Meteora.MAX_POSITION_BIN_WIDTH} bins or lower, ` +
+          'or a range this route can chunk across transactions.',
+      );
     }
     throw error; // Re-throw unexpected errors
   }
@@ -108,21 +111,13 @@ export async function openPosition(
   const minBinId = dlmmPool.getBinIdFromPrice(Number(lowerPricePerLamport), true);
   const maxBinId = dlmmPool.getBinIdFromPrice(Number(upperPricePerLamport), false);
 
-  // A DLMM position holds at most 69 bins (program error 0x1798/6040 beyond that; ranges
-  // past ~130 bins fail even earlier with InvalidRealloc because the position account
-  // would exceed Solana's 10,240-byte CPI allocation limit). Validate here so users get
-  // the actual constraint instead of a cryptic on-chain error.
-  const MAX_POSITION_BIN_WIDTH = 69;
+  // A range wider than one transaction can create and fund is opened by chunking the
+  // deposit instead of being rejected. One position spans up to POSITION_MAX_LENGTH
+  // (1400) bins, so this stays a single position; what grows is the number of
+  // transactions, because the deposit is chunked at DEFAULT_BIN_PER_POSITION bins each.
+  // quote-liquidity reports that count up front via `transactionCount`.
   const positionWidth = maxBinId - minBinId + 1;
-  if (positionWidth > MAX_POSITION_BIN_WIDTH) {
-    const binStepPct = dlmmPool.lbPair.binStep / 100;
-    const maxRangePct = ((Math.pow(1 + binStepPct / 100, MAX_POSITION_BIN_WIDTH) - 1) * 100).toFixed(1);
-    throw httpErrors.badRequest(
-      `Price range ${lowerPrice}-${upperPrice} spans ${positionWidth} bins, but a Meteora DLMM position holds at ` +
-        `most ${MAX_POSITION_BIN_WIDTH} bins. At this pool's ${binStepPct}% bin step that is ~${maxRangePct}% ` +
-        `between lower and upper price. Narrow the range, or open multiple positions to cover it.`,
-    );
-  }
+  const needsChunkedOpen = positionWidth > Meteora.MAX_POSITION_BIN_WIDTH;
 
   // Don't add SOL rent to the liquidity amounts - rent is separate
   const totalXAmount = new BN(DecimalUtil.toBN(new Decimal(baseTokenAmount || 0), dlmmPool.tokenX.mint.decimals));
@@ -132,19 +127,7 @@ export async function openPosition(
   // Slippage needs to be in BPS (basis points): percentage * 100
   const slippageBps = slippagePct * 100;
 
-  const createPositionTx = await dlmmPool.initializePositionAndAddLiquidityByStrategy({
-    positionPubKey: newImbalancePosition.publicKey,
-    user: walletPublicKey,
-    totalXAmount,
-    totalYAmount,
-    strategy: {
-      maxBinId,
-      minBinId,
-      strategyType: strategyType ?? MeteoraConfig.config.strategyType,
-    },
-    // Only add slippage if provided and greater than 0
-    ...(slippageBps ? { slippage: slippageBps } : {}),
-  });
+  const resolvedStrategyType = strategyType ?? MeteoraConfig.config.strategyType;
 
   logger.info(
     `Opening position in pool ${poolAddress} with price range ${lowerPrice.toFixed(4)} - ${upperPrice.toFixed(4)} ${tokenYSymbol}/${tokenXSymbol}`,
@@ -152,23 +135,102 @@ export async function openPosition(
   logger.info(
     `Token amounts: ${(baseTokenAmount || 0).toFixed(6)} ${tokenXSymbol}, ${(quoteTokenAmount || 0).toFixed(6)} ${tokenYSymbol}`,
   );
-  logger.info(`Bin IDs: min=${minBinId}, max=${maxBinId}, active=${activeBin.binId}`);
+  logger.info(`Bin IDs: min=${minBinId}, max=${maxBinId}, active=${activeBin.binId}, width=${positionWidth}`);
   if (slippageBps) {
     logger.info(`Slippage: ${slippagePct}% (${slippageBps} BPS)`);
   }
 
-  // Log the transaction details before sending
-  logger.info(`Transaction details: ${createPositionTx.instructions.length} instructions`);
+  // The position account, and every transaction that built it. A narrow range is one
+  // transaction, as before; a wide one is the same single position funded over several,
+  // so everything downstream reads the list rather than a lone signature.
+  let positionKeypair = newImbalancePosition;
+  const signatures: string[] = [];
+  let txFee = 0;
 
-  // Set the fee payer for simulation
-  createPositionTx.feePayer = walletPublicKey;
+  /** Send one transaction through the wallet-type-aware chokepoint and record it. */
+  const sendStep = async (tx: Transaction, signers: Keypair[], label: string): Promise<void> => {
+    tx.feePayer = walletPublicKey;
+    logger.info(`${label}: ${tx.instructions.length} instructions`);
+    const { signature, fee } = await solana.sendAndConfirmTransactionForWallet(tx, walletAddress, signers);
+    signatures.push(signature);
+    txFee += fee;
+  };
 
-  // Sign + send via the wallet-type-aware chokepoint (handles local/hardware and
-  // simulates internally). The newly generated position keypair is passed
-  // as an extra signer.
-  const { signature, fee: txFee } = await solana.sendAndConfirmTransactionForWallet(createPositionTx, walletAddress, [
-    newImbalancePosition,
-  ]);
+  if (!needsChunkedOpen) {
+    const createPositionTx = await dlmmPool.initializePositionAndAddLiquidityByStrategy({
+      positionPubKey: newImbalancePosition.publicKey,
+      user: walletPublicKey,
+      totalXAmount,
+      totalYAmount,
+      strategy: { maxBinId, minBinId, strategyType: resolvedStrategyType },
+      // Only add slippage if provided and greater than 0
+      ...(slippageBps ? { slippage: slippageBps } : {}),
+    });
+    await sendStep(createPositionTx, [newImbalancePosition], 'Create position');
+  } else {
+    // The SDK sizes the work from the strategy and hands back raw instructions grouped by
+    // position: the position init, idempotent ATA creations, and the deposit split into
+    // chunks of DEFAULT_BIN_PER_POSITION bins. Note this takes slippage as a percentage,
+    // not the basis points the single-transaction builder above wants.
+    const { instructionsByPositions } = await dlmmPool.initializeMultiplePositionAndAddLiquidityByStrategy(
+      async (count: number) => Array.from({ length: count }, () => Keypair.generate()),
+      totalXAmount,
+      totalYAmount,
+      { maxBinId, minBinId, strategyType: resolvedStrategyType },
+      walletPublicKey,
+      walletPublicKey,
+      slippagePct,
+    );
+
+    // Above POSITION_MAX_LENGTH bins the SDK splits into several positions, which this
+    // route cannot describe: its response carries one position address. Refuse rather
+    // than silently return one of several and leave the rest unreferenced.
+    if (instructionsByPositions.length !== 1) {
+      throw httpErrors.badRequest(
+        `Price range ${lowerPrice}-${upperPrice} spans ${positionWidth} bins, which needs ` +
+          `${instructionsByPositions.length} separate positions. This route opens one position — ` +
+          `narrow the range, or open each part with its own call.`,
+      );
+    }
+
+    const [plan] = instructionsByPositions;
+    positionKeypair = plan.positionKeypair;
+
+    // Create the position first, on its own. The deposit chunks are already sized to fit a
+    // transaction by themselves, so folding the init and the ATA creations in alongside one
+    // risks overflowing it — for the sake of saving a signature on a path that is
+    // multi-transaction by nature.
+    const initTx = new Transaction().add(...plan.initializeAtaIxs, plan.initializePositionIx);
+    await sendStep(initTx, [plan.positionKeypair], 'Create position');
+
+    // Each chunk deposits into part of the range. They are sent in order, and a failure
+    // partway leaves the position open with the chunks so far funded — reported below
+    // rather than swallowed, since the caller now owns an account it did not see created.
+    for (let i = 0; i < plan.addLiquidityIxs.length; i++) {
+      try {
+        await sendStep(
+          new Transaction().add(...plan.addLiquidityIxs[i]),
+          [],
+          `Add liquidity ${i + 1}/${plan.addLiquidityIxs.length}`,
+        );
+      } catch (error) {
+        logger.error(
+          `Chunk ${i + 1}/${plan.addLiquidityIxs.length} failed for ${positionKeypair.publicKey.toBase58()}`,
+        );
+        throw httpErrors.internalServerError(
+          `Position ${positionKeypair.publicKey.toBase58()} was opened, but only ${i} of ` +
+            `${plan.addLiquidityIxs.length} liquidity chunks were funded before ` +
+            `${error instanceof Error ? error.message : String(error)}. The position exists and holds what ` +
+            `landed — add the rest with add-liquidity, or close it to recover the funds. ` +
+            `Transactions: ${signatures.join(', ')}`,
+        );
+      }
+    }
+  }
+
+  // The transaction that created the position: the rent and the position account come from
+  // this one, while the amounts added are summed across all of them below.
+  const signature = signatures[0];
 
   // Get transaction data for confirmation
   // Retrying re-fetch; throws the shared landed-but-failed error if the transaction
@@ -180,26 +242,41 @@ export async function openPosition(
   if (confirmed && txData) {
     // Extract position rent from the position account's SOL balance
     // The position account is newly created, so its postBalance IS the rent
-    const positionPubkey = newImbalancePosition.publicKey;
+    const positionPubkey = positionKeypair.publicKey;
     const accountKeys = txData.transaction.message.getAccountKeys().staticAccountKeys;
     const postBalances = txData.meta?.postBalances || [];
 
+    // Read the rent off the position account itself rather than the creating transaction.
+    // A chunked open grows the position as it funds each chunk, so its balance in the
+    // first transaction is only the rent it started with, not what the caller paid. For a
+    // single-transaction open the two are the same number.
     let positionRent = 0;
-    const positionAccountIndex = accountKeys.findIndex((key) => key.equals(positionPubkey));
-    if (positionAccountIndex !== -1) {
-      // Position account's balance after tx is the rent (it was 0 before creation)
-      positionRent = postBalances[positionAccountIndex] / 1e9; // Convert lamports to SOL
+    try {
+      positionRent = (await solana.connection.getBalance(positionPubkey)) / 1e9;
+    } catch (error) {
+      // Fall back to the creating transaction's post balance, which is right whenever the
+      // position was never resized.
+      logger.warn(`Could not read rent from ${positionPubkey.toBase58()}, using the creating transaction: ${error}`);
+      const positionAccountIndex = accountKeys.findIndex((key) => key.equals(positionPubkey));
+      if (positionAccountIndex !== -1) {
+        positionRent = postBalances[positionAccountIndex] / 1e9;
+      }
     }
 
-    // Track wallet's balance changes for the tokens
-    const { balanceChanges } = await solana.extractBalanceChangesAndFee(signature, walletPublicKey.toBase58(), [
-      dlmmPool.tokenX.publicKey.toBase58(),
-      dlmmPool.tokenY.publicKey.toBase58(),
-    ]);
-
-    // Balance changes are negative (tokens leaving wallet)
-    let baseAmountAdded = Math.abs(balanceChanges[0]);
-    let quoteAmountAdded = Math.abs(balanceChanges[1]);
+    // Track wallet's balance changes for the tokens, across every transaction that funded
+    // the position. A chunked open deposits over several, so reading only the first would
+    // report a fraction of what was actually added.
+    let baseAmountAdded = 0;
+    let quoteAmountAdded = 0;
+    for (const sig of signatures) {
+      const { balanceChanges } = await solana.extractBalanceChangesAndFee(sig, walletPublicKey.toBase58(), [
+        dlmmPool.tokenX.publicKey.toBase58(),
+        dlmmPool.tokenY.publicKey.toBase58(),
+      ]);
+      // Balance changes are negative (tokens leaving wallet)
+      baseAmountAdded += Math.abs(balanceChanges[0]);
+      quoteAmountAdded += Math.abs(balanceChanges[1]);
+    }
 
     // When SOL is base/quote, the wallet paid liquidity + rent on that side, so back the
     // rent out to leave the liquidity added. The transaction fee needs no correction:
@@ -214,7 +291,9 @@ export async function openPosition(
     }
 
     logger.info(
-      `Position opened at ${newImbalancePosition.publicKey.toBase58()}: ${baseAmountAdded.toFixed(4)} ${tokenXSymbol}, ${quoteAmountAdded.toFixed(4)} ${tokenYSymbol}, rent: ${positionRent.toFixed(6)} SOL`,
+      `Position opened at ${positionKeypair.publicKey.toBase58()} over ${signatures.length} transaction(s): ` +
+        `${baseAmountAdded.toFixed(4)} ${tokenXSymbol}, ${quoteAmountAdded.toFixed(4)} ${tokenYSymbol}, ` +
+        `rent: ${positionRent.toFixed(6)} SOL`,
     );
 
     return {
@@ -222,7 +301,7 @@ export async function openPosition(
       status: 1, // CONFIRMED
       data: {
         fee: txFee,
-        positionAddress: newImbalancePosition.publicKey.toBase58(),
+        positionAddress: positionKeypair.publicKey.toBase58(),
         positionRent: positionRent,
         baseTokenAmountAdded: baseAmountAdded,
         quoteTokenAmountAdded: quoteAmountAdded,

--- a/src/connectors/meteora/clmm-routes/quotePosition.ts
+++ b/src/connectors/meteora/clmm-routes/quotePosition.ts
@@ -121,8 +121,20 @@ export async function quotePosition(
       }
     }
 
+    // What opening this range will take. Sized by the SDK from the same strategy the open
+    // uses, so the quote and the open cannot disagree. One position spans up to 1400
+    // bins, so `positionCount` stays 1 for any realistic range; the number that actually
+    // moves is `transactionCount`, because a deposit is chunked at 70 bins per
+    // transaction. Reported so a caller sees a wide range costs several transactions
+    // before opening, rather than discovering it from a rejection.
+    const { positionCount, transactionCount } = await dlmmPool.quoteCreatePosition({
+      strategy: { minBinId, maxBinId, strategyType: strategy },
+    });
+
     return {
       baseLimited,
+      positionCount,
+      transactionCount,
       baseTokenAmount: baseAmount,
       quoteTokenAmount: quoteAmount,
       baseTokenAmountMax: baseAmount * (1 + slippage),

--- a/src/connectors/meteora/clmm-routes/quotePosition.ts
+++ b/src/connectors/meteora/clmm-routes/quotePosition.ts
@@ -121,20 +121,29 @@ export async function quotePosition(
       }
     }
 
-    // What opening this range will take. Sized by the SDK from the same strategy the open
-    // uses, so the quote and the open cannot disagree. One position spans up to 1400
-    // bins, so `positionCount` stays 1 for any realistic range; the number that actually
-    // moves is `transactionCount`, because a deposit is chunked at 70 bins per
-    // transaction. Reported so a caller sees a wide range costs several transactions
+    // What opening this range will take. One position spans up to 1400 bins, so
+    // `positionCount` stays 1 for any realistic range; the number that actually moves is
+    // `transactionCount`, because a deposit is chunked at DEFAULT_BIN_PER_POSITION bins
+    // per transaction. Reported so a caller sees a wide range costs several transactions
     // before opening, rather than discovering it from a rejection.
     const { positionCount, transactionCount } = await dlmmPool.quoteCreatePosition({
       strategy: { minBinId, maxBinId, strategyType: strategy },
     });
 
+    // The SDK counts deposit chunks only — ceil(bins / DEFAULT_BIN_PER_POSITION) — and
+    // says nothing about creating the position. openPosition sends that as its own
+    // transaction whenever the range is chunked, because a full chunk is already sized to
+    // fill a transaction and folding the position init in alongside it risks overflowing
+    // one. Add it here so the number quoted is the number the open actually sends; below
+    // the chunking threshold the position is created and funded together and the SDK's
+    // count is already right.
+    const chunkedOpen = maxBinId - minBinId + 1 > Meteora.MAX_POSITION_BIN_WIDTH;
+    const openTransactionCount = chunkedOpen ? transactionCount + 1 : transactionCount;
+
     return {
       baseLimited,
       positionCount,
-      transactionCount,
+      transactionCount: openTransactionCount,
       baseTokenAmount: baseAmount,
       quoteTokenAmount: quoteAmount,
       baseTokenAmountMax: baseAmount * (1 + slippage),

--- a/src/connectors/meteora/meteora.ts
+++ b/src/connectors/meteora/meteora.ts
@@ -55,9 +55,18 @@ export interface MeteoraApiPool {
 
 export class Meteora {
   private static _instances: { [name: string]: Meteora };
-  // Recommended maximum bins per position (aligns with SDK's DEFAULT_BIN_PER_POSITION)
-  // Ensures single-transaction operations. SDK supports up to 1400 bins via multiple transactions.
-  private static readonly MAX_BINS = 70;
+  // The widest bin range one DLMM position can be created and funded in a single
+  // transaction. The program itself allows up to POSITION_MAX_LENGTH (1400) bins, but
+  // reaching that needs incremental resizes; the one-shot
+  // initializePositionAndAddLiquidityByStrategy path is bounded by
+  // DEFAULT_BIN_PER_POSITION and by Solana's 10,240-byte CPI allocation limit. A wider
+  // range is covered by splitting it across several positions — see openPosition.
+  public static readonly MAX_POSITION_BIN_WIDTH = 69;
+
+  // How many bins either side of the active bin pool-info reports. Unrelated to what a
+  // position can hold: this is how much of the book to show, and it shared a constant
+  // with the position cap only by coincidence.
+  private static readonly POOL_LIQUIDITY_BIN_RANGE = 69;
   private solana: Solana;
   public config: MeteoraConfig.RootConfig;
   private dlmmPools: Map<string, DLMM> = new Map();
@@ -290,7 +299,10 @@ export class Meteora {
     if (!dlmmPool) {
       throw new Error(`Pool not found: ${poolAddress}`);
     }
-    const binData = await dlmmPool.getBinsAroundActiveBin(Meteora.MAX_BINS - 1, Meteora.MAX_BINS - 1);
+    const binData = await dlmmPool.getBinsAroundActiveBin(
+      Meteora.POOL_LIQUIDITY_BIN_RANGE,
+      Meteora.POOL_LIQUIDITY_BIN_RANGE,
+    );
 
     return binData.bins.map((bin) => ({
       binId: bin.binId,
@@ -596,11 +608,14 @@ export class Meteora {
     const minBinId = dlmmPool.getBinIdFromPrice(Number(lowerPricePerLamport), true) - padBins;
     const maxBinId = dlmmPool.getBinIdFromPrice(Number(upperPricePerLamport), false) + padBins;
 
-    if (maxBinId - minBinId > Meteora.MAX_BINS) {
+    // Same width rule as openPosition, from the same constant. This used to compare
+    // `maxBinId - minBinId` against 70 while openPosition compared the inclusive width
+    // against 69, so the two disagreed by two bins on what a position could hold.
+    if (maxBinId - minBinId + 1 > Meteora.MAX_POSITION_BIN_WIDTH) {
       throw new Error(
-        `Position range too wide: ${maxBinId - minBinId} bins requested. ` +
-          `Recommended maximum is ${Meteora.MAX_BINS} bins for single-transaction operations. ` +
-          `For wider ranges, create multiple positions or narrow your price range.`,
+        `Position range too wide: ${maxBinId - minBinId + 1} bins requested. ` +
+          `One position holds at most ${Meteora.MAX_POSITION_BIN_WIDTH} bins. ` +
+          `For wider ranges, open the position without a pad or narrow your price range.`,
       );
     }
 

--- a/src/connectors/meteora/meteora.ts
+++ b/src/connectors/meteora/meteora.ts
@@ -56,12 +56,18 @@ export interface MeteoraApiPool {
 export class Meteora {
   private static _instances: { [name: string]: Meteora };
   // The widest bin range one DLMM position can be created and funded in a single
-  // transaction. The program itself allows up to POSITION_MAX_LENGTH (1400) bins, but
-  // reaching that needs incremental resizes; the one-shot
-  // initializePositionAndAddLiquidityByStrategy path is bounded by
-  // DEFAULT_BIN_PER_POSITION and by Solana's 10,240-byte CPI allocation limit. A wider
-  // range is covered by splitting it across several positions — see openPosition.
-  public static readonly MAX_POSITION_BIN_WIDTH = 69;
+  // transaction, and the program's own limit on how wide a position may be initialized:
+  // DEFAULT_BIN_PER_POSITION. A position can still span up to POSITION_MAX_LENGTH (1400)
+  // bins, but only by growing past this, which openPosition does by chunking the deposit.
+  //
+  // 70, not the 69 this used to say, confirmed by mainnet simulation against the Meteora
+  // SOL/USDC pool: initializePosition succeeds at 70 bins and fails at 71 with
+  // InvalidPositionWidth (6040 / 0x1798, thrown at position/common.rs:30), and the
+  // combined create-and-fund transaction behaves identically — 819 message bytes at width
+  // 70, comfortably inside the 1232-byte limit, so neither transaction size nor the
+  // 10,240-byte CPI allocation limit binds first. The old 69 came from a simulation that
+  // verified 69 worked without testing whether 70 did.
+  public static readonly MAX_POSITION_BIN_WIDTH = 70;
 
   // How many bins either side of the active bin pool-info reports. Unrelated to what a
   // position can hold: this is how much of the book to show, and it shared a constant
@@ -608,9 +614,9 @@ export class Meteora {
     const minBinId = dlmmPool.getBinIdFromPrice(Number(lowerPricePerLamport), true) - padBins;
     const maxBinId = dlmmPool.getBinIdFromPrice(Number(upperPricePerLamport), false) + padBins;
 
-    // Same width rule as openPosition, from the same constant. This used to compare
-    // `maxBinId - minBinId` against 70 while openPosition compared the inclusive width
-    // against 69, so the two disagreed by two bins on what a position could hold.
+    // Same width rule as openPosition, from the same constant. These used to disagree:
+    // this compared `maxBinId - minBinId` against 70 while openPosition compared the
+    // inclusive width against 69, differing by two bins on what a position could hold.
     if (maxBinId - minBinId + 1 > Meteora.MAX_POSITION_BIN_WIDTH) {
       throw new Error(
         `Position range too wide: ${maxBinId - minBinId + 1} bins requested. ` +

--- a/src/schemas/clmm-schema.ts
+++ b/src/schemas/clmm-schema.ts
@@ -517,6 +517,17 @@ export const QuotePositionResponse = Type.Object(
     baseTokenAmountMax: DecimalNumber({}),
     quoteTokenAmountMax: DecimalNumber({}),
     liquidity: Type.Optional(Type.Any()),
+    // What opening this range actually costs in accounts and round trips. On Meteora one
+    // position spans up to 1400 bins, but a deposit is chunked at 70 bins per
+    // transaction, so a wide range is one position funded over several transactions —
+    // `transactionCount` is what grows, and it is the number worth checking before
+    // opening. Omitted by venues that always open in a single transaction.
+    positionCount: Type.Optional(
+      Type.Number({ description: 'Number of positions required to cover this price range' }),
+    ),
+    transactionCount: Type.Optional(
+      Type.Number({ description: 'Number of transactions required to open and fund this range' }),
+    ),
   },
   { $id: 'ClmmQuoteLiquidityResponse' },
 );

--- a/test/chains/solana/solana-error-parser.test.ts
+++ b/test/chains/solana/solana-error-parser.test.ts
@@ -380,7 +380,7 @@ describe('Solana Error Parser', () => {
         // The limit is on how much an instruction grows the account, not on the position:
         // a DLMM position spans up to 1400 bins when the deposit is chunked.
         expect(result.message).toMatch(/spans up to 1400 bins/);
-        expect(result.message).toMatch(/only about 69 fit in a single transaction/);
+        expect(result.message).toMatch(/only 70 fit in a single transaction/);
       });
     });
   });

--- a/test/chains/solana/solana-error-parser.test.ts
+++ b/test/chains/solana/solana-error-parser.test.ts
@@ -377,7 +377,10 @@ describe('Solana Error Parser', () => {
 
         expect(result.type).toBe('INSTRUCTION_ERROR');
         expect(result.message).toMatch(/10,240-byte allocation limit/);
-        expect(result.message).toMatch(/at most 69 bins/);
+        // The limit is on how much an instruction grows the account, not on the position:
+        // a DLMM position spans up to 1400 bins when the deposit is chunked.
+        expect(result.message).toMatch(/spans up to 1400 bins/);
+        expect(result.message).toMatch(/only about 69 fit in a single transaction/);
       });
     });
   });

--- a/test/connectors/meteora/clmm-routes/open-position-wide-range.test.ts
+++ b/test/connectors/meteora/clmm-routes/open-position-wide-range.test.ts
@@ -1,0 +1,156 @@
+import { Keypair, PublicKey, TransactionInstruction, SystemProgram } from '@solana/web3.js';
+
+import { Solana } from '../../../../src/chains/solana/solana';
+import { openPosition } from '../../../../src/connectors/meteora/clmm-routes/openPosition';
+import { Meteora } from '../../../../src/connectors/meteora/meteora';
+
+jest.mock('../../../../src/chains/solana/solana');
+jest.mock('../../../../src/connectors/meteora/meteora');
+
+// A DLMM position's bin range is bounded by what one transaction can create and fund, not
+// by what the program allows: POSITION_MAX_LENGTH is 1400 bins, while the one-shot
+// create-and-fund path tops out around DEFAULT_BIN_PER_POSITION. A range wider than that is
+// therefore still ONE position — it is the deposit that has to be chunked across several
+// transactions — so the route sends the chunks rather than rejecting the range.
+//
+// Pinned here:
+//   - narrow range  -> one transaction, unchanged behaviour.
+//   - wide range    -> one position, several transactions, amounts summed over all of them.
+//   - a failed chunk -> an error naming the position that was already created.
+
+const POOL = '5rCf1DM8LjKTw4YqhnoLcngyZYeNnQqztScTogYHAS6';
+const WALLET = 'DQcmxgGCEwThGCzV6NmFG2WsbUpch3HLoZAhctcgeRM9';
+const SIGS = ['sigCreate', 'sigChunk1', 'sigChunk2'];
+
+const ix = () =>
+  new TransactionInstruction({
+    keys: [],
+    programId: SystemProgram.programId,
+    data: Buffer.alloc(0),
+  });
+
+/** Bin ids for a range `width` bins wide, straddling the active bin. */
+const rangeFor = (width: number) => ({ minBinId: 0, maxBinId: width - 1 });
+
+const buildPool = (width: number, chunkCount: number, positionCount = 1) => {
+  const { minBinId, maxBinId } = rangeFor(width);
+  return {
+    tokenX: { publicKey: new PublicKey('11111111111111111111111111111112'), mint: { decimals: 9 } },
+    tokenY: { publicKey: new PublicKey('11111111111111111111111111111113'), mint: { decimals: 6 } },
+    lbPair: { binStep: 20, activeId: 0 },
+    getActiveBin: jest.fn().mockResolvedValue({ binId: 0, pricePerToken: '1' }),
+    toPricePerLamport: jest.fn((p: number) => String(p)),
+    getBinIdFromPrice: jest.fn((p: number) => (p <= 1 ? minBinId : maxBinId)),
+    initializePositionAndAddLiquidityByStrategy: jest.fn().mockResolvedValue({ instructions: [ix()], add: jest.fn() }),
+    initializeMultiplePositionAndAddLiquidityByStrategy: jest.fn(async (gen: (n: number) => Promise<Keypair[]>) => ({
+      instructionsByPositions: (await gen(positionCount)).map((positionKeypair) => ({
+        positionKeypair,
+        initializePositionIx: ix(),
+        initializeAtaIxs: [ix()],
+        addLiquidityIxs: Array.from({ length: chunkCount }, () => [ix()]),
+      })),
+    })),
+  };
+};
+
+const primeSolana = (opts: { failChunk?: number } = {}) => {
+  let sent = 0;
+  const sendAndConfirmTransactionForWallet = jest.fn(async () => {
+    const i = sent++;
+    if (opts.failChunk !== undefined && i === opts.failChunk) {
+      throw new Error('blockhash expired');
+    }
+    return { signature: SIGS[i] ?? `sig${i}`, fee: 0.000005 };
+  });
+
+  (Solana.getInstance as jest.Mock).mockResolvedValue({
+    connection: { getBalance: jest.fn().mockResolvedValue(57_500_000) },
+    getToken: jest.fn(async (address: string) => ({ symbol: address.endsWith('2') ? 'TKX' : 'TKY', address })),
+    sendAndConfirmTransactionForWallet,
+    getConfirmedTransactionData: jest.fn().mockResolvedValue({
+      transaction: { message: { getAccountKeys: () => ({ staticAccountKeys: [] }) } },
+      meta: { postBalances: [] },
+    }),
+    // Each transaction moves a slice of the liquidity.
+    extractBalanceChangesAndFee: jest.fn().mockResolvedValue({
+      balanceChanges: [-1, -2],
+      fee: 0.000005,
+      txDetails: {},
+    }),
+  });
+  return sendAndConfirmTransactionForWallet;
+};
+
+describe('meteora openPosition across a wide bin range', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('opens a narrow range in a single transaction', async () => {
+    const pool = buildPool(10, 1);
+    (Meteora.getInstance as jest.Mock).mockResolvedValue({ getDlmmPool: jest.fn().mockResolvedValue(pool) });
+    const send = primeSolana();
+
+    const result = await openPosition('mainnet-beta', WALLET, 1, 2, POOL, 1, 2);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(pool.initializePositionAndAddLiquidityByStrategy).toHaveBeenCalled();
+    expect(pool.initializeMultiplePositionAndAddLiquidityByStrategy).not.toHaveBeenCalled();
+    expect(result.status).toBe(1);
+  });
+
+  it('covers a range wider than one transaction with one position and several transactions', async () => {
+    // 200 bins: too wide to create and fund at once, but well inside POSITION_MAX_LENGTH.
+    const pool = buildPool(200, 2);
+    (Meteora.getInstance as jest.Mock).mockResolvedValue({ getDlmmPool: jest.fn().mockResolvedValue(pool) });
+    const send = primeSolana();
+
+    const result = await openPosition('mainnet-beta', WALLET, 1, 2, POOL, 1, 2);
+
+    // One create + one per deposit chunk, and no fallback to the single-transaction builder.
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(pool.initializePositionAndAddLiquidityByStrategy).not.toHaveBeenCalled();
+    expect(result.status).toBe(1);
+
+    // Still a single position, despite the extra transactions.
+    expect(typeof result.data?.positionAddress).toBe('string');
+
+    // Amounts are summed over every transaction that funded it. Reading only the first
+    // would report a third of what was added.
+    expect(result.data?.baseTokenAmountAdded).toBeCloseTo(3, 9);
+    expect(result.data?.quoteTokenAmountAdded).toBeCloseTo(6, 9);
+
+    // Fee is the total across the transactions, not one of them.
+    expect(result.data?.fee).toBeCloseTo(0.000015, 9);
+  });
+
+  it('reads rent from the position account, which a chunked open grows as it funds', async () => {
+    const pool = buildPool(200, 2);
+    (Meteora.getInstance as jest.Mock).mockResolvedValue({ getDlmmPool: jest.fn().mockResolvedValue(pool) });
+    primeSolana();
+
+    const result = await openPosition('mainnet-beta', WALLET, 1, 2, POOL, 1, 2);
+
+    // 57,500,000 lamports from the account, not the 0 the creating transaction would show.
+    expect(result.data?.positionRent).toBeCloseTo(0.0575, 9);
+  });
+
+  it('names the created position when a later chunk fails', async () => {
+    const pool = buildPool(200, 2);
+    (Meteora.getInstance as jest.Mock).mockResolvedValue({ getDlmmPool: jest.fn().mockResolvedValue(pool) });
+    primeSolana({ failChunk: 2 }); // create + chunk 1 land, chunk 2 fails
+
+    // The position exists and holds what landed; the caller must be told so it can be
+    // funded or closed rather than silently orphaned.
+    await expect(openPosition('mainnet-beta', WALLET, 1, 2, POOL, 1, 2)).rejects.toThrow(
+      /was opened, but only 1 of 2 liquidity chunks were funded/,
+    );
+  });
+
+  it('refuses a range that needs more positions than the response can describe', async () => {
+    // Above POSITION_MAX_LENGTH the SDK splits into several positions.
+    const pool = buildPool(2000, 1, 2);
+    (Meteora.getInstance as jest.Mock).mockResolvedValue({ getDlmmPool: jest.fn().mockResolvedValue(pool) });
+    primeSolana();
+
+    await expect(openPosition('mainnet-beta', WALLET, 1, 2, POOL, 1, 2)).rejects.toThrow(/needs 2 separate positions/);
+  });
+});

--- a/test/connectors/meteora/clmm-routes/quote-position-transaction-count.test.ts
+++ b/test/connectors/meteora/clmm-routes/quote-position-transaction-count.test.ts
@@ -51,12 +51,15 @@ describe('meteora quote-liquidity transaction count', () => {
   });
 
   it('counts the position-creation transaction once the range is chunked', async () => {
-    // Just over the threshold: one deposit chunk, plus the separate create.
+    // One bin over the threshold. Note the threshold and the chunk size are the same
+    // number — MAX_POSITION_BIN_WIDTH is DEFAULT_BIN_PER_POSITION — so the narrowest
+    // chunked range already needs two deposit chunks, not one: the create, then 70 bins,
+    // then the remainder. There is no such thing as a one-chunk chunked open.
     primePool(Meteora.MAX_POSITION_BIN_WIDTH + 1);
 
     const quote = await quotePosition('mainnet-beta', 1, 2, POOL, 1, undefined);
 
-    expect(quote.transactionCount).toBe(2);
+    expect(quote.transactionCount).toBe(3);
   });
 
   it('matches what open-position sends for a wide range', async () => {

--- a/test/connectors/meteora/clmm-routes/quote-position-transaction-count.test.ts
+++ b/test/connectors/meteora/clmm-routes/quote-position-transaction-count.test.ts
@@ -1,0 +1,71 @@
+import { Meteora } from '../../../../src/connectors/meteora/meteora';
+import { quotePosition } from '../../../../src/connectors/meteora/clmm-routes/quotePosition';
+
+jest.mock('../../../../src/connectors/meteora/meteora');
+jest.mock('@meteora-ag/dlmm', () => ({
+  StrategyType: { Spot: 0 },
+  // The paired-amount maths is exercised elsewhere; this suite is about the counts.
+  autoFillYByStrategy: jest.fn(() => ({ toString: () => '0' })),
+  autoFillXByStrategy: jest.fn(() => ({ toString: () => '0' })),
+}));
+
+// `transactionCount` is a promise about what open-position will send, so it has to be the
+// number the open actually sends. The SDK's quoteCreatePosition counts deposit chunks only
+// — ceil(bins / DEFAULT_BIN_PER_POSITION) — and says nothing about creating the position,
+// which openPosition sends as its own transaction whenever the range is chunked. Quoting
+// the SDK's number unchanged under-reports a wide open by exactly one transaction.
+
+const POOL = '5rCf1DM8LjKTw4YqhnoLcngyZYeNnQqztScTogYHAS6';
+const CHUNK = 70; // DEFAULT_BIN_PER_POSITION
+
+const primePool = (width: number) => {
+  const minBinId = 0;
+  const maxBinId = width - 1;
+  const dlmmPool = {
+    tokenX: { mint: { decimals: 9 } },
+    tokenY: { mint: { decimals: 6 } },
+    lbPair: { binStep: 20 },
+    toPricePerLamport: jest.fn((p: number) => String(p)),
+    getBinIdFromPrice: jest.fn((p: number) => (p <= 1 ? minBinId : maxBinId)),
+    getActiveBin: jest.fn().mockResolvedValue({ binId: 0, xAmount: '0', yAmount: '0' }),
+    // Mirrors the SDK: deposit chunks only.
+    quoteCreatePosition: jest.fn().mockResolvedValue({
+      positionCount: 1,
+      transactionCount: Math.ceil(width / CHUNK),
+    }),
+  };
+  (Meteora.getInstance as jest.Mock).mockResolvedValue({ getDlmmPool: jest.fn().mockResolvedValue(dlmmPool) });
+  return dlmmPool;
+};
+
+describe('meteora quote-liquidity transaction count', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('quotes one transaction for a range that opens and funds together', async () => {
+    primePool(Meteora.MAX_POSITION_BIN_WIDTH);
+
+    const quote = await quotePosition('mainnet-beta', 1, 2, POOL, 1, undefined);
+
+    expect(quote.transactionCount).toBe(1);
+    expect(quote.positionCount).toBe(1);
+  });
+
+  it('counts the position-creation transaction once the range is chunked', async () => {
+    // Just over the threshold: one deposit chunk, plus the separate create.
+    primePool(Meteora.MAX_POSITION_BIN_WIDTH + 1);
+
+    const quote = await quotePosition('mainnet-beta', 1, 2, POOL, 1, undefined);
+
+    expect(quote.transactionCount).toBe(2);
+  });
+
+  it('matches what open-position sends for a wide range', async () => {
+    // 200 bins -> ceil(200/70) = 3 deposit chunks, plus the create = 4.
+    primePool(200);
+
+    const quote = await quotePosition('mainnet-beta', 1, 2, POOL, 1, undefined);
+
+    expect(quote.transactionCount).toBe(1 + Math.ceil(200 / CHUNK));
+    expect(quote.transactionCount).toBe(4);
+  });
+});


### PR DESCRIPTION
Meteora `openPosition` rejected any price range wider than 69 bins as exceeding what "a Meteora DLMM position holds". That is not the constraint, and the range did not need to be refused.

## The 69 is a transaction limit, not a position limit

Read out of the DLMM IDL's own constants:

| constant | value |
|---|---|
| `POSITION_MAX_LENGTH` | **1400** |
| `DEFAULT_BIN_PER_POSITION` | 70 |
| `MAX_RESIZE_LENGTH` | 70 (91 on SDK 1.9.x) |

A position spans up to **1400** bins. 69 is roughly what the one-shot `initializePositionAndAddLiquidityByStrategy` path can create *and fund* inside a single transaction, bounded by `DEFAULT_BIN_PER_POSITION` and Solana's 10,240-byte CPI allocation limit. So a wide range was being refused for being wide, when the real cost is that it takes more than one transaction.

Worth noting for anyone who reads this expecting position splitting: `getPositionCountByBinCount` is `ceil(binCount / 1400)`, so `initializeMultiplePositionAndAddLiquidityByStrategy` returns **one** position for any realistic range. What grows is the transaction count — the deposit is chunked at `DEFAULT_BIN_PER_POSITION` bins per transaction by `chunkBinRange`.

## What changed

**`openPosition` sends those transactions** instead of rejecting the range. Four consequences that are easy to get wrong, handled explicitly:

- Amounts are **summed over every transaction** that funded the position. Reading only the first reports a fraction of what was added.
- Rent is read from the **position account**, not the creating transaction — a chunked open grows the position as it funds, so the first transaction's balance is only what it started with.
- A chunk failing partway leaves the position open holding what landed. That throws an error naming the position, how many chunks funded, and every signature, so the caller can add the rest or close it rather than owning an account it never saw created. **This is the real cost of the feature: the open is no longer atomic, and it cannot be, since the deposit does not fit in one transaction.**
- Past `POSITION_MAX_LENGTH` the SDK returns several positions, which this response cannot describe — it carries one `positionAddress`. Refused outright rather than returning one and orphaning the rest.

**`quote-liquidity` reports `positionCount` and `transactionCount`**, so a caller sees what a range costs in transactions before opening rather than learning it from a rejection. Both fields optional, omitted by venues that always open in one transaction.

Note the SDK's `quoteCreatePosition().transactionCount` counts deposit chunks only — `ceil(bins / DEFAULT_BIN_PER_POSITION)` — and says nothing about creating the position, which `openPosition` sends as its own transaction whenever the range is chunked. Passing it through unchanged quoted a wide range one transaction short of what the open sends (a 200-bin range said 3, sent 4), so the create is added back here. Below the chunking threshold the position is created and funded together and the SDK's count is already right. Tested against the open's own arithmetic at the threshold, one bin past it, and at 200 bins.

**`add-liquidity` now chunks too.** Every other route on the position lifecycle already looped over a `Transaction[]` — `remove-liquidity`, `close-position` and `collect-fees` all do. `add-liquidity` was the exception, calling the non-chunkable `addLiquidityByStrategy`. That was survivable while opens were capped at 69 bins; once wide positions became creatable it was a hole in the lifecycle, and the partial-failure error above tells the caller to "add the rest with add-liquidity" — advice into a route that could not do it.

**One constant for the position width.** The connector enforced two: `openPosition` compared the inclusive width against a local 69, while `Meteora.getPriceToBinIds` compared `maxBinId - minBinId` against `MAX_BINS = 70`, so they disagreed by two bins and neither named the other. `MAX_BINS` was also deciding how many bins either side of the active bin `pool-info` reports — a question about how much of the book to show, sharing a constant with the position rule only by coincidence, so a change to either meaning would have silently moved the other. Split into `MAX_POSITION_BIN_WIDTH` and `POOL_LIQUIDITY_BIN_RANGE`.

**Corrected the position-width messages in the Solana error parser.** They said a DLMM position "holds at most 69 bins" in two places — false, per the constants above. The realloc message likewise blamed the range for being wide when the fault is growing the account that far in a single instruction, and advised narrowing the range or splitting into positions, neither of which is needed now that the deposit chunks.

## The single-transaction width is 70, measured

The previous cap of 69 came from a mainnet simulation (`7dd9bf1e`) that verified 69 worked but never tested 70, and described the program as capping positions "at ~70 bins" — so 69 was the value known to work, not a measured ceiling. It also sat one below `DEFAULT_BIN_PER_POSITION`, which the SDK's own chunker passes to `initializePosition` verbatim.

Rather than reason about it further, simulated it against the Meteora SOL/USDC pool (`2sf5NYcY...`) on mainnet:

| width | `initializePosition` | combined create + fund |
|---|---|---|
| 68 | OK | — |
| 69 | OK | OK |
| **70** | **OK** | **OK** (819 message bytes) |
| 71 | `InvalidPositionWidth` | `InvalidPositionWidth` |
| 72, 80 | `InvalidPositionWidth` | — |

`InvalidPositionWidth` is 6040 / 0x1798, thrown at `programs/lb_clmm/src/instructions/position/common.rs:30`. The combined path's message is 819 bytes at width 70 against a 1232-byte limit, so neither transaction size nor the 10,240-byte CPI allocation limit binds before the program's own check does.

So the cap is exactly `DEFAULT_BIN_PER_POSITION`, and 69 was leaving a bin on the table — a 70-bin range was being funded over three transactions when it fits in one.

One consequence worth naming, since it otherwise reads as an off-by-one: **the threshold and the deposit chunk size are now the same number**. A 71-bin range is one past what a single transaction holds but needs two chunks of 70 to cover, so the narrowest chunked open is three transactions, not two. There is no one-chunk chunked open.

## A note for anyone building on this

`openPosition` is no longer atomic for a wide range, and cannot be — the deposit does not fit in one transaction. Callers that assumed open-position either fully succeeded or did nothing need to treat the partial-failure error as "the position may exist" rather than "nothing happened"; retrying blindly opens a second position.

This also does not compose with a build/sign/submit flow that returns a single unsigned transaction, where the capture would fire on the position creation and hand back a transaction that opens an empty position with no error. There is no such flow in `development` today, so nothing here is affected, but it is the obvious trap for anyone adding one: the fix is to refuse a chunked range at the build boundary rather than return its first transaction, since an open cannot be resumed by repeating the call — each call mints a fresh position keypair.

## Verification

`pnpm build`, `pnpm typecheck` and `pnpm lint` clean. Full suite **161 suites / 1460 tests** passing (`development` baseline: 159/1452). `openapi.json` regenerated and matching, so the CI spec check passes — the two new optional fields are the only change.

New tests pin narrow-range-unchanged, wide-range chunking, amounts summed across transactions, rent read from the account, the partial-chunk failure message, and the >1400-bin refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvS83dMFobrZtpcW1LRpWx
